### PR TITLE
Add Java 8 style SNI hostname to OpenSSLEngineImpl

### DIFF
--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -303,6 +303,25 @@ public final class Conscrypt {
         }
 
         /**
+         * This method enables Server Name Indication (SNI) and sets the host name used for
+         * SNI.
+         *
+         * @param engine the engine
+         * @param hostname the desired SNI hostname, or {@code null} to disable
+         */
+        public static void setHostname(SSLEngine engine, String hostname) {
+            toConscrypt(engine).setSniHostname(hostname);
+        }
+
+        /**
+         * Returns the SNI hostname that was set for the {@code engine}. If no SNI hostname
+         * was set, it will return the hostname supplied during creation of the {@code engine}.
+         */
+        public static String getHostname(SSLEngine engine) {
+            return toConscrypt(engine).getSniHostname();
+        }
+
+        /**
          * Returns the maximum overhead, in bytes, of sealing a record with SSL.
          */
         public static int maxSealOverhead(SSLEngine engine) {

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -141,6 +141,31 @@ final class Platform {
         }
     }
 
+    public static void setSSLParameters(
+            SSLParameters params, SSLParametersImpl impl, OpenSSLEngineImpl engine) {
+        impl.setEndpointIdentificationAlgorithm(params.getEndpointIdentificationAlgorithm());
+        impl.setUseCipherSuitesOrder(params.getUseCipherSuitesOrder());
+        List<SNIServerName> serverNames = params.getServerNames();
+        if (serverNames != null) {
+            for (SNIServerName serverName : serverNames) {
+                if (serverName.getType() == StandardConstants.SNI_HOST_NAME) {
+                    engine.setSniHostname(((SNIHostName) serverName).getAsciiName());
+                    break;
+                }
+            }
+        }
+    }
+
+    public static void getSSLParameters(
+            SSLParameters params, SSLParametersImpl impl, OpenSSLEngineImpl engine) {
+        params.setEndpointIdentificationAlgorithm(impl.getEndpointIdentificationAlgorithm());
+        params.setUseCipherSuitesOrder(impl.getUseCipherSuitesOrder());
+        if (impl.getUseSni() && AddressUtils.isValidSniHostname(engine.getSniHostname())) {
+            params.setServerNames(Collections.<SNIServerName>singletonList(
+                    new SNIHostName(engine.getSniHostname())));
+        }
+    }
+
     /**
      * Tries to return a Class reference of one of the supplied class names.
      */

--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -134,6 +134,31 @@ class Platform {
         }
     }
 
+    public static void setSSLParameters(
+            SSLParameters params, SSLParametersImpl impl, OpenSSLEngineImpl engine) {
+        impl.setEndpointIdentificationAlgorithm(params.getEndpointIdentificationAlgorithm());
+        impl.setUseCipherSuitesOrder(params.getUseCipherSuitesOrder());
+        List<SNIServerName> serverNames = params.getServerNames();
+        if (serverNames != null) {
+            for (SNIServerName serverName : serverNames) {
+                if (serverName.getType() == StandardConstants.SNI_HOST_NAME) {
+                    engine.setSniHostname(((SNIHostName) serverName).getAsciiName());
+                    break;
+                }
+            }
+        }
+    }
+
+    public static void getSSLParameters(
+            SSLParameters params, SSLParametersImpl impl, OpenSSLEngineImpl engine) {
+        params.setEndpointIdentificationAlgorithm(impl.getEndpointIdentificationAlgorithm());
+        params.setUseCipherSuitesOrder(impl.getUseCipherSuitesOrder());
+        if (impl.getUseSni() && AddressUtils.isValidSniHostname(engine.getSniHostname())) {
+            params.setServerNames(Collections.<SNIServerName>singletonList(
+                    new SNIHostName(engine.getSniHostname())));
+        }
+    }
+
     /**
      * Helper function to unify calls to the different names used for each function taking a
      * Socket, SSLEngine, or String (legacy Android).


### PR DESCRIPTION
The SNIHostName, et al., support was lacking from OpenSSLEngineImpl
causing endpoint protocol identification to fail in Netty tests.