### PR TITLE
Moving android SDK checks to android module.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,18 @@ description = 'Conscrypt: Android'
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
+ext {
+    androidHome = "$System.env.ANDROID_HOME"
+    androidVersionCode = 1
+    androidVersionName = "$version"
+    androidMinSdkVersion = 9
+    androidTargetSdkVersion = 25
+    androidBuildToolsVersion = "25.0.0"
+
+    // Ensure the environment is configured properly.
+    assert file("$androidHome").exists()
+}
+
 android {
     compileSdkVersion androidTargetSdkVersion
     buildToolsVersion androidBuildToolsVersion

--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,3 @@
-// Note: Requires BoringSSL and the Android SDK
-//
-// Android SDK
-// ============
-// Download and install the latest Android SDK from https://developer.android.com/studio/install.html
-// and set the ANDROID_HOME environment variable to point to the root of the SDK.
-//
-// BoringSSL
-// =========
-// Checkout to a directory of your choice and then build as follows:
-//
-// linux/mac:
-// cd $BORINGSSL_HOME
-// mkdir build
-// cd build
-// cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS=-Wa,--noexecstack -GNinja ..
-// ninja
-//
-// windows:
-// cd $BORINGSSL_HOME
-// mkdir build
-// cd build
-// cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE=/MT -DCMAKE_CXX_FLAGS_RELEASE=/MT -GNinja ..
-// ninja
-//
-// Note: Also requires Android SDK and the environment variable ANDROID_HOME.
-
 buildscript {
     repositories {
         mavenCentral()
@@ -56,23 +29,16 @@ subprojects {
     version = "1.0.0-SNAPSHOT"
 
     ext {
-        androidHome = "$System.env.ANDROID_HOME"
         boringsslHome = "$System.env.BORINGSSL_HOME"
         boringsslIncludeDir = "$boringsslHome/include"
         boringsslSslBuildDir = "$boringsslHome/build/ssl"
         boringsslCryptoBuildDir = "$boringsslHome/build/crypto"
         jdkHome = "$System.env.JAVA_HOME"
         jdkIncludeDir = "$jdkHome/include"
-        androidVersionCode = 1
-        androidVersionName = "$version"
-        androidMinSdkVersion = 9
         // Needs to be binary compatible with androidMinSdkVersion
         androidMinJavaVersion = JavaVersion.VERSION_1_7
-        androidTargetSdkVersion = 25
-        androidBuildToolsVersion = "25.0.0"
 
         // Ensure the environment is configured properly.
-        assert file("$androidHome").exists()
         assert file("$boringsslHome").exists()
         assert file("$boringsslIncludeDir").exists()
         assert file("$boringsslSslBuildDir").exists()
@@ -81,7 +47,6 @@ subprojects {
         assert file("$jdkIncludeDir").exists()
 
         libraries = [
-                //android: 'com.google.android:android:4.1.1.4',
                 roboelectric: 'org.robolectric:android-all:5.0.0_r2-robolectric-1',
 
                 // Test dependencies.


### PR DESCRIPTION
This allows us to build openjdk without requiring installation of android sdk.