### PR TITLE
Updating build to properly support Gcc or Clang

### DIFF
--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -39,46 +39,12 @@ jar {
     classifier = osdetector.classifier
 }
 
-void configureGcc(GccCommandLineToolConfiguration cppCompiler, GccCommandLineToolConfiguration linker) {
-    cppCompiler.withArguments { args ->
-        args << "-Wall"
-        args << "-fPIC"
-        args << "-O2"
-        args << "-std=c++11"
-        args << "-I$jniSourceDir/main/include"
-        args << "-I$jniSourceDir/unbundled/include"
-        args << "-I$boringsslIncludeDir"
-        args << "-I$jdkIncludeDir"
-        if (org.gradle.internal.os.OperatingSystem.current().isLinux()) {
-            args << "-I$jdkIncludeDir/linux"
-        } else if (org.gradle.internal.os.OperatingSystem.current().isMacOsX()) {
-            args << "-I$jdkIncludeDir/darwin"
-        } else if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
-            args << "-I$jdkIncludeDir/win32"
-        }
-    }
-    linker.withArguments { args ->
-        args << "-O2"
-        args << "-L$boringsslSslBuildDir"
-        args << "-L$boringsslCryptoBuildDir"
-        args << "-lstdc++"
-        args << "-lssl"
-        args << "-lcrypto"
-    }
-}
-
 model {
     toolChains {
-        clang(Clang) {
-            eachPlatform {
-                configureGcc(cppCompiler, linker)
-            }
-        }
-        gcc(Gcc) {
-            eachPlatform {
-                configureGcc(cppCompiler, linker)
-            }
-        }
+        visualCpp(VisualCpp)
+        // Prefer Clang over Gcc (order here matters!)
+        clang(Clang)
+        gcc(Gcc)
     }
     components {
         // Builds the JNI library.
@@ -95,6 +61,31 @@ model {
             }
 
             binaries {
+                // Build the JNI lib as a shared library.
+                withType (SharedLibraryBinarySpec) {
+                    if (toolChain in Clang || toolChain in Gcc) {
+                        cppCompiler.args "-Wall",
+                                "-fPIC",
+                                "-O2",
+                                "-std=c++11",
+                                "-I$jniSourceDir/main/include",
+                                "-I$jniSourceDir/unbundled/include",
+                                "-I$boringsslIncludeDir",
+                                "-I$jdkIncludeDir",
+                                "-I$jdkIncludeDir/linux",
+                                "-I$jdkIncludeDir/darwin",
+                                "-I$jdkIncludeDir/win32"
+
+                        // Static link to BoringSSL
+                        linker.args "-O2",
+                                "-L$boringsslSslBuildDir",
+                                "-L$boringsslCryptoBuildDir",
+                                "-lstdc++",
+                                "-lssl",
+                                "-lcrypto"
+                    }
+                }
+
                 // Never build a static library.
                 withType(StaticLibraryBinarySpec) {
                     buildable = false


### PR DESCRIPTION
Previous approach of defining a toolchains section seemed to require that both Gcc and Clang be available, rather than discovering which toolchain is being used.