### PR TITLE
Fix Android platform build files

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -25,7 +25,7 @@ cc_defaults {
     ],
 
     srcs: [
-        "common/src/jni/main/cpp/org_conscrypt_NativeCrypto.cpp",
+        "common/src/jni/main/cpp/NativeCrypto.cpp",
     ],
 
     local_include_dirs: [

--- a/Android.mk
+++ b/Android.mk
@@ -77,9 +77,10 @@ common_java_files := $(filter-out \
 	%/org/conscrypt/NativeCryptoJni.java \
 	, $(call all-java-files-under,common/src/main/java))
 
-bundled_main_cpp_files := common/src/jni/main/cpp/org_conscrypt_NativeCrypto.cpp \
-                          common/src/jni/main/cpp/CompatibilityCloseMonitor.cpp \
-                          common/src/jni/main/cpp/JniConstants.cpp
+bundled_main_cpp_files := \
+	common/src/jni/main/cpp/CompatibilityCloseMonitor.cpp \
+	common/src/jni/main/cpp/JniConstants.cpp \
+	common/src/jni/main/cpp/NativeCrypto.cpp
 
 # Create the conscrypt library
 include $(CLEAR_VARS)


### PR DESCRIPTION
Renaming one of the C++ files broke the Android platform build. This
fixes the build files needed to track that change.

Change-Id: Idcd1d55ea7539dee279f0a16407f39c2429a2fbc