### PR TITLE
Revert "Do not try to loadLibrary for GmsCore (#53)"

### DIFF
--- a/android/src/main/java/org/conscrypt/NativeCryptoJni.java
+++ b/android/src/main/java/org/conscrypt/NativeCryptoJni.java
@@ -22,8 +22,10 @@ package org.conscrypt;
  */
 class NativeCryptoJni {
     public static void init() {
-        // GmsCore loads its native libraries before this point in ProviderInstallerImpl.
-        if (!"com.google.android.gms.org.conscrypt".equals(NativeCrypto.class.getPackage().getName())) {
+        if ("com.google.android.gms.org.conscrypt".equals(NativeCrypto.class.getPackage().getName())) {
+            System.loadLibrary("gmscore");
+            System.loadLibrary("conscrypt_gmscore_jni");
+        } else {
             System.loadLibrary("conscrypt_jni");
         }
     }


### PR DESCRIPTION
This reverts commit c41349bae4d2c15cdd041a7939167fa380bacc43.

Some parts of GmsCore are apparently using this without first going through the NativeLibraryLoader.