### PR TITLE
Implement X509Certificate.verify(PublicKey, Provider).

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -152,7 +152,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := $(common_java_files)
 LOCAL_SRC_FILES += $(call all-java-files-under,android/src/main/java)
 LOCAL_GENERATED_SOURCES := $(conscrypt_gen_java_files)
-LOCAL_SDK_VERSION := 16
+LOCAL_SDK_VERSION := current
 LOCAL_JAVACFLAGS := $(local_javac_flags)
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := conscrypt_unbundled
@@ -164,7 +164,7 @@ include $(BUILD_STATIC_JAVA_LIBRARY)
 # Stub library for unbundled builds
 include $(CLEAR_VARS)
 LOCAL_SRC_FILES := $(call all-java-files-under,android-stub/src/main/java)
-LOCAL_SDK_VERSION := 16
+LOCAL_SDK_VERSION := current
 LOCAL_JAVACFLAGS := $(local_javac_flags)
 LOCAL_MODULE := conscrypt-stubs
 LOCAL_JACK_FLAGS := -D jack.classpath.default-libraries=false

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -24,6 +24,7 @@ import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Principal;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.SignatureException;
@@ -351,8 +352,8 @@ public class OpenSSLX509Certificate extends X509Certificate {
     }
 
     private void verifyOpenSSL(OpenSSLKey pkey) throws CertificateException,
-            NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException,
-            SignatureException {
+                                                       NoSuchAlgorithmException,
+                                                       InvalidKeyException, SignatureException {
         try {
             NativeCrypto.X509_verify(mContext, pkey.getNativeRef());
         } catch (RuntimeException e) {
@@ -388,7 +389,7 @@ public class OpenSSLX509Certificate extends X509Certificate {
             return;
         }
 
-        verifyInternal(key, null);
+        verifyInternal(key, (String) null);
     }
 
     @Override
@@ -396,6 +397,30 @@ public class OpenSSLX509Certificate extends X509Certificate {
             NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException,
             SignatureException {
         verifyInternal(key, sigProvider);
+    }
+
+    @Override
+    public void verify(PublicKey key, Provider sigProvider)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
+                   SignatureException {
+        if (key instanceof OpenSSLKeyHolder && sigProvider instanceof OpenSSLProvider) {
+            OpenSSLKey pkey = ((OpenSSLKeyHolder) key).getOpenSSLKey();
+            verifyOpenSSL(pkey);
+            return;
+        }
+
+        final Signature sig;
+        if (sigProvider == null) {
+            sig = Signature.getInstance(getSigAlgName());
+        } else {
+            sig = Signature.getInstance(getSigAlgName(), sigProvider);
+        }
+
+        sig.initVerify(key);
+        sig.update(getTBSCertificate());
+        if (!sig.verify(getSignature())) {
+            throw new SignatureException("signature did not verify");
+        }
     }
 
     @Override


### PR DESCRIPTION
Removed NoSuchProvider from verifyOpenSSL(OpenSSLKey pkey),
native code underneath doesn't throw it.

Changed unblundled version to current to
fix the breakage due to missing verify method
in earlier API.

(cherry picked from commit f881571464b8b989d000fcd33846ae2a653fb2cf)

Test: CtsLibcoreTestCases
Bug: 31294527
Change-Id: Ide755ccc0ad1163ac8dafc9bce762f680671a488