### PR TITLE
Android log hardening

### DIFF
--- a/common/src/jni/main/include/macros.h
+++ b/common/src/jni/main/include/macros.h
@@ -151,11 +151,20 @@
 #elif defined(ANDROID) && !defined(CONSCRYPT_OPENJDK)
 
 #include <android/log.h>
+#ifndef ALOG
 #define ALOG(priority, tag, ...) __android_log_print(ANDROID_##priority, tag, __VA_ARGS__)
+#endif
+#ifndef ALOGD
 #define ALOGD(...) __android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__)
+#endif
+#ifndef ALOGE
 #define ALOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+#endif
 
+#ifndef __ALOGV
 #define __ALOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG, __VA_ARGS__)
+#endif
+#ifndef ALOGV
 #if LOG_NDEBUG
 #define ALOGV(...)                \
     do {                          \
@@ -165,6 +174,7 @@
     } while (0)
 #else
 #define ALOGV(...) __ALOGV(__VA_ARGS__)
+#endif
 #endif
 
 #else  // !ANDROID

--- a/common/src/jni/main/include/macros.h
+++ b/common/src/jni/main/include/macros.h
@@ -146,7 +146,7 @@
 
 #ifndef CONSCRYPT_UNBUNDLED
 
-#include "android/log.h"
+#include <log/log.h>
 
 #elif defined(ANDROID) && !defined(CONSCRYPT_OPENJDK)
 


### PR DESCRIPTION
Use log/log.h when bundled. When unbundled use android/log.h and defer to its log macros if present in that header.