### PR TITLE
Revert JNI library rename

### DIFF
--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -105,7 +105,7 @@ model {
 
     components {
         // Builds the JNI library.
-        conscrypt(NativeLibrarySpec) {
+        conscrypt_openjdk_jni(NativeLibrarySpec) {
             if (build32Bit) { targetPlatform arch32Name }
             if (build64Bit) { targetPlatform arch64Name }
 

--- a/openjdk/src/main/java/org/conscrypt/NativeCryptoJni.java
+++ b/openjdk/src/main/java/org/conscrypt/NativeCryptoJni.java
@@ -25,7 +25,7 @@ import java.util.Set;
  * build.
  */
 final class NativeCryptoJni {
-    private static final String LIB_NAME = "conscrypt";
+    private static final String LIB_NAME = "conscrypt_openjdk_jni";
     private static final String UNKNOWN = "unknown";
     private static final String LINUX = "linux";
 


### PR DESCRIPTION
This causes problems on build systems where multiple platforms are built
simultaneously such as Android. Keep the old name to prevent problems
there.

This reverts the rename introduced in
160e730a8666ecd1cd362ed6cb5e9c032ed2bff0