### PR TITLE
Reduce Java lint warnings

### DIFF
--- a/common/src/main/java/org/conscrypt/AbstractSessionContext.java
+++ b/common/src/main/java/org/conscrypt/AbstractSessionContext.java
@@ -59,8 +59,8 @@ abstract class AbstractSessionContext implements SSLSessionContext {
     /** Identifies OpenSSL sessions with TLS SCT data. */
     static final int OPEN_SSL_WITH_TLS_SCT = 3;
 
-    private final Map<ByteArray, SSLSession> sessions
-            = new LinkedHashMap<ByteArray, SSLSession>() {
+    @SuppressWarnings("serial")
+    private final Map<ByteArray, SSLSession> sessions = new LinkedHashMap<ByteArray, SSLSession>() {
         @Override
         protected boolean removeEldestEntry(
                 Map.Entry<ByteArray, SSLSession> eldest) {

--- a/common/src/main/java/org/conscrypt/FileClientSessionCache.java
+++ b/common/src/main/java/org/conscrypt/FileClientSessionCache.java
@@ -341,8 +341,8 @@ public class FileClientSessionCache {
     }
 
     /** A file containing a piece of cached data. */
+    @SuppressWarnings("serial")
     static class CacheFile extends File {
-
         final String name;
 
         CacheFile(File dir, String name) {

--- a/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
@@ -83,18 +83,24 @@ public class OpenSSLECKeyFactory extends KeyFactorySpi {
 
         if (key instanceof ECPublicKey && ECPublicKeySpec.class.isAssignableFrom(keySpec)) {
             ECPublicKey ecKey = (ECPublicKey) key;
-            return (T) new ECPublicKeySpec(ecKey.getW(), ecKey.getParams());
+            @SuppressWarnings("unchecked")
+            T result = (T) new ECPublicKeySpec(ecKey.getW(), ecKey.getParams());
+            return result;
         } else if (key instanceof PublicKey && ECPublicKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"X.509".equals(key.getFormat()) || encoded == null) {
                 throw new InvalidKeySpecException("Not a valid X.509 encoding");
             }
             ECPublicKey ecKey = (ECPublicKey) engineGeneratePublic(new X509EncodedKeySpec(encoded));
-            return (T) new ECPublicKeySpec(ecKey.getW(), ecKey.getParams());
+            @SuppressWarnings("unchecked")
+            T result = (T) new ECPublicKeySpec(ecKey.getW(), ecKey.getParams());
+            return result;
         } else if (key instanceof ECPrivateKey
                 && ECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             ECPrivateKey ecKey = (ECPrivateKey) key;
-            return (T) new ECPrivateKeySpec(ecKey.getS(), ecKey.getParams());
+            @SuppressWarnings("unchecked")
+            T result = (T) new ECPrivateKeySpec(ecKey.getS(), ecKey.getParams());
+            return result;
         } else if (key instanceof PrivateKey && ECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"PKCS#8".equals(key.getFormat()) || encoded == null) {
@@ -102,7 +108,9 @@ public class OpenSSLECKeyFactory extends KeyFactorySpi {
             }
             ECPrivateKey ecKey =
                     (ECPrivateKey) engineGeneratePrivate(new PKCS8EncodedKeySpec(encoded));
-            return (T) new ECPrivateKeySpec(ecKey.getS(), ecKey.getParams());
+            @SuppressWarnings("unchecked")
+            T result = (T) new ECPrivateKeySpec(ecKey.getS(), ecKey.getParams());
+            return result;
         } else if (key instanceof PrivateKey
                 && PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
@@ -112,7 +120,8 @@ public class OpenSSLECKeyFactory extends KeyFactorySpi {
             } else if (encoded == null) {
                 throw new InvalidKeySpecException("Key is not encodable");
             }
-            return (T) new PKCS8EncodedKeySpec(encoded);
+            @SuppressWarnings("unchecked") T result = (T) new PKCS8EncodedKeySpec(encoded);
+            return result;
         } else if (key instanceof PublicKey && X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"X.509".equals(key.getFormat())) {
@@ -121,7 +130,8 @@ public class OpenSSLECKeyFactory extends KeyFactorySpi {
             } else if (encoded == null) {
                 throw new InvalidKeySpecException("Key is not encodable");
             }
-            return (T) new X509EncodedKeySpec(encoded);
+            @SuppressWarnings("unchecked") T result = (T) new X509EncodedKeySpec(encoded);
+            return result;
         } else {
             throw new InvalidKeySpecException("Unsupported key type and key spec combination; key="
                     + key.getClass().getName() + ", keySpec=" + keySpec.getName());

--- a/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
@@ -619,7 +619,7 @@ public final class OpenSSLEngineImpl extends SSLEngine
                             // This means the connection was shutdown correctly, close inbound and
                             // outbound
                             closeAll();
-                        // fall-trough!
+                            return newResult(bytesConsumed, bytesProduced, handshakeStatus);
                         case SSL_ERROR_WANT_READ:
                         case SSL_ERROR_WANT_WRITE:
                             return newResult(bytesConsumed, bytesProduced, handshakeStatus);
@@ -1223,16 +1223,19 @@ public final class OpenSSLEngineImpl extends SSLEngine
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public String chooseServerPSKIdentityHint(PSKKeyManager keyManager) {
         return keyManager.chooseServerKeyIdentityHint(this);
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public String chooseClientPSKIdentity(PSKKeyManager keyManager, String identityHint) {
         return keyManager.chooseClientKeyIdentity(identityHint, this);
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public SecretKey getPSKKey(PSKKeyManager keyManager, String identityHint, String identity) {
         return keyManager.getKey(identityHint, identity, this);
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLEngineSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineSocketImpl.java
@@ -73,7 +73,9 @@ public final class OpenSSLEngineSocketImpl extends OpenSSLSocketImplWrapper {
                         engine.beginHandshake();
                         break;
                     }
-                    // Fall through to FINISHED processing.
+                    // Finish processing as well
+                    completeHandshake();
+                    break;
                 }
                 case FINISHED: {
                     completeHandshake();
@@ -300,16 +302,19 @@ public final class OpenSSLEngineSocketImpl extends OpenSSLSocketImplWrapper {
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public String chooseServerPSKIdentityHint(PSKKeyManager keyManager) {
         return engine.chooseServerPSKIdentityHint(keyManager);
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public String chooseClientPSKIdentity(PSKKeyManager keyManager, String identityHint) {
         return engine.chooseClientPSKIdentity(keyManager, identityHint);
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public SecretKey getPSKKey(PSKKeyManager keyManager, String identityHint, String identity) {
         return engine.getPSKKey(keyManager, identityHint, identity);
     }
@@ -505,7 +510,9 @@ public final class OpenSSLEngineSocketImpl extends OpenSSLSocketImplWrapper {
                                         // Need to read more data from the socket.
                                         break;
                                     }
-                                    // Fall-through and serve the data that was produced.
+                                    // Also serve the data that was produced.
+                                    needMoreData = false;
+                                    break;
                                 }
                                 case OK: {
                                     // We processed the entire packet successfully.

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
@@ -85,7 +85,9 @@ public class OpenSSLRSAKeyFactory extends KeyFactorySpi {
 
         if (key instanceof RSAPublicKey && RSAPublicKeySpec.class.isAssignableFrom(keySpec)) {
             RSAPublicKey rsaKey = (RSAPublicKey) key;
-            return (T) new RSAPublicKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent());
+            @SuppressWarnings("unchecked")
+            T result = (T) new RSAPublicKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent());
+            return result;
         } else if (key instanceof PublicKey && RSAPublicKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"X.509".equals(key.getFormat()) || encoded == null) {
@@ -93,22 +95,30 @@ public class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             }
             RSAPublicKey rsaKey =
                     (RSAPublicKey) engineGeneratePublic(new X509EncodedKeySpec(encoded));
-            return (T) new RSAPublicKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent());
+            @SuppressWarnings("unchecked")
+            T result = (T) new RSAPublicKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent());
+            return result;
         } else if (key instanceof RSAPrivateCrtKey
                 && RSAPrivateCrtKeySpec.class.isAssignableFrom(keySpec)) {
             RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey) key;
-            return (T) new RSAPrivateCrtKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent(),
+            @SuppressWarnings("unchecked")
+            T result = (T) new RSAPrivateCrtKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent(),
                     rsaKey.getPrivateExponent(), rsaKey.getPrimeP(), rsaKey.getPrimeQ(),
                     rsaKey.getPrimeExponentP(), rsaKey.getPrimeExponentQ(),
                     rsaKey.getCrtCoefficient());
+            return result;
         } else if (key instanceof RSAPrivateCrtKey
                 && RSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey) key;
-            return (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
+            @SuppressWarnings("unchecked")
+            T result = (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
+            return result;
         } else if (key instanceof RSAPrivateKey
                 && RSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             RSAPrivateKey rsaKey = (RSAPrivateKey) key;
-            return (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
+            @SuppressWarnings("unchecked")
+            T result = (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
+            return result;
         } else if (key instanceof PrivateKey
                 && RSAPrivateCrtKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
@@ -119,10 +129,12 @@ public class OpenSSLRSAKeyFactory extends KeyFactorySpi {
                     (RSAPrivateKey) engineGeneratePrivate(new PKCS8EncodedKeySpec(encoded));
             if (privKey instanceof RSAPrivateCrtKey) {
                 RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey) privKey;
-                return (T) new RSAPrivateCrtKeySpec(rsaKey.getModulus(),
-                        rsaKey.getPublicExponent(), rsaKey.getPrivateExponent(),
-                        rsaKey.getPrimeP(), rsaKey.getPrimeQ(), rsaKey.getPrimeExponentP(),
-                        rsaKey.getPrimeExponentQ(), rsaKey.getCrtCoefficient());
+                @SuppressWarnings("unchecked")
+                T result = (T) new RSAPrivateCrtKeySpec(rsaKey.getModulus(),
+                        rsaKey.getPublicExponent(), rsaKey.getPrivateExponent(), rsaKey.getPrimeP(),
+                        rsaKey.getPrimeQ(), rsaKey.getPrimeExponentP(), rsaKey.getPrimeExponentQ(),
+                        rsaKey.getCrtCoefficient());
+                return result;
             } else {
                 throw new InvalidKeySpecException("Encoded key is not an RSAPrivateCrtKey");
             }
@@ -133,7 +145,9 @@ public class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             }
             RSAPrivateKey rsaKey =
                     (RSAPrivateKey) engineGeneratePrivate(new PKCS8EncodedKeySpec(encoded));
-            return (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
+            @SuppressWarnings("unchecked")
+            T result = (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
+            return result;
         } else if (key instanceof PrivateKey
                 && PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
@@ -143,7 +157,8 @@ public class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             } else if (encoded == null) {
                 throw new InvalidKeySpecException("Key is not encodable");
             }
-            return (T) new PKCS8EncodedKeySpec(encoded);
+            @SuppressWarnings("unchecked") T result = (T) new PKCS8EncodedKeySpec(encoded);
+            return result;
         } else if (key instanceof PublicKey && X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"X.509".equals(key.getFormat())) {
@@ -152,7 +167,8 @@ public class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             } else if (encoded == null) {
                 throw new InvalidKeySpecException("Key is not encodable");
             }
-            return (T) new X509EncodedKeySpec(encoded);
+            @SuppressWarnings("unchecked") T result = (T) new X509EncodedKeySpec(encoded);
+            return result;
         } else {
             throw new InvalidKeySpecException("Unsupported key type and key spec combination; key="
                     + key.getClass().getName() + ", keySpec=" + keySpec.getName());

--- a/common/src/main/java/org/conscrypt/OpenSSLSignatureRawRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignatureRawRSA.java
@@ -77,6 +77,7 @@ public class OpenSSLSignatureRawRSA extends SignatureSpi {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected Object engineGetParameter(String param) throws InvalidParameterException {
         return null;
     }
@@ -121,6 +122,7 @@ public class OpenSSLSignatureRawRSA extends SignatureSpi {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     protected void engineSetParameter(String param, Object value) throws InvalidParameterException {
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -1310,16 +1310,19 @@ public class OpenSSLSocketImpl
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public String chooseServerPSKIdentityHint(PSKKeyManager keyManager) {
         return keyManager.chooseServerKeyIdentityHint(this);
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public String chooseClientPSKIdentity(PSKKeyManager keyManager, String identityHint) {
         return keyManager.chooseClientKeyIdentity(identityHint, this);
     }
 
     @Override
+    @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public SecretKey getPSKKey(PSKKeyManager keyManager, String identityHint, String identity) {
         return keyManager.getKey(identityHint, identity, this);
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CertPath.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CertPath.java
@@ -32,6 +32,8 @@ import java.util.List;
 import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 public class OpenSSLX509CertPath extends CertPath {
+    private static final long serialVersionUID = -3249106005255170761L;
+
     private static final byte[] PKCS7_MARKER = new byte[] {
             '-', '-', '-', '-', '-', 'B', 'E', 'G', 'I', 'N', ' ', 'P', 'K', 'C', 'S', '7'
     };

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -51,6 +51,8 @@ import javax.security.auth.x500.X500Principal;
 import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 public class OpenSSLX509Certificate extends X509Certificate {
+    private static final long serialVersionUID = 1992239142393372128L;
+
     private transient final long mContext;
     private transient Integer mHashCode;
 

--- a/common/src/main/java/org/conscrypt/util/EmptyArray.java
+++ b/common/src/main/java/org/conscrypt/util/EmptyArray.java
@@ -27,7 +27,7 @@ public final class EmptyArray {
     public static final double[] DOUBLE = new double[0];
     public static final int[] INT = new int[0];
 
-    public static final Class<?>[] CLASS = new Class[0];
+    public static final Class<?>[] CLASS = new Class<?>[ 0 ];
     public static final Object[] OBJECT = new Object[0];
     public static final String[] STRING = new String[0];
     public static final Throwable[] THROWABLE = new Throwable[0];

--- a/openjdk/src/test/java/libcore/java/security/StandardNames.java
+++ b/openjdk/src/test/java/libcore/java/security/StandardNames.java
@@ -16,6 +16,10 @@
 
 package libcore.java.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.security.Security;
 import java.security.spec.DSAPrivateKeySpec;
 import java.security.spec.DSAPublicKeySpec;
@@ -36,7 +40,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.DHPublicKeySpec;
-import junit.framework.Assert;
 
 /**
  * This class defines expected string names for protocols, key types,
@@ -63,7 +66,7 @@ import junit.framework.Assert;
  * Java &trade; PKCS#11 Reference Guide
  * </a>.
  */
-public final class StandardNames extends Assert {
+public final class StandardNames {
     public static final boolean IS_RI =
             !"Dalvik Core Library".equals(System.getProperty("java.specification.name"));
     public static final String JSSE_PROVIDER_NAME = (IS_RI) ? "SunJSSE" : "AndroidOpenSSL";
@@ -91,28 +94,29 @@ public final class StandardNames extends Assert {
     /**
      * A map from algorithm type (e.g. Cipher) to a set of algorithms (e.g. AES, DES, ...)
      */
-    public static final Map<String, Set<String>> PROVIDER_ALGORITHMS =
-            new HashMap<String, Set<String>>();
+    public static final HashMap<String, HashSet<String>> PROVIDER_ALGORITHMS =
+            new HashMap<String, HashSet<String>>();
 
-    public static final Map<String, Set<String>> CIPHER_MODES = new HashMap<String, Set<String>>();
+    public static final HashMap<String, HashSet<String>> CIPHER_MODES =
+            new HashMap<String, HashSet<String>>();
 
-    public static final Map<String, Set<String>> CIPHER_PADDINGS =
-            new HashMap<String, Set<String>>();
+    public static final HashMap<String, HashSet<String>> CIPHER_PADDINGS =
+            new HashMap<String, HashSet<String>>();
 
-    private static final Map<String, String[]> SSL_CONTEXT_PROTOCOLS_ENABLED =
+    private static final HashMap<String, String[]> SSL_CONTEXT_PROTOCOLS_ENABLED =
             new HashMap<String, String[]>();
 
     private static void provide(String type, String algorithm) {
-        Set<String> algorithms = PROVIDER_ALGORITHMS.get(type);
+        HashSet<String> algorithms = PROVIDER_ALGORITHMS.get(type);
         if (algorithms == null) {
-            algorithms = new HashSet();
+            algorithms = new HashSet<String>();
             PROVIDER_ALGORITHMS.put(type, algorithms);
         }
         assertTrue("Duplicate " + type + " " + algorithm,
                 algorithms.add(algorithm.toUpperCase(Locale.ROOT)));
     }
     private static void unprovide(String type, String algorithm) {
-        Set<String> algorithms = PROVIDER_ALGORITHMS.get(type);
+        HashSet<String> algorithms = PROVIDER_ALGORITHMS.get(type);
         assertNotNull(algorithms);
         assertTrue(algorithm, algorithms.remove(algorithm.toUpperCase(Locale.ROOT)));
         if (algorithms.isEmpty()) {
@@ -120,7 +124,7 @@ public final class StandardNames extends Assert {
         }
     }
     private static void provideCipherModes(String algorithm, String newModes[]) {
-        Set<String> modes = CIPHER_MODES.get(algorithm);
+        HashSet<String> modes = CIPHER_MODES.get(algorithm);
         if (modes == null) {
             modes = new HashSet<String>();
             CIPHER_MODES.put(algorithm, modes);
@@ -128,7 +132,7 @@ public final class StandardNames extends Assert {
         modes.addAll(Arrays.asList(newModes));
     }
     private static void provideCipherPaddings(String algorithm, String newPaddings[]) {
-        Set<String> paddings = CIPHER_PADDINGS.get(algorithm);
+        HashSet<String> paddings = CIPHER_PADDINGS.get(algorithm);
         if (paddings == null) {
             paddings = new HashSet<String>();
             CIPHER_PADDINGS.put(algorithm, paddings);
@@ -970,8 +974,8 @@ public final class StandardNames extends Assert {
         assertTrue(cipherSuites.length != 0);
 
         // Make sure all cipherSuites names are expected
-        Set remainingCipherSuites = new HashSet<String>(expected);
-        Set unknownCipherSuites = new HashSet<String>();
+        HashSet<String> remainingCipherSuites = new HashSet<String>(expected);
+        HashSet<String> unknownCipherSuites = new HashSet<String>();
         for (String cipherSuite : cipherSuites) {
             boolean removed = remainingCipherSuites.remove(cipherSuite);
             if (!removed) {
@@ -1005,8 +1009,8 @@ public final class StandardNames extends Assert {
         assertTrue(protocols.length != 0);
 
         // Make sure all protocols names are expected
-        Set remainingProtocols = new HashSet<String>(expected);
-        Set unknownProtocols = new HashSet<String>();
+        HashSet<String> remainingProtocols = new HashSet<String>(expected);
+        HashSet<String> unknownProtocols = new HashSet<String>();
         for (String protocol : protocols) {
             if (!remainingProtocols.remove(protocol)) {
                 unknownProtocols.add(protocol);

--- a/openjdk/src/test/java/libcore/java/security/TestKeyStore.java
+++ b/openjdk/src/test/java/libcore/java/security/TestKeyStore.java
@@ -16,6 +16,8 @@
 
 package libcore.java.security;
 
+import static org.junit.Assert.assertEquals;
+
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.CRLReason;
@@ -78,7 +80,6 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.security.auth.x500.X500Principal;
-import junit.framework.Assert;
 import libcore.javax.net.ssl.TestKeyManager;
 import libcore.javax.net.ssl.TestTrustManager;
 
@@ -89,7 +90,7 @@ import libcore.javax.net.ssl.TestTrustManager;
  * Creating a key store is relatively slow, so a singleton instance is
  * accessible via TestKeyStore.get().
  */
-public final class TestKeyStore extends Assert {
+public final class TestKeyStore {
     /** Size of DSA keys to generate for testing. */
     private static final int DSA_KEY_SIZE_BITS = 1024;
 
@@ -156,7 +157,6 @@ public final class TestKeyStore extends Assert {
         }
     }
 
-    private static final boolean TEST_MANAGERS = true;
     private static final byte[] LOCAL_HOST_ADDRESS = {127, 0, 0, 1};
     private static final String LOCAL_HOST_NAME = "localhost";
 

--- a/openjdk/src/test/java/org/conscrypt/DuckTypedPSKKeyManagerTest.java
+++ b/openjdk/src/test/java/org/conscrypt/DuckTypedPSKKeyManagerTest.java
@@ -57,6 +57,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     public void testDuckTypingFailsWhenOneMethodMissing() throws Exception {
         try {
             DuckTypedPSKKeyManager.getInstance(new AlmostPSKKeyManager());
@@ -64,8 +65,8 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         } catch (NoSuchMethodException expected) {}
     }
 
-    public void testDuckTypingFailsWhenOneMethodReturnTypeIncompatible()
-            throws Exception {
+    @SuppressWarnings("deprecation")
+    public void testDuckTypingFailsWhenOneMethodReturnTypeIncompatible() throws Exception {
         try {
             assertNotNull(DuckTypedPSKKeyManager.getInstance(
                     new KeyManagerOfferingAllPSKKeyManagerMethodsWithIncompatibleReturnTypes()));
@@ -73,11 +74,13 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         } catch (NoSuchMethodException expected) {}
     }
 
+    @SuppressWarnings("deprecation")
     public void testDuckTypingSucceedsWhenAllMethodsPresentWithExactReturnTypes() throws Exception {
         assertNotNull(DuckTypedPSKKeyManager.getInstance(
                 new KeyManagerOfferingAllPSKKeyManagerMethodsWithExactReturnTypes()));
     }
 
+    @SuppressWarnings("deprecation")
     public void testDuckTypingSucceedsWhenAllMethodsPresentWithDifferentButCompatibleReturnTypes()
             throws Exception {
         assertNotNull(DuckTypedPSKKeyManager.getInstance(
@@ -91,10 +94,11 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         // Proxy are returned to us.
 
         MockInvocationHandler mockInvocationHandler = new MockInvocationHandler();
+        @SuppressWarnings("deprecation")
         PSKKeyManager delegate = (PSKKeyManager) Proxy.newProxyInstance(
-                DuckTypedPSKKeyManager.class.getClassLoader(),
-                new Class[] {PSKKeyManager.class},
+                DuckTypedPSKKeyManager.class.getClassLoader(), new Class<?>[] {PSKKeyManager.class},
                 mockInvocationHandler);
+        @SuppressWarnings("deprecation")
         PSKKeyManager pskKeyManager = DuckTypedPSKKeyManager.getInstance(delegate);
         String identityHint = "hint";
         String identity = "identity";
@@ -103,7 +107,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         assertSame(identityHint, pskKeyManager.chooseServerKeyIdentityHint(mSSLSocket));
         assertEquals("chooseServerKeyIdentityHint",
                 mockInvocationHandler.lastInvokedMethod.getName());
-        assertEquals(Arrays.asList(new Class[] {Socket.class}),
+        assertEquals(Arrays.asList(new Class<?>[] {Socket.class}),
                 Arrays.asList(mockInvocationHandler.lastInvokedMethod.getParameterTypes()));
         assertEquals(1, mockInvocationHandler.lastInvokedMethodArgs.length);
         assertSame(mSSLSocket, mockInvocationHandler.lastInvokedMethodArgs[0]);
@@ -112,7 +116,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         assertSame(identityHint, pskKeyManager.chooseServerKeyIdentityHint(mSSLEngine));
         assertEquals("chooseServerKeyIdentityHint",
                 mockInvocationHandler.lastInvokedMethod.getName());
-        assertEquals(Arrays.asList(new Class[] {SSLEngine.class}),
+        assertEquals(Arrays.asList(new Class<?>[] {SSLEngine.class}),
                 Arrays.asList(mockInvocationHandler.lastInvokedMethod.getParameterTypes()));
         assertEquals(1, mockInvocationHandler.lastInvokedMethodArgs.length);
         assertSame(mSSLEngine, mockInvocationHandler.lastInvokedMethodArgs[0]);
@@ -120,7 +124,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         mockInvocationHandler.returnValue = identity;
         assertSame(identity, pskKeyManager.chooseClientKeyIdentity(identityHint, mSSLSocket));
         assertEquals("chooseClientKeyIdentity", mockInvocationHandler.lastInvokedMethod.getName());
-        assertEquals(Arrays.asList(new Class[] {String.class, Socket.class}),
+        assertEquals(Arrays.asList(new Class<?>[] {String.class, Socket.class}),
                 Arrays.asList(mockInvocationHandler.lastInvokedMethod.getParameterTypes()));
         assertEquals(2, mockInvocationHandler.lastInvokedMethodArgs.length);
         assertSame(identityHint, mockInvocationHandler.lastInvokedMethodArgs[0]);
@@ -129,7 +133,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         mockInvocationHandler.returnValue = identity;
         assertSame(identity, pskKeyManager.chooseClientKeyIdentity(identityHint, mSSLEngine));
         assertEquals("chooseClientKeyIdentity", mockInvocationHandler.lastInvokedMethod.getName());
-        assertEquals(Arrays.asList(new Class[] {String.class, SSLEngine.class}),
+        assertEquals(Arrays.asList(new Class<?>[] {String.class, SSLEngine.class}),
                 Arrays.asList(mockInvocationHandler.lastInvokedMethod.getParameterTypes()));
         assertEquals(2, mockInvocationHandler.lastInvokedMethodArgs.length);
         assertSame(identityHint, mockInvocationHandler.lastInvokedMethodArgs[0]);
@@ -139,7 +143,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         mockInvocationHandler.returnValue = key;
         assertSame(key, pskKeyManager.getKey(identityHint, identity, mSSLSocket));
         assertEquals("getKey", mockInvocationHandler.lastInvokedMethod.getName());
-        assertEquals(Arrays.asList(new Class[] {String.class, String.class, Socket.class}),
+        assertEquals(Arrays.asList(new Class<?>[] {String.class, String.class, Socket.class}),
                 Arrays.asList(mockInvocationHandler.lastInvokedMethod.getParameterTypes()));
         assertEquals(3, mockInvocationHandler.lastInvokedMethodArgs.length);
         assertSame(identityHint, mockInvocationHandler.lastInvokedMethodArgs[0]);
@@ -149,7 +153,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         mockInvocationHandler.returnValue = key;
         assertSame(key, pskKeyManager.getKey(identityHint, identity, mSSLEngine));
         assertEquals("getKey", mockInvocationHandler.lastInvokedMethod.getName());
-        assertEquals(Arrays.asList(new Class[] {String.class, String.class, SSLEngine.class}),
+        assertEquals(Arrays.asList(new Class<?>[] {String.class, String.class, SSLEngine.class}),
                 Arrays.asList(mockInvocationHandler.lastInvokedMethod.getParameterTypes()));
         assertEquals(3, mockInvocationHandler.lastInvokedMethodArgs.length);
         assertSame(identityHint, mockInvocationHandler.lastInvokedMethodArgs[0]);
@@ -161,6 +165,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
             throws Exception {
         // Check that nothing blows up when we invoke getKey which is declared to return
         // SecretKeySpec rather than SecretKey as declared in the PSKKeyManager interface.
+        @SuppressWarnings("deprecation")
         PSKKeyManager pskKeyManager = DuckTypedPSKKeyManager.getInstance(
                 new KeyManagerOfferingAllPSKKeyManagerMethodsWithCompatibleReturnTypes());
         pskKeyManager.getKey(null, "", mSSLSocket);

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -1378,6 +1378,7 @@ public class NativeCryptoTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_SSL_do_handshake_with_psk_with_identity_and_hint_of_max_length()
             throws Exception {
         // normal TLS-PSK client and server case where the server provides the client with a PSK
@@ -1477,6 +1478,7 @@ public class NativeCryptoTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_SSL_do_handshake_with_psk_key_too_long() throws Exception {
         final ServerSocket listener = new ServerSocket(0);
         ClientHooks cHooks = new ClientHooks() {
@@ -1582,6 +1584,7 @@ public class NativeCryptoTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void test_SSL_use_psk_identity_hint() throws Exception {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c);


### PR DESCRIPTION
This reduces the number of Java lint warnings down to just the
[serialization] class of warnings as well as the Sun proprietary
warnings for the OpenJDK implementation.

These changes do not result in any change of behavior, but the
serialization changes might. Those will be fixed in a separate CL.