### PR TITLE
Fix mistake in Windows building instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -78,7 +78,7 @@ installation.
 
 To build in 64-bit mode, set up with this command line:
 
-```dos
+```bat
 call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64 8.1
 mkdir build64
 cd build64
@@ -86,7 +86,7 @@ cd build64
 
 To build in 32-bit mode, set up with this command line:
 
-```dos
+```bat
 call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86 8.1
 mkdir build32
 cd build32
@@ -94,7 +94,7 @@ cd build32
 
 In either the 64-bit or 32-bit case, run this afterward:
 
-```dos
+```bat
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DCMAKE_C_FLAGS_RELEASE=/MT ^

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -71,14 +71,15 @@ ninja
 ```
 
 ##### Building on Windows
-This assumes that you have Microsoft Visual Studio 2015 in `MSVCDIR` and are
-running on a 64-bit machine. Currently Conscrypt is compiled against the
-Windows 8.1 SDK.
+This assumes that you have Microsoft Visual Studio 2015 installed along
+with Windows 8.1 SDK and your machine is capable of compiling 64-bit.
+Visual Studio 2015 sets the `VS140COMNTOOLS` environment variable upon
+installation.
 
 To build in 64-bit mode, set up with this command line:
 
 ```bash
-call %MSCVDIR%\vc\vcvarsall.bat amd64 8.1
+call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64 8.1
 mkdir build64
 cd build64
 ```
@@ -86,7 +87,7 @@ cd build64
 To build in 32-bit mode, set up with this command line:
 
 ```bash
-call %MSCVDIR%\vc\vcvarsall.bat x86 8.1
+call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86 8.1
 mkdir build32
 cd build32
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -78,7 +78,7 @@ installation.
 
 To build in 64-bit mode, set up with this command line:
 
-```bash
+```dos
 call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" amd64 8.1
 mkdir build64
 cd build64
@@ -86,7 +86,7 @@ cd build64
 
 To build in 32-bit mode, set up with this command line:
 
-```bash
+```dos
 call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86 8.1
 mkdir build32
 cd build32
@@ -94,11 +94,11 @@ cd build32
 
 In either the 64-bit or 32-bit case, run this afterward:
 
-```bash
-cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_C_FLAGS_RELEASE=/MT \
-      -DCMAKE_CXX_FLAGS_RELEASE=/MT \
+```dos
+cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DCMAKE_C_FLAGS_RELEASE=/MT ^
+      -DCMAKE_CXX_FLAGS_RELEASE=/MT ^
       -GNinja ..
 ninja
 ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -72,10 +72,13 @@ ninja
 
 ##### Building on Windows
 This assumes that you have Microsoft Visual Studio 2015 in `MSVCDIR` and are
-running on a 64-bit machine. Set up with this command line:
+running on a 64-bit machine. Currently Conscrypt is compiled against the
+Windows 8.1 SDK.
+
+To build in 64-bit mode, set up with this command line:
 
 ```bash
-call %MSCVDIR%\vc\vcvarsall.bat x64
+call %MSCVDIR%\vc\vcvarsall.bat amd64 8.1
 mkdir build64
 cd build64
 ```
@@ -83,7 +86,7 @@ cd build64
 To build in 32-bit mode, set up with this command line:
 
 ```bash
-call %MSCVDIR%\vc\vcvarsall.bat x64
+call %MSCVDIR%\vc\vcvarsall.bat x86 8.1
 mkdir build32
 cd build32
 ```


### PR DESCRIPTION
Also specify that we currently use Windows SDK 8.1.