### PR TITLE
Only build .cpp files under constants/

### DIFF
--- a/constants/build.gradle
+++ b/constants/build.gradle
@@ -36,6 +36,7 @@ model {
                     // Sources assumed to be in src/gen/cpp by default.
                     exportedHeaders {
                         srcDirs "${boringsslIncludeDir}"
+                        include "**/*.cpp"
                     }
                 }
             }


### PR DESCRIPTION
This prevents compilation errors due to non-source files under `srcDirs`.