### PR TITLE
Add armeabi-v7a, x86, x86_64 for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ target
 .classpath
 .project
 .settings
-.gitignore
 bin
 
 # OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: android
 
 env:
   global:
-    - NDK_VERSION=r11c
     - BORINGSSL_HOME="$HOME/boringssl"
     - CC=clang
     - CXX=clang++
@@ -12,7 +11,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/dists/
-    - $HOME/.cache/ndk
 
 matrix:
   include:
@@ -100,10 +98,8 @@ before_script:
   # newest Android NDK
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
     then
-        mkdir -p $HOME/.cache/ndk;
-        curl https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip -z $HOME/.cache/ndk/ndk-${NDK_VERSION}.zip -o $HOME/.cache/ndk/ndk-${NDK_VERSION}.zip;
-        unzip -q $HOME/.cache/ndk/ndk-$NDK_VERSION.zip -d $HOME;
-        echo "ndk.dir=$HOME/android-ndk-$NDK_VERSION" >> local.properties;
+        yes | $ANDROID_HOME/tools/bin/sdkmanager --channel=1 ndk-bundle 'cmake;3.6.3155560';
+        export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle;
     fi
 
   # Don't let the Android build download extra packages.

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,1 @@
+\.externalNativeBuild/

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.4.1)
+add_library(conscrypt_jni
+            SHARED
+            ../common/src/jni/main/cpp/CompatibilityCloseMonitor.cpp
+            ../common/src/jni/main/cpp/JniConstants.cpp
+            ../common/src/jni/main/cpp/NativeCrypto.cpp
+            ../common/src/jni/main/cpp/jni_load.cpp
+            )
+include_directories(../common/src/jni/main/include/
+                    ../common/src/jni/unbundled/include/
+                    ${BORINGSSL_HOME}/include)
+
+find_library(android-log-lib log)
+target_link_libraries(conscrypt_jni ${android-log-lib} ssl crypto)
+
+add_definitions(-DANDROID
+                -fvisibility=hidden
+                -DBORINGSSL_SHARED_LIBRARY
+                -DBORINGSSL_IMPLEMENTATION
+                -DOPENSSL_SMALL
+                -D_XOPEN_SOURCE=700
+                -Wno-unused-parameter)
+
+add_subdirectory(${BORINGSSL_HOME} ${CMAKE_CURRENT_BINARY_DIR}/boringssl)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,15 @@ if (!androidSdkInstalled) {
 
             testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
+            externalNativeBuild {
+                cmake {
+                    arguments '-DANDROID=True', '-DANDROID_STL=c++_static', '-DBORINGSSL_HOME=' + boringsslHome
+                    cFlags '-fvisibility=hidden', '-DBORINGSSL_SHARED_LIBRARY', '-DBORINGSSL_IMPLEMENTATION', '-DOPENSSL_SMALL', '-D_XOPEN_SOURCE=700', '-Wno-unused-parameter'
+                }
+            }
+            ndk {
+                abiFilters 'x86', 'x86_64', 'armeabi-v7a'
+            }
         }
         buildTypes {
             release {
@@ -46,6 +55,11 @@ if (!androidSdkInstalled) {
                         "${rootDir}/common/src/main/java",
                         "src/main/java"
                 ]
+            }
+        }
+        externalNativeBuild {
+            cmake {
+                path 'CMakeLists.txt'
             }
         }
         lintOptions {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   ANDROID_HOME: "C:\\android-sdk-windows"
-  ANDROID_NDK_HOME: "C:\\android-ndk-r11c"
+  ANDROID_NDK_HOME: "C:\\android-sdk-windows\\ndk-bundle"
   JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
   BORINGSSL_HOME: "C:\\boringssl"
   ANDROID_TOOLS_URL: "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
@@ -83,8 +83,10 @@ install:
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.0
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
-  - echo y | "%ANDROID_HOME%\\tools\bin\sdkmanager.bat" --channel=1 ndk-bundle
-  - echo y | "%ANDROID_HOME%\\tools\bin\sdkmanager.bat" cmake;3.6.3155560
+  - mkdir %ANDROID_HOME%\licenses
+  - ps: '"8933bad161af4178b1185d1a37fbf41ea5269c55" | Out-File $env:ANDROID_HOME\licenses\android-sdk-license -Encoding UTF8'
+  - '%ANDROID_HOME%\tools\bin\sdkmanager.bat --channel=1 ndk-bundle'
+  - '%ANDROID_HOME%\tools\bin\sdkmanager.bat cmake;3.6.3155560'
 
 build_script:
   - gradlew.bat --info assemble

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,7 +84,8 @@ install:
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
   - mkdir %ANDROID_HOME%\licenses
-  - ps: '"8933bad161af4178b1185d1a37fbf41ea5269c55" | Out-File $env:ANDROID_HOME\licenses\android-sdk-license -Encoding UTF8'
+  - ps: 'Add-Content -Value "`n8933bad161af4178b1185d1a37fbf41ea5269c55" -Path $env:ANDROID_HOME\licenses\android-sdk-license -Encoding ASCII'
+  - ps: 'Add-Content -Value "`n84831b9409646a918e30573bab4c9c91346d8abd" -Path $env:ANDROID_HOME\licenses\android-sdk-preview-license -Encoding ASCII'
   - '%ANDROID_HOME%\tools\bin\sdkmanager.bat --channel=1 ndk-bundle'
   - '%ANDROID_HOME%\tools\bin\sdkmanager.bat cmake;3.6.3155560'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,10 +31,6 @@ init:
   - appveyor DownloadFile %ANDROID_TOOLS_URL% -FileName android-tools.zip
   - 7z x android-tools.zip -o"%ANDROID_HOME%" > nul
 
-  # Download the Android NDK
-  - appveyor DownloadFile %ANDROID_NDK_URL% -FileName android-ndk.zip
-  - 7z x android-ndk.zip > nul
-
   # Get Ninja
   - appveyor DownloadFile %NINJA_URL% -FileName ninja.zip
   - 7z x ninja.zip -oC:\ninja > nul
@@ -81,16 +77,14 @@ before_build:
   # Go to project directory
   - cd C:\projects\conscrypt
 
-  # Work around bug in Android build scripts:
-  # https://code.google.com/p/android/issues/detail?id=212688#c10
-  - ps: (echo "ndk.dir=$ANDROID_NDK_HOME") -replace '\\', '\\\\' > local.properties
-
 install:
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.0
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
+  - echo y | "%ANDROID_HOME%\\tools\bin\sdkmanager.bat" --channel=1 ndk-bundle
+  - echo y | "%ANDROID_HOME%\\tools\bin\sdkmanager.bat" cmake;3.6.3155560
 
 build_script:
   - gradlew.bat --info assemble

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,7 +85,7 @@ install:
   - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
   - mkdir %ANDROID_HOME%\licenses
   - ps: 'Add-Content -Value "`n8933bad161af4178b1185d1a37fbf41ea5269c55" -Path $env:ANDROID_HOME\licenses\android-sdk-license -Encoding ASCII'
-  - ps: 'Add-Content -Value "`n84831b9409646a918e30573bab4c9c91346d8abd" -Path $env:ANDROID_HOME\licenses\android-sdk-preview-license -Encoding ASCII'
+  - ps: 'Add-Content -Value "`n84831b9409646a918e30573bab4c9c91346d8abd`n504667f4c0de7af1a06de9f4b1727b84351f2910" -Path $env:ANDROID_HOME\licenses\android-sdk-preview-license -Encoding ASCII'
   - '%ANDROID_HOME%\tools\bin\sdkmanager.bat --channel=1 ndk-bundle'
   - '%ANDROID_HOME%\tools\bin\sdkmanager.bat cmake;3.6.3155560'
 


### PR DESCRIPTION
First step in getting Android's build working unbundled with gradle.
This currently builds armeabi-v7a, x86, and x86_64 libraries in native.
There is an issue preventing arm64-v8a from working currently.

Should get us most of the way toward fixing #12.