### PR TITLE
Specifying JMH dependencies for latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,10 @@ subprojects {
 
                 // Benchmark dependencies
                 jmh_core: "org.openjdk.jmh:jmh-core:${jmhVersion}",
+                jmh_generator_annprocess: "org.openjdk.jmh:jmh-generator-annprocess:${jmhVersion}",
+                jmh_generator_asm: "org.openjdk.jmh:jmh-generator-asm:${jmhVersion}",
+                jmh_generator_bytecode: "org.openjdk.jmh:jmh-generator-bytecode:${jmhVersion}",
+                jmh_generator_reflection: "org.openjdk.jmh:jmh-generator-reflection:${jmhVersion}",
                 netty_handler: 'io.netty:netty-handler:4.1.8.Final',
                 netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:1.1.33.Fork26',
         ]

--- a/openjdk-benchmarks/build.gradle
+++ b/openjdk-benchmarks/build.gradle
@@ -21,6 +21,10 @@ jmh {
     duplicateClassesStrategy = 'warn'
 }
 
+configurations {
+    jmhGenerators
+}
+
 dependencies {
     compile project(path: ':conscrypt-openjdk', configuration: "$openJdkConfiguration"),
             project(':conscrypt-openjdk-testing'),
@@ -29,8 +33,9 @@ dependencies {
             libraries.netty_handler,
             libraries.netty_tcnative
 
-    jmh libraries.jmh_core,
-            libraries.jmh_generator_asm, 
+    jmh libraries.jmh_core
+
+    jmhGenerators libraries.jmh_generator_asm,
             libraries.jmh_generator_bytecode,
             libraries.jmh_generator_reflection,
             libraries.jmh_generator_annprocess
@@ -39,7 +44,7 @@ dependencies {
 // Running benchmarks in IntelliJ seems broken without this.
 // See https://github.com/melix/jmh-gradle-plugin/issues/39
 idea.module {
-    scopes.PROVIDED.plus += [ configurations.jmh ]
+    scopes.PROVIDED.plus += [ configurations.jmh, configurations.jmhGenerators ]
 }
 
 static classifierFor(osName, archName) {

--- a/openjdk-benchmarks/build.gradle
+++ b/openjdk-benchmarks/build.gradle
@@ -29,7 +29,11 @@ dependencies {
             libraries.netty_handler,
             libraries.netty_tcnative
 
-    jmh libraries.jmh_core
+    jmh libraries.jmh_core,
+            libraries.jmh_generator_asm, 
+            libraries.jmh_generator_bytecode,
+            libraries.jmh_generator_reflection,
+            libraries.jmh_generator_annprocess
 }
 
 // Running benchmarks in IntelliJ seems broken without this.


### PR DESCRIPTION
This seems to be needed for running in IntelliJ, which is really handy.  I recall that the JMH configuration was a bit touchy so we may need to try this out on a few platforms to make sure it doesn't break anything.