### PR TITLE
Eliminate some unneeded complexity in platform build

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -25,7 +25,10 @@ cc_defaults {
     ],
 
     srcs: [
+        "common/src/jni/main/cpp/CompatibilityCloseMonitor.cpp",
+        "common/src/jni/main/cpp/JniConstants.cpp",
         "common/src/jni/main/cpp/NativeCrypto.cpp",
+        "common/src/jni/main/cpp/jni_load.cpp",
     ],
 
     local_include_dirs: [
@@ -38,11 +41,6 @@ cc_defaults {
 
 cc_defaults {
     name: "conscrypt_unbundled",
-
-    srcs: [
-        "common/src/jni/main/cpp/CompatibilityCloseMonitor.cpp",
-        "common/src/jni/main/cpp/JniConstants.cpp",
-    ],
 
     local_include_dirs: [
         "common/src/jni/unbundled/include",
@@ -73,11 +71,6 @@ cc_library_host_shared {
 
     cflags: [
         "-DCONSCRYPT_OPENJDK",
-    ],
-
-    srcs: [
-        "common/src/jni/main/cpp/CompatibilityCloseMonitor.cpp",
-        "common/src/jni/main/cpp/JniConstants.cpp",
     ],
 
     local_include_dirs: [

--- a/Android.mk
+++ b/Android.mk
@@ -77,11 +77,6 @@ common_java_files := $(filter-out \
 	%/org/conscrypt/NativeCryptoJni.java \
 	, $(call all-java-files-under,common/src/main/java))
 
-bundled_main_cpp_files := \
-	common/src/jni/main/cpp/CompatibilityCloseMonitor.cpp \
-	common/src/jni/main/cpp/JniConstants.cpp \
-	common/src/jni/main/cpp/NativeCrypto.cpp
-
 # Create the conscrypt library
 include $(CLEAR_VARS)
 LOCAL_SRC_FILES := $(common_java_files)
@@ -140,7 +135,7 @@ include $(CLEAR_VARS)
 LOCAL_CFLAGS += $(core_cflags)
 LOCAL_CFLAGS += -DJNI_JARJAR_PREFIX="com/android/"
 LOCAL_CPPFLAGS += $(core_cppflags)
-LOCAL_SRC_FILES := $(bundled_main_cpp_files)
+LOCAL_SRC_FILES := $(call all-cpp-files-under,common/src/jni/main/cpp)
 LOCAL_C_INCLUDES += \
         external/openssl/include \
         external/openssl \
@@ -183,7 +178,7 @@ LOCAL_CPPFLAGS += $(core_cppflags) \
         -DJNI_JARJAR_PREFIX="com/google/android/gms/" \
         -DCONSCRYPT_UNBUNDLED \
         -DSTATIC_LIB
-LOCAL_SRC_FILES := $(bundled_main_cpp_files)
+LOCAL_SRC_FILES := $(call all-cpp-files-under,common/src/jni/main/cpp)
 LOCAL_C_INCLUDES += \
         external/openssl/include \
         external/openssl \
@@ -247,7 +242,7 @@ endif
 # Conscrypt native library for host
 include $(CLEAR_VARS)
 LOCAL_CLANG := true
-LOCAL_SRC_FILES += $(bundled_main_cpp_files)
+LOCAL_SRC_FILES := $(call all-cpp-files-under,common/src/jni/main/cpp)
 LOCAL_C_INCLUDES += \
         external/openssl/include \
         external/openssl \
@@ -283,5 +278,4 @@ conscrypt_generate_constants_exe :=
 core_cflags :=
 core_cppflags :=
 local_javac_flags :=
-bundled_main_cpp_files :=
 bundled_test_java_files :=


### PR DESCRIPTION
All the files compile whether unbundled or not, so we can eliminate the
switch statements in the build logic and just have it included
everywhere.

Change-Id: I7b6df16ad90a355f8e04bef27274a02806230ca9