### PR TITLE
hardening fixes with regards to the liblog headers on Android

### DIFF
--- a/common/src/jni/main/cpp/org_conscrypt_NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/org_conscrypt_NativeCrypto.cpp
@@ -63,7 +63,7 @@
 #endif
 
 #ifndef CONSCRYPT_UNBUNDLED
-#include "android/log.h"
+#include "log/log.h"
 #else
 #include "log_compat.h"
 #endif

--- a/common/src/jni/unbundled/include/log_compat.h
+++ b/common/src/jni/unbundled/include/log_compat.h
@@ -20,18 +20,26 @@
 #if defined(ANDROID) && !defined(CONSCRYPT_OPENJDK)
 
 #include <android/log.h>
+#ifndef ALOG
 #define ALOG(priority, tag, ...) \
             __android_log_print(ANDROID_##priority, tag, __VA_ARGS__)
+#endif
+#ifndef ALOGD
 #define ALOGD(...) \
             __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+#endif
+#ifndef ALOGE
 #define ALOGE(...) \
             __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#endif
 
+#ifndef ALOGV
 #define __ALOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG, __VA_ARGS__)
 #if LOG_NDEBUG
 #define ALOGV(...) do { if (0) { __ALOGV(__VA_ARGS__); } } while (0)
 #else
 #define ALOGV(...) __ALOGV(__VA_ARGS__)
+#endif
 #endif
 
 #else /* !ANDROID */


### PR DESCRIPTION
Two hardening fixes with regards to the liblog headers on Android. One to use log/log.h for bundled applications, the other to not create build errors, and to use the supplied set, should android/log.h contain the logging macros.