### PR TITLE
Fix AbstractSessionContextTest for CTS running

### DIFF
--- a/common/src/main/java/org/conscrypt/AbstractSessionContext.java
+++ b/common/src/main/java/org/conscrypt/AbstractSessionContext.java
@@ -204,7 +204,7 @@ abstract class AbstractSessionContext implements SSLSessionContext {
      *
      * @return session data as bytes or null if the session can't be converted
      */
-    byte[] toBytes(SSLSession session) {
+    public byte[] toBytes(SSLSession session) {
         // TODO: Support SSLSessionImpl, too.
         if (!(session instanceof OpenSSLSessionImpl)) {
             return null;


### PR DESCRIPTION
Make the AbstractSessionContext#toBytes public for testing. Otherwise CTS explodes because the test and the class-under-test are loaded in different ClassLoaders.