### PR TITLE
Share JVM buffers with native SSL functions.

### DIFF
--- a/common/src/jni/unbundled/include/ScopedPrimitiveArray.h
+++ b/common/src/jni/unbundled/include/ScopedPrimitiveArray.h
@@ -141,4 +141,74 @@ INSTANTIATE_SCOPED_PRIMITIVE_ARRAY_RW(jshort, Short);
 
 #undef INSTANTIATE_SCOPED_PRIMITIVE_ARRAY_RW
 
+class ScopedCriticalByteArrayRO {
+public:
+    ScopedCriticalByteArrayRO(JNIEnv* env, jbyteArray java_array, jint size)
+        : env_(env), java_array_(java_array), size_(size) {
+        if (java_array_ == nullptr) {
+            conscrypt::Errors::jniThrowNullPointerException(env_, nullptr);
+        } else {
+            raw_array_ = static_cast<char*>(env_->GetPrimitiveArrayCritical(java_array_, nullptr));
+            if (raw_array_ == nullptr) {
+                conscrypt::Errors::jniThrowNullPointerException(env_, nullptr);
+            }
+        }
+    }
+
+    ~ScopedCriticalByteArrayRO() {
+        env_->ReleasePrimitiveArrayCritical(java_array_, static_cast<void*>(raw_array_), JNI_ABORT);
+    }
+
+    const char* get() const {
+        return raw_array_;
+    }
+
+    size_t size() const {
+        return size_;
+    }
+
+private:
+    JNIEnv* env_;
+    jbyteArray java_array_;
+    char* raw_array_;
+    size_t size_;
+};
+
+class ScopedCriticalByteArrayRW {
+public:
+    ScopedCriticalByteArrayRW(JNIEnv* env, jbyteArray java_array, jint size)
+        : env_(env), java_array_(java_array), size_(size) {
+        if (java_array_ == nullptr) {
+            conscrypt::Errors::jniThrowNullPointerException(env_, nullptr);
+        } else {
+            raw_array_ = static_cast<char*>(env_->GetPrimitiveArrayCritical(java_array_, nullptr));
+            if (raw_array_ == nullptr) {
+                conscrypt::Errors::jniThrowNullPointerException(env_, nullptr);
+            }
+        }
+    }
+
+    ~ScopedCriticalByteArrayRW() {
+        env_->ReleasePrimitiveArrayCritical(java_array_, static_cast<void*>(raw_array_), JNI_ABORT);
+    }
+
+    const char* get() const {
+        return raw_array_;
+    }
+
+    char* get() {
+        return raw_array_;
+    }
+
+    size_t size() const {
+        return size_;
+    }
+
+private:
+    JNIEnv* env_;
+    jbyteArray java_array_;
+    char* raw_array_;
+    size_t size_;
+};
+
 #endif  // SCOPED_PRIMITIVE_ARRAY_H_included


### PR DESCRIPTION
The NativeCrypto SSL_read and SSL_write functions currently call GetByteArrayElements and ReleaseByteArrayElements. According to the JNI spec, This may result in a copy when data is transferred from the JVM to native code and an additional copy if changes to the data need to be written back to the JVM. On all machines I tested, this results in copies (in both directions, when changes need to be committed).

This change uses GetPrimitiveArrayCritical and ReleasePrimitiveArrayCritical, eliminating copies even when the JVM implementation does not support pinning. It also introduces ScopedCriticalByteArrayRO and ScopedCriticalByteArrayRW helper classes which support memory access and release via RAII. They should only be used within critical sections where no other JNI functions are called and no syscalls block on the completion of other JNI calls. See http://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetPrimitiveArrayCritical_ReleasePrimitiveArrayCritical for further details.