### PR TITLE
Do not try to loadLibrary for GmsCore

### DIFF
--- a/android/src/main/java/org/conscrypt/NativeCryptoJni.java
+++ b/android/src/main/java/org/conscrypt/NativeCryptoJni.java
@@ -22,10 +22,7 @@ package org.conscrypt;
  */
 class NativeCryptoJni {
     public static void init() {
-        if ("com.google.android.gms.org.conscrypt".equals(NativeCrypto.class.getPackage().getName())) {
-            System.loadLibrary("gmscore");
-            System.loadLibrary("conscrypt_gmscore_jni");
-        } else {
+        if (!"com.google.android.gms.org.conscrypt".equals(NativeCrypto.class.getPackage().getName())) {
             System.loadLibrary("conscrypt_jni");
         }
     }

--- a/android/src/main/java/org/conscrypt/NativeCryptoJni.java
+++ b/android/src/main/java/org/conscrypt/NativeCryptoJni.java
@@ -22,6 +22,7 @@ package org.conscrypt;
  */
 class NativeCryptoJni {
     public static void init() {
+        // GmsCore loads its native libraries before this point in ProviderInstallerImpl.
         if (!"com.google.android.gms.org.conscrypt".equals(NativeCrypto.class.getPackage().getName())) {
             System.loadLibrary("conscrypt_jni");
         }


### PR DESCRIPTION
GmsCore loads the JNI libraries before calling into the Java code, so
do not bother trying to call System.loadLibrary in Conscrypt.