### PR TITLE
Only attempt to build .cpp JNI files

### DIFF
--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -111,9 +111,8 @@ model {
             sources {
                 cpp {
                     source {
-                        srcDirs = [
-                                "$jniSourceDir/main/cpp"
-                        ]
+                        srcDirs "$jniSourceDir/main/cpp"
+                        include "**/*.cpp"
                     }
                 }
             }


### PR DESCRIPTION
This prevents compilation errors when, e.g., editor swap files appear in the JNI source directory. Without the filter, gradle attempts to build _everything_ under `srcDirs`.