### PR TITLE
Configure OCSP and SCTs on the SSL, not SSL_CTX.

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -6372,29 +6372,28 @@ static jbyteArray NativeCrypto_SSL_get_signed_cert_timestamp_list(JNIEnv *env, j
 }
 
 /*
- * public static native void SSL_CTX_set_signed_cert_timestamp_list(long ssl, byte[] response);
+ * public static native void SSL_set_signed_cert_timestamp_list(long ssl, byte[] response);
  */
-static void NativeCrypto_SSL_CTX_set_signed_cert_timestamp_list(JNIEnv *env, jclass,
-        jlong ssl_ctx_address, jbyteArray list) {
-    SSL_CTX* ssl_ctx = to_SSL_CTX(env, ssl_ctx_address, true);
-    JNI_TRACE("ssl_ctx=%p NativeCrypto_SSL_CTX_set_signed_cert_timestamp_list", ssl_ctx);
-    if (ssl_ctx == nullptr) {
+static void NativeCrypto_SSL_set_signed_cert_timestamp_list(JNIEnv *env, jclass,
+        jlong ssl_address, jbyteArray list) {
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_set_signed_cert_timestamp_list", ssl);
+    if (ssl == nullptr) {
         return;
     }
 
     ScopedByteArrayRO listBytes(env, list);
     if (listBytes.get() == nullptr) {
-        JNI_TRACE("ssl_ctx=%p NativeCrypto_SSL_CTX_set_signed_cert_timestamp_list =>"
-                  " list == null", ssl_ctx);
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_set_signed_cert_timestamp_list => list == null", ssl);
         return;
     }
 
-    if (!SSL_CTX_set_signed_cert_timestamp_list(ssl_ctx,
+    if (!SSL_set_signed_cert_timestamp_list(ssl,
                 reinterpret_cast<const uint8_t *>(listBytes.get()),
                 listBytes.size())) {
-        JNI_TRACE("ssl_ctx=%p NativeCrypto_SSL_CTX_set_signed_cert_timestamp_list => fail", ssl_ctx);
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_set_signed_cert_timestamp_list => fail", ssl);
     } else {
-        JNI_TRACE("ssl_ctx=%p NativeCrypto_SSL_CTX_set_signed_cert_timestamp_list => ok", ssl_ctx);
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_set_signed_cert_timestamp_list => ok", ssl);
     }
 }
 
@@ -6446,28 +6445,28 @@ static jbyteArray NativeCrypto_SSL_get_ocsp_response(JNIEnv *env, jclass,
 }
 
 /*
- * public static native void SSL_CTX_set_ocsp_response(long ssl, byte[] response);
+ * public static native void SSL_set_ocsp_response(long ssl, byte[] response);
  */
-static void NativeCrypto_SSL_CTX_set_ocsp_response(JNIEnv *env, jclass,
-        jlong ssl_ctx_address, jbyteArray response) {
-    SSL_CTX* ssl_ctx = to_SSL_CTX(env, ssl_ctx_address, true);
-    JNI_TRACE("ssl_ctx=%p NativeCrypto_SSL_CTX_set_ocsp_response", ssl_ctx);
-    if (ssl_ctx == nullptr) {
+static void NativeCrypto_SSL_set_ocsp_response(JNIEnv *env, jclass,
+        jlong ssl_address, jbyteArray response) {
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_set_ocsp_response", ssl);
+    if (ssl == nullptr) {
         return;
     }
 
     ScopedByteArrayRO responseBytes(env, response);
     if (responseBytes.get() == nullptr) {
-        JNI_TRACE("ssl_ctx=%p NativeCrypto_SSL_CTX_set_ocsp_response => response == null", ssl_ctx);
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_set_ocsp_response => response == null", ssl);
         return;
     }
 
-    if (!SSL_CTX_set_ocsp_response(ssl_ctx,
+    if (!SSL_set_ocsp_response(ssl,
                 reinterpret_cast<const uint8_t *>(responseBytes.get()),
                 responseBytes.size())) {
-        JNI_TRACE("ssl_ctx=%p NativeCrypto_SSL_CTX_set_ocsp_response => fail", ssl_ctx);
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_set_ocsp_response => fail", ssl);
     } else {
-        JNI_TRACE("ssl_ctx=%p NativeCrypto_SSL_CTX_set_ocsp_response => ok", ssl_ctx);
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_set_ocsp_response => ok", ssl);
     }
 }
 
@@ -9156,10 +9155,10 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_clear_options, "(JJ)J"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_enable_signed_cert_timestamps, "(J)V"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_get_signed_cert_timestamp_list, "(J)[B"),
-        CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_CTX_set_signed_cert_timestamp_list, "(J[B)V"),
+        CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_set_signed_cert_timestamp_list, "(J[B)V"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_enable_ocsp_stapling, "(J)V"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_get_ocsp_response, "(J)[B"),
-        CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_CTX_set_ocsp_response, "(J[B)V"),
+        CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_set_ocsp_response, "(J[B)V"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, SSL_use_psk_identity_hint, "(JLjava/lang/String;)V"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, set_SSL_psk_client_callback_enabled, "(JZ)V"),
         CONSCRYPT_NATIVE_METHOD(NativeCrypto, set_SSL_psk_server_callback_enabled, "(JZ)V"),

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -814,13 +814,13 @@ public final class NativeCrypto {
 
     public static native byte[] SSL_get_signed_cert_timestamp_list(long ssl);
 
-    public static native void SSL_CTX_set_signed_cert_timestamp_list(long ssl, byte[] list);
+    public static native void SSL_set_signed_cert_timestamp_list(long ssl, byte[] list);
 
     public static native void SSL_enable_ocsp_stapling(long ssl);
 
     public static native byte[] SSL_get_ocsp_response(long ssl);
 
-    public static native void SSL_CTX_set_ocsp_response(long ssl, byte[] response);
+    public static native void SSL_set_ocsp_response(long ssl, byte[] response);
 
     public static native void SSL_use_psk_identity_hint(long ssl, String identityHint)
             throws SSLException;

--- a/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
@@ -245,9 +245,7 @@ public final class OpenSSLEngineImpl extends SSLEngine
         boolean releaseResources = true;
         try {
             final AbstractSessionContext sessionContext = sslParameters.getSessionContext();
-            final long sslCtxNativePointer = sessionContext.sslCtxNativePointer;
-            sslParameters.setSSLCtxParameters(sslCtxNativePointer);
-            sslNativePointer = NativeCrypto.SSL_new(sslCtxNativePointer);
+            sslNativePointer = NativeCrypto.SSL_new(sessionContext.sslCtxNativePointer);
             networkBio = NativeCrypto.SSL_BIO_new(sslNativePointer);
             sslSession =
                     sslParameters.getSessionToReuse(sslNativePointer, getPeerHost(), getPeerPort());

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -292,9 +292,7 @@ public class OpenSSLSocketImpl
         boolean releaseResources = true;
         try {
             final AbstractSessionContext sessionContext = sslParameters.getSessionContext();
-            final long sslCtxNativePointer = sessionContext.sslCtxNativePointer;
-            sslParameters.setSSLCtxParameters(sslCtxNativePointer);
-            sslNativePointer = NativeCrypto.SSL_new(sslCtxNativePointer);
+            sslNativePointer = NativeCrypto.SSL_new(sessionContext.sslCtxNativePointer);
             Platform.closeGuardOpen(guard, "close");
 
             boolean enableSessionCreation = getEnableSessionCreation();

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -535,19 +535,6 @@ public class SSLParametersImpl implements Cloneable {
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-    void setSSLCtxParameters(long sslCtxNativePointer) throws SSLException, IOException {
-        if (!client_mode) {
-            if (sctExtension != null) {
-                NativeCrypto.SSL_CTX_set_signed_cert_timestamp_list(
-                        sslCtxNativePointer, sctExtension);
-            }
-
-            if (ocspResponse != null) {
-                NativeCrypto.SSL_CTX_set_ocsp_response(sslCtxNativePointer, ocspResponse);
-            }
-        }
-    }
-
     void setSSLParameters(long sslNativePointer, AliasChooser chooser, PSKCallbacks pskCallbacks,
             String sniHostname) throws SSLException, IOException {
         if (enabledProtocols.length == 0 && isEnabledProtocolsFiltered) {
@@ -583,6 +570,14 @@ public class SSLParametersImpl implements Cloneable {
 
             NativeCrypto.SSL_set_options(sslNativePointer,
                     NativeConstants.SSL_OP_CIPHER_SERVER_PREFERENCE);
+
+            if (sctExtension != null) {
+                NativeCrypto.SSL_set_signed_cert_timestamp_list(sslNativePointer, sctExtension);
+            }
+
+            if (ocspResponse != null) {
+                NativeCrypto.SSL_set_ocsp_response(sslNativePointer, ocspResponse);
+            }
         }
 
         enablePSKKeyManagerIfRequested(sslNativePointer, pskCallbacks);

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -1528,8 +1528,9 @@ public class NativeCryptoTest {
         Hooks sHooks = new ServerHooks(getServerPrivateKey(), getServerCertificates()) {
             @Override
             public long beforeHandshake(long c) throws SSLException {
-                NativeCrypto.SSL_CTX_set_ocsp_response(c, OCSP_TEST_DATA);
-                return super.beforeHandshake(c);
+                long s = super.beforeHandshake(c);
+                NativeCrypto.SSL_set_ocsp_response(s, OCSP_TEST_DATA);
+                return s;
             }
         };
 
@@ -1569,8 +1570,9 @@ public class NativeCryptoTest {
         Hooks sHooks = new ServerHooks(getServerPrivateKey(), getServerCertificates()) {
             @Override
             public long beforeHandshake(long c) throws SSLException {
-                NativeCrypto.SSL_CTX_set_signed_cert_timestamp_list(c, SCT_TEST_DATA);
-                return super.beforeHandshake(c);
+                long s = super.beforeHandshake(c);
+                NativeCrypto.SSL_set_signed_cert_timestamp_list(s, SCT_TEST_DATA);
+                return s;
             }
         };
 

--- a/platform/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/platform/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -1461,8 +1461,9 @@ public class NativeCryptoTest {
         Hooks sHooks = new ServerHooks(getServerPrivateKey(), getServerCertificates()) {
             @Override
             public long beforeHandshake(long c) throws SSLException {
-                NativeCrypto.SSL_CTX_set_ocsp_response(c, OCSP_TEST_DATA);
-                return super.beforeHandshake(c);
+                long s = super.beforeHandshake(c);
+                NativeCrypto.SSL_set_ocsp_response(s, OCSP_TEST_DATA);
+                return s;
             }
         };
 
@@ -1502,8 +1503,9 @@ public class NativeCryptoTest {
         Hooks sHooks = new ServerHooks(getServerPrivateKey(), getServerCertificates()) {
             @Override
             public long beforeHandshake(long c) throws SSLException {
-                NativeCrypto.SSL_CTX_set_signed_cert_timestamp_list(c, SCT_TEST_DATA);
-                return super.beforeHandshake(c);
+                long s = super.beforeHandshake(c);
+                NativeCrypto.SSL_set_signed_cert_timestamp_list(s, SCT_TEST_DATA);
+                return s;
             }
         };
 


### PR DESCRIPTION
As Conscrypt is currently set up, one SSL_CTX (owned, ultimately, by the
SSLContext) may correspond to multiple SSLParameters which, in the Java
API, are configured on the SSLSocket or SSLEngine directly. Thus we
should use the SSL versions of the APIs which now exist. This avoids
mutating an SSL_CTX which may be shared by multiple SSLs with different
configurations.

Change-Id: I19485c316087004c6050d85520b0169f2ca0d493