### PR TITLE
Minimize buffer copy penalty in SSL read/write.

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -7367,6 +7367,9 @@ static jint NativeCrypto_SSL_read(JNIEnv* env, jclass, jlong ssl_address, jobjec
                 // TODO: Make sure it's safe to reuse same callbacks repeatedly.
                 temp_ret = sslRead(env, ssl, fdObject, shc, reinterpret_cast<char*>(buf.get()),
                                    chunk_size, sslError, read_timeout_millis);
+                if (temp_ret == THROWN_EXCEPTION && ret > 0) {
+                    return ret;
+                }
                 if (temp_ret == THROW_SSLEXCEPTION || temp_ret == THROW_SOCKETTIMEOUTEXCEPTION ||
                     temp_ret == THROWN_EXCEPTION) {
                     // An error was encountered. Handle below.

--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -7367,17 +7367,22 @@ static jint NativeCrypto_SSL_read(JNIEnv* env, jclass, jlong ssl_address, jobjec
                 // TODO: Make sure it's safe to reuse same callbacks repeatedly.
                 temp_ret = sslRead(env, ssl, fdObject, shc, reinterpret_cast<char*>(buf.get()),
                                    chunk_size, sslError, read_timeout_millis);
-                if (temp_ret == THROWN_EXCEPTION && ret > 0) {
+                if ((temp_ret == THROWN_EXCEPTION || temp_ret == -1) && ret > 0) {
+                    // TODO: Should we only check for -1 above?
                     return ret;
                 }
-                if (temp_ret == THROW_SSLEXCEPTION || temp_ret == THROW_SOCKETTIMEOUTEXCEPTION ||
-                    temp_ret == THROWN_EXCEPTION) {
+                if (temp_ret < 0) {
                     // An error was encountered. Handle below.
-                    // TODO: Is it sufficient to check for negative values?
+                    // TODO: Apparently we need to check for all negative values to cover all error
+                    // cases. Is this correct?
                     ret = temp_ret;
                     break;
                 }
                 env->SetByteArrayRegion(b, offset, temp_ret, buf.get());
+                if (env->ExceptionCheck()) {
+                    // Error committing changes to JVM.
+                    return -1;
+                }
                 // Accumulate bytes read.
                 ret += temp_ret;
                 offset += temp_ret;

--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -7294,7 +7294,7 @@ static int sslRead(JNIEnv* env, SSL* ssl, jobject fdObject, jobject shc, char* b
 
 /**
  * OpenSSL read function (2): read into buffer at offset n chunks.
- * Returns 1 (success) or value <= 0 (failure).
+ * Returns the number of bytes read (success) or value <= 0 (failure).
  */
 static jint NativeCrypto_SSL_read(JNIEnv* env, jclass, jlong ssl_address, jobject fdObject,
                                   jobject shc, jbyteArray b, jint offset, jint len,
@@ -7316,16 +7316,82 @@ static jint NativeCrypto_SSL_read(JNIEnv* env, jclass, jlong ssl_address, jobjec
         JNI_TRACE("ssl=%p NativeCrypto_SSL_read => sslHandshakeCallbacks == null", ssl);
         return 0;
     }
+    if (b == nullptr) {
+        Errors::jniThrowNullPointerException(env, "b == null");
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_read => b == null", ssl);
+        return 0;
+    }
 
-    ScopedByteArrayRW bytes(env, b);
-    if (bytes.get() == nullptr) {
-        JNI_TRACE("ssl=%p NativeCrypto_SSL_read => threw exception", ssl);
+    size_t array_size = static_cast<size_t>(env->GetArrayLength(b));
+    if (ARRAY_CHUNK_INVALID(array_size, offset, len)) {
+        Errors::jniThrowException(env, "java/lang/ArrayIndexOutOfBoundsException", "b");
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_read => ArrayIndexOutOfBoundsException", ssl);
         return 0;
     }
 
     OpenSslError sslError;
-    int ret = sslRead(env, ssl, fdObject, shc, reinterpret_cast<char*>(bytes.get() + offset), len,
+    int ret;
+    if (JniUtil::isGetByteArrayElementsLikelyToReturnACopy(array_size)) {
+        if (len <= 1024) {
+            // Allocate small buffers on the stack for performance.
+            jbyte buf[1024];
+            ret = sslRead(env, ssl, fdObject, shc, reinterpret_cast<char*>(&buf[0]), len, sslError,
+                          read_timeout_millis);
+            if (ret > 0) {
+                // Don't bother applying changes if issues were encountered.
+                env->SetByteArrayRegion(b, offset, ret, &buf[0]);
+            }
+        } else {
+            // Allocate larger buffers on the heap.
+            // TODO: Enforce that len >= 0? If not, the cast below could result in a memory
+            // allocation error/attack.
+            jint remaining = len;
+            jint buf_size = (remaining >= 65536) ? 65536 : remaining;
+            std::unique_ptr<jbyte[]> buf(new jbyte[static_cast<unsigned int>(buf_size)]);
+            // TODO: Doesn't the following condition require new(std::nothrow)?
+            if (buf.get() == nullptr) {
+                Errors::jniThrowOutOfMemory(env, "Unable to allocate chunk buffer");
+                return 0;
+            }
+            jint expected_reads = len / buf_size;
+            if (expected_reads > 0) {
+                // TODO: Fix cumulative read timeout? This currently ensures that the cumulative
+                // timeout does not exceed the given timeout, but it is overly strict in that it
+                // allocates uniformly-sized time slots for each call.
+                read_timeout_millis = read_timeout_millis / expected_reads;
+            }
+            ret = 0;
+            while (remaining > 0) {
+                jint temp_ret;
+                jint chunk_size = (remaining >= buf_size) ? buf_size : remaining;
+                // TODO: Make sure it's safe to reuse same callbacks repeatedly.
+                temp_ret = sslRead(env, ssl, fdObject, shc, reinterpret_cast<char*>(buf.get()),
+                                   chunk_size, sslError, read_timeout_millis);
+                if (temp_ret == THROW_SSLEXCEPTION || temp_ret == THROW_SOCKETTIMEOUTEXCEPTION ||
+                    temp_ret == THROWN_EXCEPTION) {
+                    // An error was encountered. Handle below.
+                    // TODO: Is it sufficient to check for negative (or even non-positive) values? 0
+                    // itself appears to be an error code.
+                    ret = temp_ret;
+                    break;
+                }
+                env->SetByteArrayRegion(b, offset, temp_ret, buf.get());
+                // Accumulate bytes read.
+                ret += temp_ret;
+                offset += chunk_size;
+                remaining -= chunk_size;
+            }
+        }
+    } else {
+        ScopedByteArrayRW bytes(env, b);
+        if (bytes.get() == nullptr) {
+            JNI_TRACE("ssl=%p NativeCrypto_SSL_read => threw exception", ssl);
+            return 0;
+        }
+
+        ret = sslRead(env, ssl, fdObject, shc, reinterpret_cast<char*>(bytes.get() + offset), len,
                       sslError, read_timeout_millis);
+    }
 
     int result;
     switch (ret) {
@@ -7517,15 +7583,59 @@ static void NativeCrypto_SSL_write(JNIEnv* env, jclass, jlong ssl_address, jobje
         JNI_TRACE("ssl=%p NativeCrypto_SSL_write => sslHandshakeCallbacks == null", ssl);
         return;
     }
-
-    ScopedByteArrayRO bytes(env, b);
-    if (bytes.get() == nullptr) {
-        JNI_TRACE("ssl=%p NativeCrypto_SSL_write => threw exception", ssl);
+    if (b == nullptr) {
+        Errors::jniThrowNullPointerException(env, "b == null");
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_write => b == null", ssl);
         return;
     }
+
+    size_t array_size = static_cast<size_t>(env->GetArrayLength(b));
+    if (ARRAY_CHUNK_INVALID(array_size, offset, len)) {
+        Errors::jniThrowException(env, "java/lang/ArrayIndexOutOfBoundsException", "b");
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_write => ArrayIndexOutOfBoundsException", ssl);
+        return;
+    }
+
     OpenSslError sslError;
-    int ret = sslWrite(env, ssl, fdObject, shc, reinterpret_cast<const char*>(bytes.get() + offset),
+    int ret;
+    if (JniUtil::isGetByteArrayElementsLikelyToReturnACopy(array_size)) {
+        if (len <= 1024) {
+            jbyte buf[1024];
+            env->GetByteArrayRegion(b, offset, len, buf);
+            ret = sslWrite(env, ssl, fdObject, shc, reinterpret_cast<const char*>(&buf[0]), len,
+                           sslError, write_timeout_millis);
+        } else {
+            // TODO: Similar safety concerns and questions here as in SSL_read.
+            jint remaining = len;
+            jint buf_size = (remaining >= 65536) ? 65536 : remaining;
+            std::unique_ptr<jbyte[]> buf(new jbyte[static_cast<unsigned int>(buf_size)]);
+            if (buf.get() == nullptr) {
+                Errors::jniThrowOutOfMemory(env, "Unable to allocate chunk buffer");
+                return;
+            }
+            while (remaining > 0) {
+                jint chunk_size = (remaining >= buf_size) ? buf_size : remaining;
+                env->GetByteArrayRegion(b, offset, chunk_size, buf.get());
+                ret = sslWrite(env, ssl, fdObject, shc, reinterpret_cast<const char*>(buf.get()),
+                               chunk_size, sslError, write_timeout_millis);
+                if (ret == THROW_SSLEXCEPTION || ret == THROW_SOCKETTIMEOUTEXCEPTION ||
+                    ret == THROWN_EXCEPTION) {
+                    // Encountered an error. Terminate early and handle below.
+                    break;
+                }
+                offset += chunk_size;
+                remaining -= chunk_size;
+            }
+        }
+    } else {
+        ScopedByteArrayRO bytes(env, b);
+        if (bytes.get() == nullptr) {
+            JNI_TRACE("ssl=%p NativeCrypto_SSL_write => threw exception", ssl);
+            return;
+        }
+        ret = sslWrite(env, ssl, fdObject, shc, reinterpret_cast<const char*>(bytes.get() + offset),
                        len, sslError, write_timeout_millis);
+    }
 
     switch (ret) {
         case THROW_SSLEXCEPTION:

--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -7379,6 +7379,10 @@ static jint NativeCrypto_SSL_read(JNIEnv* env, jclass, jlong ssl_address, jobjec
                 ret += temp_ret;
                 offset += temp_ret;
                 remaining -= temp_ret;
+                if (temp_ret < chunk_size) {
+                    // sslRead isn't able to fulfill our request right now.
+                    break;
+                }
             }
         }
     } else {

--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -7370,16 +7370,15 @@ static jint NativeCrypto_SSL_read(JNIEnv* env, jclass, jlong ssl_address, jobjec
                 if (temp_ret == THROW_SSLEXCEPTION || temp_ret == THROW_SOCKETTIMEOUTEXCEPTION ||
                     temp_ret == THROWN_EXCEPTION) {
                     // An error was encountered. Handle below.
-                    // TODO: Is it sufficient to check for negative (or even non-positive) values? 0
-                    // itself appears to be an error code.
+                    // TODO: Is it sufficient to check for negative values?
                     ret = temp_ret;
                     break;
                 }
                 env->SetByteArrayRegion(b, offset, temp_ret, buf.get());
                 // Accumulate bytes read.
                 ret += temp_ret;
-                offset += chunk_size;
-                remaining -= chunk_size;
+                offset += temp_ret;
+                remaining -= temp_ret;
             }
         }
     } else {
@@ -7623,8 +7622,8 @@ static void NativeCrypto_SSL_write(JNIEnv* env, jclass, jlong ssl_address, jobje
                     // Encountered an error. Terminate early and handle below.
                     break;
                 }
-                offset += chunk_size;
-                remaining -= chunk_size;
+                offset += ret;
+                remaining -= ret;
             }
         }
     } else {


### PR DESCRIPTION
This change is an attempt to address performance issues in NativeCrypto.SSL_read and SSL_write when large buffer sizes are used.  It attempts to guess whether Get/ReleaseByteArrayElements will result in copies between native code and the JVM. If so, Get/SetByteArrayRegion is used instead, operating on small chunks of the target buffer and ensuring that at most one copy per region crosses the JNI boundary.

This uses the same strategy as the cipher streaming code here: https://github.com/google/conscrypt/blob/196ca9aad6223e2962e1330cff9e885c569c20ca/common/src/jni/main/cpp/NativeCrypto.cpp#L2410.

See https://github.com/google/conscrypt/pull/89 for additional context.