### PR TITLE
Revert JNI_JARJAR_PREFIX change

### DIFF
--- a/common/src/jni/main/cpp/JniConstants.cpp
+++ b/common/src/jni/main/cpp/JniConstants.cpp
@@ -54,11 +54,11 @@ void JniConstants::init(JavaVM *vm, JNIEnv *env) {
     stringClass = JniUtil::findClass(env, "java/lang/String");
 
     cryptoUpcallsClass = JniUtil::getGlobalRefToClass(
-            env, CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/CryptoUpcalls");
-    nativeRefClass =
-            JniUtil::getGlobalRefToClass(env, CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeRef");
+            env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/CryptoUpcalls");
+    nativeRefClass = JniUtil::getGlobalRefToClass(
+            env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef");
     openSslInputStreamClass = JniUtil::getGlobalRefToClass(
-            env, CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/OpenSSLBIOInputStream");
+            env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/OpenSSLBIOInputStream");
 
     nativeRef_context = JniUtil::getFieldRef(env, nativeRefClass, "context", "J");
 

--- a/common/src/jni/main/cpp/org_conscrypt_NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/org_conscrypt_NativeCrypto.cpp
@@ -9132,15 +9132,16 @@ static int NativeCrypto_ENGINE_SSL_write_heap(JNIEnv* env, jclass, jlong sslRef,
 
 #define FILE_DESCRIPTOR "Ljava/io/FileDescriptor;"
 #define SSL_CALLBACKS \
-    "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeCrypto$SSLHandshakeCallbacks;"
-#define REF_EC_GROUP "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeRef$EC_GROUP;"
-#define REF_EC_POINT "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeRef$EC_POINT;"
-#define REF_EVP_CIPHER_CTX "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeRef$EVP_CIPHER_CTX;"
-#define REF_EVP_MD_CTX "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeRef$EVP_MD_CTX;"
-#define REF_EVP_PKEY "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeRef$EVP_PKEY;"
-#define REF_EVP_PKEY_CTX "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeRef$EVP_PKEY_CTX;"
-#define REF_HMAC_CTX "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeRef$HMAC_CTX;"
-#define REF_BIO_IN_STREAM "L" CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/OpenSSLBIOInputStream;"
+    "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeCrypto$SSLHandshakeCallbacks;"
+#define REF_EC_GROUP "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef$EC_GROUP;"
+#define REF_EC_POINT "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef$EC_POINT;"
+#define REF_EVP_CIPHER_CTX \
+    "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef$EVP_CIPHER_CTX;"
+#define REF_EVP_MD_CTX "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef$EVP_MD_CTX;"
+#define REF_EVP_PKEY "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef$EVP_PKEY;"
+#define REF_EVP_PKEY_CTX "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef$EVP_PKEY_CTX;"
+#define REF_HMAC_CTX "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef$HMAC_CTX;"
+#define REF_BIO_IN_STREAM "L" TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/OpenSSLBIOInputStream;"
 static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, clinit, "()V"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, EVP_PKEY_new_RSA, "([B[B[B[B[B[B[B[B)J"),
@@ -9422,8 +9423,9 @@ CONSCRYPT_PUBLIC jint JNICALL JNI_OnLoad(JavaVM* vm, void*) {
 
     JniConstants::init(vm, env);
 
-    JniUtil::jniRegisterNativeMethods(env, CONSCRYPT_SYMBOL_PREFIX "org/conscrypt/NativeCrypto",
-                             sNativeCryptoMethods, NELEM(sNativeCryptoMethods));
+    JniUtil::jniRegisterNativeMethods(env,
+                                      TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeCrypto",
+                                      sNativeCryptoMethods, NELEM(sNativeCryptoMethods));
 
     CompatibilityCloseMonitor::init();
     return JNI_VERSION_1_6;

--- a/common/src/jni/main/include/Errors.h
+++ b/common/src/jni/main/include/Errors.h
@@ -141,8 +141,7 @@ public:
      * Throws a ParsingException with the given string as a message.
      */
     static int throwParsingException(JNIEnv* env, const char* message) {
-        return jniThrowException(env, CONSCRYPT_SYMBOL_PREFIX
-                                 "org/conscrypt/OpenSSLX509CertificateFactory$ParsingException",
+        return jniThrowException(env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/OpenSSLX509CertificateFactory$ParsingException",
                                  message);
     }
 

--- a/common/src/jni/main/include/macros.h
+++ b/common/src/jni/main/include/macros.h
@@ -17,14 +17,13 @@
 #ifndef CONSCRYPT_SRC_MAIN_NATIVE_MACROS_H_
 #define CONSCRYPT_SRC_MAIN_NATIVE_MACROS_H_
 
-#ifdef JNI_JARJAR_PREFIX
-#define TO_STRING(x) #x
-#define CONSCRYPT_SYMBOL_PREFIX TO_STRING(JNI_JARJAR_PREFIX)
-#else
-#define CONSCRYPT_SYMBOL_PREFIX ""
+#define TO_STRING1(x) #x
+#define TO_STRING(x) TO_STRING1(x)
+#ifndef JNI_JARJAR_PREFIX
 #ifndef CONSCRYPT_NOT_UNBUNDLED
 #define CONSCRYPT_UNBUNDLED
 #endif
+#define JNI_JARJAR_PREFIX
 #endif
 
 // The FALLTHROUGH_INTENDED macro can be used to annotate implicit fall-through


### PR DESCRIPTION
The C preprocessor was inserting "JNI_JARJAR_PREFIX" as the prefix for
the objects instead of the intended value "com.android"  Revert this
part of the change for now.