### PR TITLE
Expose SSLContext.SSL as an alias for SSLContext.TLS

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -55,6 +55,8 @@ public final class OpenSSLProvider extends Provider {
         /* === SSL Contexts === */
         final String classOpenSSLContextImpl = PREFIX + "OpenSSLContextImpl";
         final String tls12SSLContext = classOpenSSLContextImpl + "$TLSv12";
+        // Keep SSL as an alias to TLS
+        put("SSLContext.SSL", tls12SSLContext);
         put("SSLContext.TLS", tls12SSLContext);
         put("SSLContext.TLSv1", classOpenSSLContextImpl + "$TLSv1");
         put("SSLContext.TLSv1.1", classOpenSSLContextImpl + "$TLSv11");


### PR DESCRIPTION
SSL was removed with SSLv3 however a lot of callers use
SSL instead of Default leading to breakage.

Test: libcore/run-libcore-tests
libcore/luni/src/test/java/libcore/javax/net/ssl/*
Bug:32584776
Bug:30977793
Change-Id: Ic5c8a721d79d52eb02bdc811c07616db078c02d8