### PR TITLE
Add formatting checks to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,8 +110,16 @@ before_script:
   - echo 'android.builder.sdkDownload=false' > gradle.properties
 
 script:
-  - git rev-list $(git merge-base HEAD origin/master)..HEAD | xargs -i git clang-format --binary=$(which clang-format-3.8) --style=file {} && git diff --exit-code || { git reset --hard; false; }
-  - git rev-list $(git merge-base HEAD origin/master)..HEAD | xargs -i git diff-tree --no-commit-id --name-only -r {} | grep -E '\.java$' | xargs -r git ls-files | xargs -r java -jar $HOME/gjf.jar -a -i --fix-imports-only && git diff --exit-code || { git reset --hard; false; }
+  # MacOS (BSD) xargs is missing some nice features that make this easy, so skip it.
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+    then
+        git rev-list $(git merge-base HEAD origin/master)..HEAD | xargs -i git clang-format --binary=$(which clang-format-3.8) --style=file {} && git diff --exit-code || { git reset --hard; false; }
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+    then
+        git rev-list $(git merge-base HEAD origin/master)..HEAD | xargs -i git diff-tree --no-commit-id --name-only -r {} | grep -E '\.java$' | xargs -r git ls-files | xargs -r java -jar $HOME/gjf.jar -a -i --fix-imports-only && git diff --exit-code || { git reset --hard; false; }
+    fi
+
   - ./gradlew --stacktrace --info build
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - BORINGSSL_HOME="$HOME/boringssl"
     - CC=clang
     - CXX=clang++
+    - GOOGLE_JAVA_FORMAT_VERSION=1.1
 
 cache:
   directories:
@@ -36,9 +37,11 @@ matrix:
         apt:
           sources:
             - kalakris-cmake
+            - llvm-toolchain-precise-3.8  # for clang-format-3.8
             - ubuntu-toolchain-r-test
           packages:
             - clang
+            - clang-format-3.8  # for style checks
             - cmake
             - g++-multilib
             - gcc-multilib
@@ -61,6 +64,9 @@ before_cache:
   - rm -rf $HOME/.gradle/caches/[1-9]*
 
 before_script:
+  # Get Google Java Format
+  - curl -L https://github.com/google/google-java-format/releases/download/google-java-format-1.1/google-java-format-${GOOGLE_JAVA_FORMAT_VERSION}-all-deps.jar -o $HOME/gjf.jar
+
   # get BoringSSL
   - mkdir $BORINGSSL_HOME
   - git clone --depth 1 https://boringssl.googlesource.com/boringssl $BORINGSSL_HOME
@@ -70,6 +76,15 @@ before_script:
   - cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS=-Wa,--noexecstack -GNinja ..
   - ninja
   - popd
+
+  # Get git-clang-format
+  - mkdir $HOME/bin
+  - curl -L https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/git-clang-format -o $HOME/bin/git-clang-format
+  - chmod 0755 $HOME/bin/git-clang-format
+  - export PATH="$HOME/bin:$PATH"
+
+  # We need this to find the merge-base
+  - git fetch origin +refs/heads/master:refs/remotes/origin/master
 
   # TODO(nathanmittler): Need to figure out how to make 32-bit builds work
   # Build BoringSSL for 32-bit
@@ -95,6 +110,8 @@ before_script:
   - echo 'android.builder.sdkDownload=false' > gradle.properties
 
 script:
+  - git rev-list $(git merge-base HEAD origin/master)..HEAD | xargs -i git clang-format --binary=$(which clang-format-3.8) --style=file {} && git diff --exit-code || { git reset --hard; false; }
+  - git rev-list $(git merge-base HEAD origin/master)..HEAD | xargs -i git diff-tree --no-commit-id --name-only -r {} | grep -E '\.java$' | xargs -r git ls-files | xargs -r java -jar $HOME/gjf.jar -a -i --fix-imports-only && git diff --exit-code || { git reset --hard; false; }
   - ./gradlew --stacktrace --info build
 
 after_script:


### PR DESCRIPTION
This mirrors what the Android source tree used to have as presubmit
checks. It uses clang-format for formatting C++ and Java files, but
google-java-format for checking for unused imports and import ordering.