### PR TITLE
Fix #130

### DIFF
--- a/constants/build.gradle
+++ b/constants/build.gradle
@@ -18,7 +18,7 @@ sourceSets.main {
 
 dependencies {
     compile files("${genDir}") {
-        builtBy 'runGen'
+        builtBy ':conscrypt-constants:runGen'
     }
 }
 


### PR DESCRIPTION
Specify full path to the `runGen` task within `conscrypt-constants`.

I don't have a good understanding of how Gradle works, so I can't say for sure whether this should actually work.