### PR TITLE
Adding uber jar support.

### DIFF
--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -1,0 +1,61 @@
+description = 'Conscrypt: OpenJdk UberJAR'
+
+ext {
+    buildUberJar = Boolean.parseBoolean(System.getProperty('org.conscrypt.openjdk.buildUberJar', 'false'))
+    uberJarClassifiers = (System.getProperty('org.conscrypt.openjdk.uberJarClassifiers',
+            'osx-x86_64,linux-x86_64,windows-x86_64')).split(',')
+    classesDir = "${buildDir}/classes"
+    resourcesDir = "${buildDir}/resources"
+}
+
+if (buildUberJar) {
+    configurations {
+        uberJar
+    }
+
+    // Point the jar task to the copied classes and resources directories.
+    jar {
+        from classesDir
+        from resourcesDir
+    }
+
+    // Add the dependencies for the uber jar.
+    uberJarClassifiers.each { uberJarClassifier ->
+        dependencies.uberJar "${group}:conscrypt-openjdk:${version}:${uberJarClassifier}"
+    }
+
+    /**
+     * Copy the native libraries to the resources directory.
+     */
+    task copySharedLibs(type: Copy, dependsOn: configurations.uberJar) {
+        from {
+            configurations.uberJar.collect {
+                zipTree(it)
+            }
+        }
+        include '/META-INF/native/**'
+        into file(resourcesDir)
+    }
+    jar.dependsOn copySharedLibs
+
+    /**
+     * Copy the object files to the classes directory.
+     */
+    task copyClasses(type: Copy, dependsOn: configurations.uberJar) {
+        from {
+            configurations.uberJar.collect {
+                zipTree(it)
+            }
+        }
+        exclude '/META-INF/**'
+        into file(classesDir)
+    }
+    jar.dependsOn copyClasses
+
+} else {
+    // Not building an uber jar - disable all tasks.
+    tasks.collect {
+        it.enabled = false
+    }
+}
+

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -228,7 +228,3 @@ model {
     }
 }
 
-def getFileExtension(File f) {
-    String name = f.getName()
-    return new String(name.substring(name.lastIndexOf('.')))
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,12 @@
 rootProject.name = "conscrypt"
 include ":conscrypt-constants"
 include ":conscrypt-openjdk"
+include ":conscrypt-openjdk-uber"
 include ":conscrypt-android"
 include ":conscrypt-android-stub"
 
 project(':conscrypt-constants').projectDir = "$rootDir/constants" as File
 project(':conscrypt-openjdk').projectDir = "$rootDir/openjdk" as File
+project(':conscrypt-openjdk-uber').projectDir = "$rootDir/openjdk-uber" as File
 project(':conscrypt-android').projectDir = "$rootDir/android" as File
 project(':conscrypt-android-stub').projectDir = "$rootDir/android-stub" as File


### PR DESCRIPTION
The uber jar will not build by default.  To build it, you need to do:

./gradlew -Dorg.conscrypt.openjdk.buildUberJar=true build -p openjdk-uber

By default, it will include osx-x86_64, linux-x86_64, and windows-x86_64

This can be overridden with a property. For example:

-Dorg.conscrypt.openjdk.uberJarClassifiers=windows-x86,windows-x86_64

Fixes #8