### PR TITLE
Throw proper exception for unknown ASN.1 sig OID

### DIFF
--- a/common/src/jni/main/include/Errors.h
+++ b/common/src/jni/main/include/Errors.h
@@ -168,11 +168,12 @@ public:
 #endif
                 return throwInvalidKeyException(env, message);
                 break;
+            case ASN1_R_UNKNOWN_SIGNATURE_ALGORITHM:
 #if defined(ASN1_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM)
             case ASN1_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM:
+#endif
                 return throwNoSuchAlgorithmException(env, message);
                 break;
-#endif
         }
         return defaultThrow(env, message);
     }

--- a/common/src/jni/main/include/Errors.h
+++ b/common/src/jni/main/include/Errors.h
@@ -169,9 +169,7 @@ public:
                 return throwInvalidKeyException(env, message);
                 break;
             case ASN1_R_UNKNOWN_SIGNATURE_ALGORITHM:
-#if defined(ASN1_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM)
             case ASN1_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM:
-#endif
                 return throwNoSuchAlgorithmException(env, message);
                 break;
         }


### PR DESCRIPTION
When BoringSSL is asked to decode an unknown signature algorithm it will
push the ASN1_R_UNKNOWN_SIGNATURE_ALGORITHM error code onto the stack.
Interpret this as a NoSuchAlgorithmException instead of throwing a
RuntimeException.