### PR TITLE
Less restrictive output buffer size in wrap()

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.conscrypt;
 
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.FINISHED;
@@ -35,6 +51,7 @@ import static org.conscrypt.NativeConstants.SSL_ERROR_WANT_WRITE;
 import static org.conscrypt.NativeConstants.SSL_ERROR_ZERO_RETURN;
 import static org.conscrypt.NativeConstants.SSL_RECEIVED_SHUTDOWN;
 import static org.conscrypt.NativeConstants.SSL_SENT_SHUTDOWN;
+import static org.conscrypt.SSLUtils.calculateOutNetBufSize;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -934,14 +951,10 @@ public final class OpenSSLEngineImpl extends SSLEngine
             throws SSLException {
         checkNotNull(srcs, "srcs");
         checkNotNull(dst, "dst");
+        checkIndex(srcs.length, offset, length, "srcs");
         if (dst.isReadOnly()) {
             throw new ReadOnlyBufferException();
         }
-        final int endOffset = offset + length;
-        for (int i = offset; i < endOffset; ++i) {
-            checkNotNull(srcs[i], "one of the src");
-        }
-        checkIndex(srcs.length, offset, length, "srcs");
 
         synchronized (stateLock) {
             switch (engineState) {
@@ -972,7 +985,27 @@ public final class OpenSSLEngineImpl extends SSLEngine
                 // NEED_WRAP - just fall through to perform the wrap.
             }
 
-            if (dst.remaining() < SSL3_RT_MAX_PACKET_SIZE) {
+            int srcsLen = 0;
+            final int endOffset = offset + length;
+            for (int i = offset; i < endOffset; ++i) {
+                final ByteBuffer src = srcs[i];
+                if (src == null) {
+                    throw new IllegalArgumentException("srcs[" + i + "] is null");
+                }
+                if (srcsLen == SSL3_RT_MAX_PLAIN_LENGTH) {
+                    continue;
+                }
+
+                srcsLen += src.remaining();
+                if (srcsLen > SSL3_RT_MAX_PLAIN_LENGTH || srcsLen < 0) {
+                    // If srcLen > MAX_PLAINTEXT_LENGTH or secLen < 0 just set it to MAX_PLAINTEXT_LENGTH.
+                    // This also help us to guard against overflow.
+                    // We not break out here as we still need to check for null entries in srcs[].
+                    srcsLen = SSL3_RT_MAX_PLAIN_LENGTH;
+                }
+            }
+
+            if (dst.remaining() < calculateOutNetBufSize(srcsLen)) {
                 return new SSLEngineResult(
                         Status.BUFFER_OVERFLOW, getHandshakeStatusInternal(), 0, 0);
             }

--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -32,11 +32,13 @@
 
 package org.conscrypt;
 
+import static java.lang.Math.min;
 import static org.conscrypt.NativeConstants.SSL3_RT_ALERT;
 import static org.conscrypt.NativeConstants.SSL3_RT_APPLICATION_DATA;
 import static org.conscrypt.NativeConstants.SSL3_RT_CHANGE_CIPHER_SPEC;
 import static org.conscrypt.NativeConstants.SSL3_RT_HANDSHAKE;
 import static org.conscrypt.NativeConstants.SSL3_RT_HEADER_LENGTH;
+import static org.conscrypt.NativeConstants.SSL3_RT_MAX_PLAIN_LENGTH;
 
 import java.nio.ByteBuffer;
 
@@ -46,6 +48,38 @@ import java.nio.ByteBuffer;
 final class SSLUtils {
     static final boolean USE_ENGINE_SOCKET_BY_DEFAULT =
             Boolean.parseBoolean(System.getProperty("org.conscrypt.useEngineSocketByDefault"));
+
+    /**
+     * This is the maximum overhead when encrypting plaintext as defined by
+     * <a href="https://www.ietf.org/rfc/rfc5246.txt">rfc5264</a>,
+     * <a href="https://www.ietf.org/rfc/rfc5289.txt">rfc5289</a> and openssl implementation itself.
+     *
+     * Please note that we use a padding of 16 here as openssl uses PKC#5 which uses 16 bytes
+     * whilethe spec itself allow up to 255 bytes. 16 bytes is the max for PKC#5 (which handles it
+     * the same way as PKC#7) as we use a block size of 16. See <a
+     * href="https://tools.ietf.org/html/rfc5652#section-6.3">rfc5652#section-6.3</a>.
+     *
+     * 16 (IV) + 48 (MAC) + 1 (Padding_length field) + 15 (Padding) + 1 (ContentType) + 2
+     * (ProtocolVersion) + 2 (Length)
+     *
+     * TODO: We may need to review this calculation once TLS 1.3 becomes available.
+     */
+    private static final int MAX_ENCRYPTION_OVERHEAD_LENGTH = 15 + 48 + 1 + 16 + 1 + 2 + 2;
+
+    private static final int MAX_ENCRYPTED_PACKET_LENGTH =
+            SSL3_RT_MAX_PLAIN_LENGTH + MAX_ENCRYPTION_OVERHEAD_LENGTH;
+
+    private static final int MAX_ENCRYPTION_OVERHEAD_DIFF =
+            Integer.MAX_VALUE - MAX_ENCRYPTION_OVERHEAD_LENGTH;
+
+    /**
+     * Calculates the minimum bytes required in the encrypted output buffer for the given number of
+     * plaintext source bytes.
+     */
+    static int calculateOutNetBufSize(int pendingBytes) {
+        return min(MAX_ENCRYPTED_PACKET_LENGTH,
+                MAX_ENCRYPTION_OVERHEAD_LENGTH + min(MAX_ENCRYPTION_OVERHEAD_DIFF, pendingBytes));
+    }
 
     /**
      * Return how much bytes can be read out of the encrypted data. Be aware that this method will

--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -38,7 +38,7 @@ import static org.conscrypt.NativeConstants.SSL3_RT_APPLICATION_DATA;
 import static org.conscrypt.NativeConstants.SSL3_RT_CHANGE_CIPHER_SPEC;
 import static org.conscrypt.NativeConstants.SSL3_RT_HANDSHAKE;
 import static org.conscrypt.NativeConstants.SSL3_RT_HEADER_LENGTH;
-import static org.conscrypt.NativeConstants.SSL3_RT_MAX_PLAIN_LENGTH;
+import static org.conscrypt.NativeConstants.SSL3_RT_MAX_PACKET_SIZE;
 
 import java.nio.ByteBuffer;
 
@@ -66,9 +66,6 @@ final class SSLUtils {
      */
     private static final int MAX_ENCRYPTION_OVERHEAD_LENGTH = 15 + 48 + 1 + 16 + 1 + 2 + 2;
 
-    private static final int MAX_ENCRYPTED_PACKET_LENGTH =
-            SSL3_RT_MAX_PLAIN_LENGTH + MAX_ENCRYPTION_OVERHEAD_LENGTH;
-
     private static final int MAX_ENCRYPTION_OVERHEAD_DIFF =
             Integer.MAX_VALUE - MAX_ENCRYPTION_OVERHEAD_LENGTH;
 
@@ -77,7 +74,7 @@ final class SSLUtils {
      * plaintext source bytes.
      */
     static int calculateOutNetBufSize(int pendingBytes) {
-        return min(MAX_ENCRYPTED_PACKET_LENGTH,
+        return min(SSL3_RT_MAX_PACKET_SIZE,
                 MAX_ENCRYPTION_OVERHEAD_LENGTH + min(MAX_ENCRYPTION_OVERHEAD_DIFF, pendingBytes));
     }
 


### PR DESCRIPTION
We currently require that the output buffer be >= MAX_PACKET_SIZE. This is needlessly strict and causes the Netty tests to fail, since they only use 2k buffers.

This PR copies over some of the recent changes from Netty to handle this properly.