### PR TITLE
Add arm64-v8a to Android artifacts

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -21,4 +21,8 @@ add_definitions(-DANDROID
                 -D_XOPEN_SOURCE=700
                 -Wno-unused-parameter)
 
+if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -march=armv8-a+crypto")
+endif()
+
 add_subdirectory(${BORINGSSL_HOME} ${CMAKE_CURRENT_BINARY_DIR}/boringssl)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ if (androidSdkInstalled) {
                 }
             }
             ndk {
-                abiFilters 'x86', 'x86_64', 'armeabi-v7a'
+                abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
             }
         }
         buildTypes {


### PR DESCRIPTION
-march must be set for arm64-v8a builds since the clang in NDK is too
old to understand BoringSSL's directive.

This fixes #12 