### PR TITLE
Don't throw away all altnames when a bad one is seen

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -3610,8 +3610,6 @@ static jobject GENERAL_NAME_to_jobject(JNIEnv* env, GENERAL_NAME* gen) {
             JNI_TRACE("GENERAL_NAME_to_jobject(%p) => Email/DNS/URI \"%s\"", gen, data);
             return env->NewStringUTF(data);
         } else {
-            Errors::jniThrowException(env, "java/security/cert/CertificateParsingException",
-                    "Invalid dNSName encoding");
             JNI_TRACE("GENERAL_NAME_to_jobject(%p) => Email/DNS/URI invalid", gen);
             return nullptr;
         }


### PR DESCRIPTION
Conscrypt is strict in following RFC 5280's requirement that DNS
alternative names listed in X.509 certificates must be IA5Strings (aka
7-bit ASCII), with international domain names encoded in Punycode,
but the existing implementation throws an exception when it encounters
a nonconforming name, which results in the entire list of altnames
being discarded whenever any of them are invalid.

This change makes it so that only the nonconforming name is ignored,
returning any other conforming names.