### PR TITLE
Fix-up sslSelect logic for Windows

### DIFF
--- a/common/src/jni/main/include/compat.h
+++ b/common/src/jni/main/include/compat.h
@@ -54,35 +54,9 @@ typedef long ssize_t;
 #define strcasecmp _stricmp
 
 // Windows doesn't define this either *sigh*...
-inline int vasprintf(char **ret, const char *format, va_list args) {
-    va_list copy;
-    va_copy(copy, args);
-    *ret = nullptr;
+int vasprintf(char **ret, const char *format, va_list args);
 
-    int count = vsnprintf(nullptr, 0, format, args);
-    if (count >= 0) {
-        char *buffer = static_cast<char *>(malloc((std::size_t)count + 1));
-        if (buffer == nullptr) {
-            count = -1;
-        } else if ((count = vsnprintf(buffer, static_cast<std::size_t>(count + 1), format, copy)) <
-                   0) {
-            free(buffer);
-        } else {
-            *ret = buffer;
-        }
-    }
-    va_end(copy);  // Each va_start() or va_copy() needs a va_end()
-
-    return count;
-}
-
-inline int asprintf(char **strp, const char *fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-    int r = vasprintf(strp, fmt, ap);
-    va_end(ap);
-    return r;
-}
+int asprintf(char **strp, const char *fmt, ...);
 
 inline int gettimeofday(struct timeval *tp, struct timezone *) {
     // Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing


### PR DESCRIPTION
This allows Windows to work with parity for existing code. Interrupting
works and all the tests pass.

In the future, the #ifdefs could be split out into a different file
so we could include more strategies such as epoll or kqueue in the
future. However, this is only selecting on two objects.

Change-Id: Ia5c58b72e78aeac129f2987b99ce2a6d75448d32