### PR TITLE
Fix logging format string change

### DIFF
--- a/common/src/jni/main/cpp/org_conscrypt_NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/org_conscrypt_NativeCrypto.cpp
@@ -6870,7 +6870,7 @@ static jbyteArray NativeCrypto_SSL_get_tls_channel_id(JNIEnv* env, jclass, jlong
         ALOGE("%s", ERR_error_string(ERR_peek_error(), nullptr));
         throwSSLExceptionWithSslErrors(env, ssl, SSL_ERROR_NONE, "Error getting Channel ID");
         safeSslClear(ssl);
-        JNI_TRACE("ssl=%p NativeCrypto_SSL_get_tls_channel_id => error, returned %ld", ssl, ret);
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_get_tls_channel_id => error, returned %zd", ssl, ret);
         return nullptr;
     }
 


### PR DESCRIPTION
Looks like this may not be caught in the gradle build, but it breaks the
Android platform build.

Change-Id: I934f9a34abeba9d965f4bdd0cb1f3a63bdb54cfc