### PR TITLE
Use the Windows 8.1 SDK instead of 7.1a

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ subprojects {
                 visualCpp(VisualCpp) {
                     // Temporary hack for https://github.com/gradle/gradle/issues/929
                     installDir "file:///C:/Program%20Files%20(x86)/Microsoft%20Visual%20Studio%2014.0"
-                    windowsSdkDir "file:///C:/Program%20Files%20(x86)/Microsoft%20SDKs/Windows/v7.1A"
+                    windowsSdkDir "file:///C:/Program%20Files%20(x86)/Windows%20Kits/8.1"
                 }
                 // Prefer Clang over Gcc (order here matters!)
                 clang(Clang)


### PR DESCRIPTION
The inet_ntop function is first defined in Windows 8.0 SDK, but 8.1 SDK is already installed in Appveyor.

Change-Id: Ib15ff5091127e6df06d2b75365c20acddbd96598