### PR TITLE
Keep Java 7 compatibility

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -399,7 +399,8 @@ public class OpenSSLX509Certificate extends X509Certificate {
         verifyInternal(key, sigProvider);
     }
 
-    @Override
+    /* @Override */
+    @SuppressWarnings("MissingOverride")  // For compilation with Java 7.
     public void verify(PublicKey key, Provider sigProvider)
             throws CertificateException, NoSuchAlgorithmException, InvalidKeyException,
                    SignatureException {


### PR DESCRIPTION
A platform that Conscrypt is built on still uses Java 7, so keep
compatibility with it. To avoid ErrorProne warnings, suppress the check
for this.