### PR TITLE
Reduce verbosity of CI outputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,25 @@ matrix:
     - os: linux
       jdk: oraclejdk8
       sudo: false
-      android:
-        components:
-          - tools
-          - tools # https://github.com/travis-ci/travis-ci/issues/6040
-          - platform-tools
-          - extra-android-m2repository
-          - build-tools-25.0.0
-          - android-25
-        license:
-          - 'android-sdk-license-.+'
+
+      env:
+        - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/tools_r25.2.3-linux.zip"
+        - ANDROID_HOME="$HOME/android-sdk-linux"
+        - ANDROID_NDK_HOME="$ANDROID_HOME/ndk-bundle"
+
+      before_install:
+        - curl -L $ANDROID_TOOLS_URL -o $HOME/tools.zip
+        - unzip -q $HOME/tools.zip -d $ANDROID_HOME
+        - mkdir $ANDROID_HOME/licenses
+        - echo -ne "\n8933bad161af4178b1185d1a37fbf41ea5269c55" >> $ANDROID_HOME/licenses/android-sdk-license
+        - echo -ne "\n84831b9409646a918e30573bab4c9c91346d8abd\n504667f4c0de7af1a06de9f4b1727b84351f2910" >> $ANDROID_HOME/licenses/android-sdk-preview-license
+        - $ANDROID_HOME/tools/bin/sdkmanager tools
+        - $ANDROID_HOME/tools/bin/sdkmanager platform-tools
+        - $ANDROID_HOME/tools/bin/sdkmanager 'build-tools;25.0.0'
+        - $ANDROID_HOME/tools/bin/sdkmanager 'platforms;android-25'
+        - $ANDROID_HOME/tools/bin/sdkmanager 'extras;android;m2repository'
+        - $ANDROID_HOME/tools/bin/sdkmanager --channel=1 ndk-bundle
+        - $ANDROID_HOME/tools/bin/sdkmanager 'cmake;3.6.3155560'
 
       addons:
         apt:
@@ -91,16 +100,6 @@ before_script:
   #      ninja;
   #      popd;
   #  fi
-
-  # newest Android NDK
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
-    then
-        yes | $ANDROID_HOME/tools/bin/sdkmanager --channel=1 ndk-bundle 'cmake;3.6.3155560';
-        export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle;
-    fi
-
-  # Don't let the Android build download extra packages.
-  - echo 'android.builder.sdkDownload=false' > gradle.properties
 
   # We need this to find the merge-base
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PULL_REQUEST" != "false" ]];

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ script:
         git rev-list $(git merge-base HEAD origin/master)..HEAD | xargs -i git diff-tree --no-commit-id --name-only -r {} | grep -E '\.java$' | xargs -r git ls-files | xargs -r java -jar $HOME/gjf.jar -a -i --fix-imports-only && git diff --exit-code || { git reset --hard; false; }
     fi
 
-  - ./gradlew --stacktrace --info build
+  - ./gradlew build
 
 after_script:
   - "[ -f android/build/outputs/lint-results-debug.xml ] && cat android/build/outputs/lint-results-debug.xml"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,10 +90,10 @@ install:
   - '%ANDROID_HOME%\tools\bin\sdkmanager.bat cmake;3.6.3155560'
 
 build_script:
-  - gradlew.bat --info assemble
+  - gradlew.bat assemble
 
 test_script:
-  - gradlew.bat --info check
+  - gradlew.bat check
 
 after_test:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   JAVA_HOME: "C:\\Program Files\\Java\\jdk1.8.0"
   BORINGSSL_HOME: "C:\\boringssl"
   ANDROID_TOOLS_URL: "https://dl.google.com/android/repository/tools_r25.2.3-windows.zip"
-  ANDROID_NDK_URL: "https://dl.google.com/android/repository/android-ndk-r11c-windows-x86_64.zip"
   NINJA_URL: "https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-win.zip"
   CMAKE_URL: "https://cmake.org/files/v3.4/cmake-3.4.0-win32-x86.zip"
   MSVC: "14.0"
@@ -78,14 +77,14 @@ before_build:
   - cd C:\projects\conscrypt
 
 install:
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t tools
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t platform-tools
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t build-tools-25.0.0
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t android-25
-  - echo y | "%ANDROID_HOME%\tools\android.bat" update sdk -u -a -t extra-android-m2repository
   - mkdir %ANDROID_HOME%\licenses
   - ps: 'Add-Content -Value "`n8933bad161af4178b1185d1a37fbf41ea5269c55" -Path $env:ANDROID_HOME\licenses\android-sdk-license -Encoding ASCII'
   - ps: 'Add-Content -Value "`n84831b9409646a918e30573bab4c9c91346d8abd`n504667f4c0de7af1a06de9f4b1727b84351f2910" -Path $env:ANDROID_HOME\licenses\android-sdk-preview-license -Encoding ASCII'
+  - '%ANDROID_HOME%\tools\bin\sdkmanager.bat tools'
+  - '%ANDROID_HOME%\tools\bin\sdkmanager.bat platform-tools'
+  - '%ANDROID_HOME%\tools\bin\sdkmanager.bat build-tools;25.0.0'
+  - '%ANDROID_HOME%\tools\bin\sdkmanager.bat platforms;android-25'
+  - '%ANDROID_HOME%\tools\bin\sdkmanager.bat extras;android;m2repository'
   - '%ANDROID_HOME%\tools\bin\sdkmanager.bat --channel=1 ndk-bundle'
   - '%ANDROID_HOME%\tools\bin\sdkmanager.bat cmake;3.6.3155560'
 


### PR DESCRIPTION
The build log is growing above the limits allowed for Travis-CI (10000
lines) with verbose output enabled. Since the build is fairly stable,
reduce the verbosity of the output for now.

This will allow us to see warnings a bit more clearly as well.