### PR TITLE
Adding conversion utility ALPN protocols

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1170,7 +1170,7 @@ public final class NativeCrypto {
     public static native long SSL_get1_session(long ssl);
 
     /**
-     * Returns the maximum overhead, in bytes, of sealing a record with ssl.
+     * Returns the maximum overhead, in bytes, of sealing a record with SSL.
      */
     public static native int SSL_max_seal_overhead(long ssl);
 

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -915,7 +915,7 @@ public class OpenSSLSocketImpl
      * @param useSessionTickets True to enable session tickets
      */
     public void setUseSessionTickets(boolean useSessionTickets) {
-        sslParameters.useSessionTickets = useSessionTickets;
+        sslParameters.setUseSessionTickets(useSessionTickets);
     }
 
     /**
@@ -1272,20 +1272,26 @@ public class OpenSSLSocketImpl
     }
 
     /**
-     * Sets the list of protocols this peer is interested in. If the list is
-     * {@code null}, no protocols will be used.
+     * Sets the list of ALPN protocols. This method internally converts the protocols to their
+     * wire-format form.
      *
-     * @param alpnProtocols a non-empty array of protocol names. From
-     *            SSL_select_next_proto, "vector of 8-bit, length prefixed byte
-     *            strings. The length byte itself is not included in the length.
-     *            A byte string of length 0 is invalid. No byte string may be
-     *            truncated.".
+     * @param alpnProtocols the list of ALPN protocols
+     * @see #setAlpnProtocols(byte[])
+     */
+    public void setAlpnProtocols(String[] alpnProtocols) {
+        sslParameters.setAlpnProtocols(alpnProtocols);
+    }
+
+    /**
+     * Alternate version of {@link #setAlpnProtocols(String[])} that directly sets the list of
+     * ALPN in the wire-format form used by BoringSSL (length-prefixed 8-bit strings).
+     * Requires that all strings be encoded with US-ASCII.
+     *
+     * @param alpnProtocols the encoded form of the ALPN protocol list
+     * @see #setAlpnProtocols(String[])
      */
     public void setAlpnProtocols(byte[] alpnProtocols) {
-        if (alpnProtocols != null && alpnProtocols.length == 0) {
-            throw new IllegalArgumentException("alpnProtocols.length == 0");
-        }
-        sslParameters.alpnProtocols = alpnProtocols;
+        sslParameters.setAlpnProtocols(alpnProtocols);
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -109,8 +109,8 @@ public class SSLParametersImpl implements Cloneable {
     private byte[] sctExtension;
     private byte[] ocspResponse;
 
-    byte[] alpnProtocols;
-    boolean useSessionTickets;
+    private byte[] alpnProtocols;
+    private boolean useSessionTickets;
     private Boolean useSni;
 
     /**
@@ -283,6 +283,32 @@ public class SSLParametersImpl implements Cloneable {
     }
 
     /**
+     * Sets the list of ALPN protocols. This method internally converts the protocols to their
+     * wire-format form.
+     *
+     * @param alpnProtocols the list of ALPN protocols
+     * @see #setAlpnProtocols(byte[])
+     */
+    void setAlpnProtocols(String[] alpnProtocols) {
+        setAlpnProtocols(SSLUtils.toLengthPrefixedList(alpnProtocols));
+    }
+
+    /**
+     * Alternate version of {@link #setAlpnProtocols(String[])} that directly sets the list of
+     * ALPN in the wire-format form used by BoringSSL (length-prefixed 8-bit strings).
+     * Requires that all strings be encoded with US-ASCII.
+     *
+     * @param alpnProtocols the encoded form of the ALPN protocol list
+     * @see #setAlpnProtocols(String[])
+     */
+    void setAlpnProtocols(byte[] alpnProtocols) {
+        if (alpnProtocols != null && alpnProtocols.length == 0) {
+            throw new IllegalArgumentException("alpnProtocols.length == 0");
+        }
+        this.alpnProtocols = alpnProtocols;
+    }
+
+    /**
      * Tunes the peer holding this parameters to work in client mode.
      * @param   mode if the peer is configured to work in client mode
      */
@@ -346,6 +372,10 @@ public class SSLParametersImpl implements Cloneable {
      */
     protected boolean getEnableSessionCreation() {
         return enable_session_creation;
+    }
+
+    void setUseSessionTickets(boolean useSessionTickets) {
+        this.useSessionTickets = useSessionTickets;
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -41,7 +41,6 @@ import static org.conscrypt.NativeConstants.SSL3_RT_HEADER_LENGTH;
 import static org.conscrypt.NativeConstants.SSL3_RT_MAX_PACKET_SIZE;
 
 import java.nio.ByteBuffer;
-import java.util.List;
 
 /**
  * Utility methods for SSL packet processing. Copied from the Netty project.

--- a/openjdk/src/test/java/org/conscrypt/SSLUtilsTest.java
+++ b/openjdk/src/test/java/org/conscrypt/SSLUtilsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SSLUtilsTest {
+    private static final byte[] VALID_CHARACTERS =
+            "0123456789abcdefghijklmnopqrstuvwxyz".getBytes();
+
+    @Test
+    public void noProtocolsShouldSucceed() {
+        byte[] expected = new byte[0];
+        byte[] actual = SSLUtils.toLengthPrefixedList();
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void emptyProtocolShouldThrow() {
+        SSLUtils.toLengthPrefixedList("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void longProtocolShouldThrow() {
+        SSLUtils.toLengthPrefixedList(new String(newValidProtocol(256)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void protocolWithInvalidCharacterShouldThrow() {
+        SSLUtils.toLengthPrefixedList("This is a bad character: €");
+    }
+
+    @Test
+    public void validProtocolsShouldSucceed() {
+        byte[][] protocols = new byte[][]{
+                "protocol-1".getBytes(),
+                "protocol-2".getBytes(),
+                "protocol-3".getBytes(),
+        };
+        byte[] expected = getExpectedEncodedBytes(protocols);
+        byte[] actual = SSLUtils.toLengthPrefixedList(toStrings(protocols));
+        assertArrayEquals(expected, actual);
+    }
+
+    private static String[] toStrings(byte[][] protocols) {
+        int numProtocols = protocols.length;
+        String[] out = new String[numProtocols];
+        for(int i = 0; i < numProtocols; ++i) {
+            out[i] = new String(protocols[i]);
+        }
+        return out;
+    }
+
+    private static byte[] getExpectedEncodedBytes(byte[][] protocols) {
+        int numProtocols = protocols.length;
+        int encodedLength = numProtocols;
+        for (byte[] protocol : protocols) {
+            encodedLength += protocol.length;
+        }
+        byte[] encoded = new byte[encodedLength];
+        for(int encodedIndex = 0, i = 0; i < numProtocols; ++i) {
+            byte[] protocol = protocols[i];
+            encoded[encodedIndex++] = (byte) protocol.length;
+            System.arraycopy(protocol, 0, encoded, encodedIndex, protocol.length);
+            encodedIndex += protocol.length;
+        }
+        return encoded;
+    }
+
+    private static byte[] newValidProtocol(int length) {
+        byte[] chars = new byte[length];
+        for (int i = 0; i < length; ++i) {
+            int charIndex = i % VALID_CHARACTERS.length;
+            chars[i] = VALID_CHARACTERS[charIndex];
+        }
+        return chars;
+    }
+}


### PR DESCRIPTION
Exposing additional set methods in OpenSSLEngineImpl and OpenSSLSocketImpl to allow the caller to set the ALPN protocols without having to manually encode.