### PR TITLE
Relax socket timeout for NativeCrypto.SSL_read

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -7322,13 +7322,8 @@ static jint NativeCrypto_SSL_read(JNIEnv* env, jclass, jlong ssl_address, jobjec
                 Errors::jniThrowOutOfMemory(env, "Unable to allocate chunk buffer");
                 return 0;
             }
-            jint expected_reads = len / buf_size;
-            if (expected_reads > 0) {
-                // TODO: Fix cumulative read timeout? This currently ensures that the cumulative
-                // timeout does not exceed the given timeout, but it is overly strict in that it
-                // allocates uniformly-sized time slots for each call.
-                read_timeout_millis = read_timeout_millis / expected_reads;
-            }
+            // TODO: Fix cumulative read timeout? The effective timeout is the multiplied by the
+            // number of internal calls to sslRead() below.
             ret = 0;
             while (remaining > 0) {
                 jint temp_ret;


### PR DESCRIPTION
The timeout logic is overly strict, causing excessive timeouts.

Note that this matches the current behavior of NativeCrypto.SSL_write since I never introduced this change there. Polling semantics are system-dependent anyway, so we don't lose much with this change.