### PR TITLE
Fix buffer underflow bug

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLEngineSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineSocketImpl.java
@@ -522,7 +522,7 @@ public final class OpenSSLEngineSocketImpl extends OpenSSLSocketImplWrapper {
                             if (engineResult.getHandshakeStatus() == HandshakeStatus.FINISHED) {
                                 completeHandshake();
                             }
-                            if (engineResult.bytesProduced() == 0) {
+                            if (!needMoreData && engineResult.bytesProduced() == 0) {
                                 // Read successfully, but produced no data. Possibly part of a
                                 // handshake.
                                 return 0;


### PR DESCRIPTION
In the event the engine returns BUFFER_UNDERFLOW, and was not able to produce any bytes as a result, the ```read()``` returns 0 instead of continuing to read from the socket.