### PR TITLE
Exposing SSL_max_seal_overhead

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -8333,6 +8333,14 @@ static jlong NativeCrypto_SSL_get1_session(JNIEnv* env, jclass, jlong ssl_addres
     return reinterpret_cast<uintptr_t>(SSL_get1_session(ssl));
 }
 
+static jint NativeCrypto_SSL_max_seal_overhead(JNIEnv* env, jclass, jlong ssl_address) {
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    if (ssl == nullptr) {
+        return 0;
+    }
+    return (jint) SSL_max_seal_overhead(ssl);
+}
+
 /**
  * public static native int SSL_new_BIO(long ssl) throws SSLException;
  */
@@ -9194,6 +9202,7 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_BIO_new, "(J)J"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_get0_session, "(J)J"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_get1_session, "(J)J"),
+        CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_max_seal_overhead, "(J)I"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_clear_error, "()V"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_pending_readable_bytes, "(J)I"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_pending_written_bytes_in_BIO, "(J)I"),

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1170,6 +1170,11 @@ public final class NativeCrypto {
     public static native long SSL_get1_session(long ssl);
 
     /**
+     * Returns the maximum overhead, in bytes, of sealing a record with ssl.
+     */
+    public static native int SSL_max_seal_overhead(long ssl);
+
+    /**
      * Sets the list of supported ALPN protocols in wire-format (length-prefixed 8-bit strings).
      */
     public static native void SSL_configure_alpn(

--- a/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
@@ -166,6 +166,8 @@ public final class OpenSSLEngineImpl extends SSLEngine
      */
     OpenSSLKey channelIdPrivateKey;
 
+    private int maxWrapOverhead;
+
     private final ByteBuffer[] singleSrcBuffer = new ByteBuffer[1];
     private final ByteBuffer[] singleDstBuffer = new ByteBuffer[1];
 
@@ -176,6 +178,15 @@ public final class OpenSSLEngineImpl extends SSLEngine
     public OpenSSLEngineImpl(String host, int port, SSLParametersImpl sslParameters) {
         super(host, port);
         this.sslParameters = sslParameters;
+    }
+
+    /**
+     * Calculates the maximum size of the buffer required to store the encrypted result of
+     * wrapping the given plaintext bytes.
+     */
+    public final int calculateMaxLengthForWrap(int plaintextLength) {
+        int amt = maxWrapOverhead + plaintextLength;
+        return amt < 0 ? Integer.MAX_VALUE : amt;
     }
 
     @Override
@@ -219,6 +230,7 @@ public final class OpenSSLEngineImpl extends SSLEngine
             } else {
                 NativeCrypto.SSL_set_accept_state(sslNativePointer);
             }
+            maxWrapOverhead = NativeCrypto.SSL_max_seal_overhead(sslNativePointer);
             handshake();
             releaseResources = false;
         } catch (IOException e) {


### PR DESCRIPTION
Also adding a method to calculate the maximum buffer size required for a wrap operation.