### PR TITLE
Add javadoc JARs to distribution.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ subprojects {
         }
 
         artifacts {
-            archives sourcesJar
+            archives sourcesJar, javadocJar
         }
 
         uploadArchives.repositories.mavenDeployer {


### PR DESCRIPTION
This is required when releasing to Maven Central.