### PR TITLE
Don't call SSL_get_state.

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -7187,8 +7187,8 @@ static int sslRead(JNIEnv* env, SSL* ssl, jobject fdObject, jobject shc, char* b
 
         if (!SSL_is_init_finished(ssl) && !SSL_in_false_start(ssl) &&
             !SSL_renegotiate_pending(ssl)) {
-            JNI_TRACE("ssl=%p sslRead => init is not finished (state=0x%x)", ssl,
-                    SSL_get_state(ssl));
+            JNI_TRACE("ssl=%p sslRead => init is not finished (state: %s)", ssl,
+                    SSL_state_string_long(ssl));
             return THROW_SSLEXCEPTION;
         }
 
@@ -7380,8 +7380,8 @@ static int sslWrite(JNIEnv* env, SSL* ssl, jobject fdObject, jobject shc, const 
 
         if (!SSL_is_init_finished(ssl) && !SSL_in_false_start(ssl) &&
             !SSL_renegotiate_pending(ssl)) {
-            JNI_TRACE("ssl=%p sslWrite => init is not finished (state=0x%x)", ssl,
-                    SSL_get_state(ssl));
+            JNI_TRACE("ssl=%p sslWrite => init is not finished (state: %s)", ssl,
+                    SSL_state_string_long(ssl));
             return THROW_SSLEXCEPTION;
         }
 


### PR DESCRIPTION
SSL_state_string_long provides a string which is more readable for
humans. We plan to unexport the numerical value to prevent code from
depending on implementation details of the state machine. The
string-based APIs will probably stay for debugging as they're much less
likely to be acted on programmatically.