### PR TITLE
Fix Heap Buffer write bug

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLEngineSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineSocketImpl.java
@@ -387,7 +387,7 @@ public final class OpenSSLEngineSocketImpl extends OpenSSLSocketImplWrapper {
                             }
                         } else {
                             // Target is a heap buffer.
-                            socketOutputStream.write(target.array(), 0, target.position());
+                            socketOutputStream.write(target.array(), 0, target.limit());
                         }
                         if (engineResult.getHandshakeStatus() == HandshakeStatus.FINISHED) {
                             completeHandshake();


### PR DESCRIPTION
After the call to buffer.flip(), target.position() is set to 0.  When
writing to a heap buffer, we should use target.limit() as the end point.