### PR TITLE
Allow building both 32-bit and 64-bit JNI libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,10 @@ addons:
       - kalakris-cmake
       - ubuntu-toolchain-r-test
     packages:
-      - cmake
-      - ninja-build
       - clang
+      - cmake
+      - gcc-multilib
+      - ninja-build
 
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - popd
   # Build BoringSSL for 32-bit
   - mkdir $BORINGSSL_HOME/build32 && pushd $BORINGSSL_HOME/build32
-  - cmake -DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS=-Wa,--noexecstack -GNinja ..
+  - cmake -DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake -DCMAKE_ASM_FLAGS="-m32 -msse2" -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS=-Wa,--noexecstack -GNinja ..
   - ninja
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - popd
   # Build BoringSSL for 32-bit
   - mkdir $BORINGSSL_HOME/build32 && pushd $BORINGSSL_HOME/build32
-  - cmake -DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake -DCMAKE_ASM_FLAGS="-m32 -msse2" -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS=-Wa,--noexecstack -GNinja ..
+  - cmake -DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS="-Wa,--noexecstack -m32 -msse2" -GNinja ..
   - ninja
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,17 @@ before_script:
   - curl https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip -z $HOME/.cache/ndk/ndk-${NDK_VERSION}.zip -o $HOME/.cache/ndk/ndk-${NDK_VERSION}.zip
   - unzip -q $HOME/.cache/ndk/ndk-$NDK_VERSION.zip -d $HOME
   - echo "ndk.dir=$HOME/android-ndk-$NDK_VERSION" >> local.properties
-  # get and build BoringSSL
+  # get BoringSSL
   - mkdir $BORINGSSL_HOME
   - git clone --depth 1 https://boringssl.googlesource.com/boringssl $BORINGSSL_HOME
-  - mkdir $BORINGSSL_HOME/build && pushd $BORINGSSL_HOME/build
+  # Build BoringSSL for 64-bit
+  - mkdir $BORINGSSL_HOME/build64 && pushd $BORINGSSL_HOME/build64
   - cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS=-Wa,--noexecstack -GNinja ..
+  - ninja
+  - popd
+  # Build BoringSSL for 32-bit
+  - mkdir $BORINGSSL_HOME/build32 && pushd $BORINGSSL_HOME/build32
+  - cmake -DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS=-Wa,--noexecstack -GNinja ..
   - ninja
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ addons:
       - g++-multilib
       - gcc-multilib
       - libc6-dev-i386
+      - libc6-dev:i386
       - ninja-build
 
 android:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,9 @@ addons:
     packages:
       - clang
       - cmake
+      - g++-multilib
       - gcc-multilib
+      - libc6-dev-i386
       - ninja-build
 
 android:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -43,27 +43,54 @@ git clone https://boringssl.googlesource.com/boringssl
 cd boringssl
 
 # Also need to set an environment variable to point to the installation location.
-export BORINGSSL_HOME $PWD
+export BORINGSSL_HOME=$PWD
 ```
 
 ##### Building on Linux/OS-X
+To build in the 64-bit version on a 64-bit machine:
 ```bash
-mkdir build
-cd build
+mkdir build64
+cd build64
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_ASM_FLAGS=-Wa,\
-      --noexecstack \
+      -DCMAKE_ASM_FLAGS=-Wa,--noexecstack \
+      -GNinja ..
+ninja
+```
+
+To make a 32-bit build on a 64-bit machine:
+```base
+mkdir build32
+cd build32
+cmake -DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_ASM_FLAGS=-Wa,--noexecstack \
       -GNinja ..
 ninja
 ```
 
 ##### Building on Windows
-This assumes that you have
+This assumes that you have Microsoft Visual Studio 2015 in `MSVCDIR` and are
+running on a 64-bit machine. Set up with this command line:
 
 ```bash
-mkdir build
-cd build
+call %MSCVDIR%\vc\vcvarsall.bat x64
+mkdir build64
+cd build64
+```
+
+To build in 32-bit mode, set up with this command line:
+
+```bash
+call %MSCVDIR%\vc\vcvarsall.bat x64
+mkdir build32
+cd build32
+```
+
+In either the 64-bit or 32-bit case, run this afterward:
+
+```bash
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_C_FLAGS_RELEASE=/MT \

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -63,10 +63,9 @@ To make a 32-bit build on a 64-bit machine:
 mkdir build32
 cd build32
 cmake -DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake \
-      -DCMAKE_ASM_FLAGS="-m32 -msse2" \
       -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_ASM_FLAGS=-Wa,--noexecstack \
+      -DCMAKE_ASM_FLAGS="-Wa,--noexecstack -m32 -msse2" \
       -GNinja ..
 ninja
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -63,6 +63,7 @@ To make a 32-bit build on a 64-bit machine:
 mkdir build32
 cd build32
 cmake -DCMAKE_TOOLCHAIN_FILE=../util/32-bit-toolchain.cmake \
+      -DCMAKE_ASM_FLAGS="-m32 -msse2" \
       -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_ASM_FLAGS=-Wa,--noexecstack \

