### PR TITLE
AppData.h: add includes that are used

### DIFF
--- a/common/src/jni/main/include/AppData.h
+++ b/common/src/jni/main/include/AppData.h
@@ -19,6 +19,8 @@
 
 #include "NetFd.h"
 #include "NetworkUtil.h"
+#include "Trace.h"
+#include "compat.h"
 
 #include <jni.h>
 #include <mutex>


### PR DESCRIPTION
This breaks the Android platform build, but for some reason gradle is not broken.