### PR TITLE
Add error-prone and fix all the errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,16 @@ buildscript {
         mavenCentral()
         mavenLocal()
         jcenter()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
     }
     dependencies {
         // Add dependency for build script,
         // so we can access Git from our
         // build script.
         classpath 'org.ajoberstar:grgit:1.1.0'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.9'
     }
 }
 
@@ -35,6 +39,7 @@ subprojects {
     apply plugin: "signing"
     apply plugin: "idea"
     apply plugin: "jacoco"
+    apply plugin: "net.ltgt.errorprone"
 
     group = "org.conscrypt"
     description = 'Conscrypt is an alternate Java Security Provider that uses BoringSSL'

--- a/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
@@ -1017,6 +1017,8 @@ public final class OpenSSLEngineImpl extends SSLEngine
                 case NEW:
                     throw new IllegalStateException(
                             "Client/server mode must be set before calling wrap");
+                default:
+                    break;
             }
 
             // If we haven't completed the handshake yet, just let the caller know.

--- a/common/src/main/java/org/conscrypt/OpenSSLSessionImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSessionImpl.java
@@ -293,6 +293,7 @@ public class OpenSSLSessionImpl extends AbstractOpenSSLSession {
     /**
      * Returns the name requested by the SNI extension.
      */
+    @Override
     public String getRequestedServerName() {
         return NativeCrypto.get_SSL_SESSION_tlsext_hostname(sslSessionNativePointer);
     }
@@ -300,6 +301,7 @@ public class OpenSSLSessionImpl extends AbstractOpenSSLSession {
     /**
      * Returns the OCSP stapled response.
      */
+    @Override
     public List<byte[]> getStatusResponses() {
         if (peerCertificateOcspData == null) {
             return Collections.<byte[]>emptyList();
@@ -308,6 +310,7 @@ public class OpenSSLSessionImpl extends AbstractOpenSSLSession {
         return Collections.singletonList(peerCertificateOcspData.clone());
     }
 
+    @Override
     public byte[] getTlsSctData() {
         if (peerTlsSctData == null) {
             return null;

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.SocketImpl;
 import java.nio.channels.SocketChannel;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -81,8 +82,7 @@ final class Platform {
             Field f_impl = Socket.class.getDeclaredField("impl");
             f_impl.setAccessible(true);
             Object socketImpl = f_impl.get(s);
-            Class<?> c_socketImpl = Class.forName("java.net.SocketImpl");
-            Field f_fd = c_socketImpl.getDeclaredField("fd");
+            Field f_fd = SocketImpl.class.getDeclaredField("fd");
             f_fd.setAccessible(true);
             return (FileDescriptor) f_fd.get(socketImpl);
         } catch (Exception e) {

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -749,8 +749,9 @@ public class NativeCryptoTest {
             if (DEBUG) {
                 System.out.println("ssl=0x" + Long.toString(sslNativePointer, 16)
                         + " clientCertificateRequested"
-                        + " keyTypes=" + keyTypes + " asn1DerEncodedX500Principals="
-                        + asn1DerEncodedX500Principals);
+                        + " keyTypes=" + Arrays.toString(keyTypes)
+                        + " asn1DerEncodedX500Principals="
+                        + Arrays.toString(asn1DerEncodedX500Principals));
             }
             this.keyTypes = keyTypes;
             this.asn1DerEncodedX500Principals = asn1DerEncodedX500Principals;


### PR DESCRIPTION
error-prone provides excellent insight into common problems with the source code tree. Start using it so we don't accidentally introduce errors.

After this change there are 22 warnings and 0 errors.