--- a/build.gradle
+++ b/build.gradle
@@ -42,18 +42,20 @@ subprojects {
     ext {
         boringsslHome = "$System.env.BORINGSSL_HOME"
         boringsslIncludeDir = "$boringsslHome/include"
-        boringsslSslBuildDir = "$boringsslHome/build/ssl"
-        boringsslCryptoBuildDir = "$boringsslHome/build/crypto"
+        boringssl32BuildDir = "$boringsslHome/build32"
+        boringssl64BuildDir = "$boringsslHome/build64"
         jdkHome = "$System.env.JAVA_HOME"
         jdkIncludeDir = "$jdkHome/include"
         // Needs to be binary compatible with androidMinSdkVersion
         androidMinJavaVersion = JavaVersion.VERSION_1_7
 
+        build32Bit = file("$boringssl32BuildDir").exists()
+        build64Bit = file("$boringssl64BuildDir").exists()
+
         // Ensure the environment is configured properly.
         assert file("$boringsslHome").exists()
         assert file("$boringsslIncludeDir").exists()
-        assert file("$boringsslSslBuildDir").exists()
-        assert file("$boringsslCryptoBuildDir").exists()
+        assert build32Bit || build64Bit
         assert file("$jdkHome").exists()
         assert file("$jdkIncludeDir").exists()
 

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -4,8 +4,7 @@ description = 'Conscrypt: OpenJdk'
 
 ext {
     jniSourceDir = "$rootDir/common/src/jni"
-    jniLibName = "conscrypt_openjdk_jni-$osdetector.classifier"
-    jniLibTaskName = "${jniLibName}SharedLibrary"
+    jniLibPrefix = "conscrypt_openjdk_jni-${osdetector.os}"
 
     assert file("$jniSourceDir").exists()
 }
@@ -31,18 +30,27 @@ dependencies {
                 libraries.mockito
 }
 
-// Make sure we build and copy the native library to the output directory.
-compileJava.dependsOn 'copyNativeLib'
-
 // Set the platform-specific classifier on the artifact.
 jar {
     classifier = osdetector.classifier
 }
 
 model {
+    platforms {
+        x86 {
+            architecture "x86"
+        }
+        x86_64 {
+            architecture "x86_64"
+        }
+    }
+
     components {
         // Builds the JNI library.
-        "$jniLibName"(NativeLibrarySpec) {
+        "$jniLibPrefix"(NativeLibrarySpec) {
+            if (build32Bit) { targetPlatform "x86" }
+            if (build64Bit) { targetPlatform "x86_64" }
+
             sources {
                 cpp {
                     source {
@@ -59,6 +67,19 @@ model {
                 withType (SharedLibraryBinarySpec) {
                     cppCompiler.define "CONSCRYPT_OPENJDK"
 
+                    // Set up 32-bit vs 64-bit build
+                    def libPaths
+                    if (targetPlatform.getArchitecture().getName() == "x86") {
+                        libPaths = ["$boringssl32BuildDir/ssl",
+                            "$boringssl32BuildDir/crypto"]
+                    } else if (targetPlatform.getArchitecture().getName() == "x86-64") {
+                        libPaths = ["$boringssl64BuildDir/ssl",
+                            "$boringssl64BuildDir/crypto"]
+                    } else {
+                        throw new GradleException("Unknown architecture: " +
+                                targetPlatform.getArchitecture().getName())
+                    }
+
                     if (toolChain in Clang || toolChain in Gcc) {
                         cppCompiler.args "-Wall",
                                 "-fPIC",
@@ -73,10 +94,9 @@ model {
                                 "-I$jdkIncludeDir/win32"
 
                         // Static link to BoringSSL
+                        libPaths.each { linker.args.add("-L" + it) }
                         linker.args "-O2",
                                 "-fvisibility=hidden",
-                                "-L$boringsslSslBuildDir",
-                                "-L$boringsslCryptoBuildDir",
                                 "-lstdc++",
                                 "-lssl",
                                 "-lcrypto"
@@ -114,13 +134,12 @@ model {
                                 "-I$jdkIncludeDir/win32"
 
                         // Static link to BoringSSL
-                        linker.args "/O2",
-                                "-WX",
-                                "-L$boringsslSslBuildDir",
-                                "-L$boringsslCryptoBuildDir",
-                                "-lssl",
-                                "-lcrypto",
-                                "-lWs2_32.lib"
+                        libPaths.each { linker.args.add("/LIBPATH:" + it) }
+                        linker.args "-WX",
+                                "ws2_32.lib",
+                                "advapi32.lib",
+                                "ssl.lib",
+                                "crypto.lib"
                     }
                 }
 
@@ -131,11 +150,27 @@ model {
             }
         }
     }
+
+    tasks {
+        $.binaries.withType(SharedLibraryBinarySpec).each {
+            def archName = it.targetPlatform.architecture.name.replaceAll('-', '_')
+            def source = it.sharedLibraryFile
+
+            // Copies the native library to a resource location that will be included in the jar.
+            task "copyNativeLib${archName}"(type: Copy) {
+                from source
+                rename '(.+)(\\.[^\\.]+)', "\$1-$archName\$2"
+                // This location will automatically be included in the jar.
+                into "build/resources/main/META-INF/native"
+            }
+
+            // Make sure we build and copy the native library to the output directory.
+            compileJava.dependsOn "copyNativeLib${archName}"
+        }
+    }
 }
 
-// Copies the native library to a resource location that will be included in the jar.
-task copyNativeLib(type: Copy, dependsOn: "$jniLibTaskName") {
-    from "build/libs/${jniLibName}/shared"
-    // This location will automatically be included in the jar.
-    into 'build/resources/main/META-INF/native'
+def getFileExtension(File f) {
+    String name = f.getName()
+    return new String(name.substring(name.lastIndexOf('.')))
 }


### PR DESCRIPTION
Since we will be distributing this as an uberjar, we need to be able to
build both 32-bit and 64-bit versions of the libraries.

Update the documentation to match.

Change-Id: Ie0a862ef7c6155f11fde1403841aee54d2634656