### PR TITLE
Add null check in RSA cipher engine

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -195,6 +195,10 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
             usingPrivateKey = false;
             this.key = OpenSSLRSAPublicKey.getInstance(rsaPublicKey);
         } else {
+            if (null == key) {
+                throw new InvalidKeyException("RSA private or public key is null");
+            }
+            
             throw new InvalidKeyException("Need RSA private or public key");
         }
 


### PR DESCRIPTION
Null check performed last and only used to inform API users that the key value was actually not provided, rather than the likely possibility of using a wrong key type.

See the discussion in #128 