### PR TITLE
Add null check on RSA cipher initialization

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -166,6 +166,10 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
 
     protected void engineInitInternal(int opmode, Key key, AlgorithmParameterSpec spec)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
+        if (null == key) {
+            throw new IllegalArgumentException("Key must not be null");
+        }
+        
         if (opmode == Cipher.ENCRYPT_MODE || opmode == Cipher.WRAP_MODE) {
             encrypting = true;
         } else if (opmode == Cipher.DECRYPT_MODE || opmode == Cipher.UNWRAP_MODE) {


### PR DESCRIPTION
Null check is implicitly done in the instanceof list, but if the key is null then the user of the API is not explicitly told that the key is null.

It could be a cause of some production problems I'm experiencing, and this null check would greatly help.