### PR TITLE
Locking down public APIs

### DIFF
--- a/android-stub/src/main/java/com/android/org/conscrypt/NativeCrypto.java
+++ b/android-stub/src/main/java/com/android/org/conscrypt/NativeCrypto.java
@@ -20,7 +20,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import javax.net.ssl.SSLException;
 
-class NativeCrypto {
+final class NativeCrypto {
     public interface SSLHandshakeCallbacks {
         /**
          * Verify that we trust the certificate chain is trusted.
@@ -30,7 +30,7 @@ class NativeCrypto {
          *
          * @throws CertificateException if the certificate is untrusted
          */
-        public void verifyCertificateChain(byte[][] asn1DerEncodedCertificateChain,
+        void verifyCertificateChain(byte[][] asn1DerEncodedCertificateChain,
                 String authMethod) throws CertificateException;
         /**
          * Called on an SSL client when the server requests (or
@@ -43,7 +43,7 @@ class NativeCrypto {
          * convertible to strings with #keyType
          * @param asn1DerEncodedX500Principals CAs known to the server
          */
-        public void clientCertificateRequested(
+        void clientCertificateRequested(
                 byte[] keyTypes, byte[][] asn1DerEncodedX500Principals)
                 throws CertificateEncodingException, SSLException;
         /**
@@ -51,6 +51,6 @@ class NativeCrypto {
          * be after SSL_do_handshake returns when handshake cutthrough
          * is enabled.
          */
-        public void handshakeCompleted();
+        void handshakeCompleted();
     }
 }

--- a/android-stub/src/main/java/com/android/org/conscrypt/OpenSSLSocketImpl.java
+++ b/android-stub/src/main/java/com/android/org/conscrypt/OpenSSLSocketImpl.java
@@ -81,15 +81,18 @@ public class OpenSSLSocketImpl
     }
 
     @SuppressWarnings("unused") // used by NativeCrypto.SSLHandshakeCallbacks / client_cert_cb
+    @Override
     public void clientCertificateRequested(byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals)
             throws CertificateEncodingException, SSLException {
         throw new RuntimeException("Stub!");
     }
 
     @SuppressWarnings("unused") // used by NativeCrypto.SSLHandshakeCallbacks / info_callback
+    @Override
     public void handshakeCompleted() {
         throw new RuntimeException("Stub!");
     }
+
     @SuppressWarnings("unused") // used by NativeCrypto.SSLHandshakeCallbacks
     @Override
     public void verifyCertificateChain(byte[][] bytes, String authMethod)
@@ -106,6 +109,7 @@ public class OpenSSLSocketImpl
     public OutputStream getOutputStream() throws IOException {
         throw new RuntimeException("Stub!");
     }
+
     @Override
     public SSLSession getSession() {
         throw new RuntimeException("Stub!");
@@ -175,6 +179,7 @@ public class OpenSSLSocketImpl
     public byte[] getChannelId() throws SSLException {
         throw new RuntimeException("Stub!");
     }
+
     public void setChannelIdPrivateKey(PrivateKey privateKey) {
         throw new RuntimeException("Stub!");
     }
@@ -219,11 +224,13 @@ public class OpenSSLSocketImpl
         throw new RuntimeException("Stub!");
     }
 
+    @SuppressWarnings("UnsynchronizedOverridesSynchronized")
     @Override
     public void setSoTimeout(int readTimeoutMilliseconds) throws SocketException {
         throw new RuntimeException("Stub!");
     }
 
+    @SuppressWarnings("UnsynchronizedOverridesSynchronized")
     @Override
     public int getSoTimeout() throws SocketException {
         throw new RuntimeException("Stub!");
@@ -251,6 +258,7 @@ public class OpenSSLSocketImpl
         throw new RuntimeException("Stub!");
     }
 
+    @SuppressWarnings("UnsynchronizedOverridesSynchronized")
     @Override
     public void close() throws IOException {
         throw new RuntimeException("Stub!");

--- a/android-stub/src/main/java/dalvik/system/BlockGuard.java
+++ b/android-stub/src/main/java/dalvik/system/BlockGuard.java
@@ -28,6 +28,7 @@ public class BlockGuard {
     public static class PolicyWrapper implements Policy {
         private PolicyWrapper() {}
 
+        @Override
         public void onNetwork() {
             throw new UnsupportedOperationException("Stub!");
         }

--- a/android-stub/src/main/java/org/apache/harmony/xnet/provider/jsse/NativeCrypto.java
+++ b/android-stub/src/main/java/org/apache/harmony/xnet/provider/jsse/NativeCrypto.java
@@ -20,7 +20,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import javax.net.ssl.SSLException;
 
-class NativeCrypto {
+final class NativeCrypto {
     public interface SSLHandshakeCallbacks {
         /**
          * Verify that we trust the certificate chain is trusted.
@@ -30,7 +30,7 @@ class NativeCrypto {
          *
          * @throws CertificateException if the certificate is untrusted
          */
-        public void verifyCertificateChain(byte[][] asn1DerEncodedCertificateChain,
+        void verifyCertificateChain(byte[][] asn1DerEncodedCertificateChain,
                 String authMethod) throws CertificateException;
         /**
          * Called on an SSL client when the server requests (or
@@ -43,7 +43,7 @@ class NativeCrypto {
          * convertible to strings with #keyType
          * @param asn1DerEncodedX500Principals CAs known to the server
          */
-        public void clientCertificateRequested(
+        void clientCertificateRequested(
                 byte[] keyTypes, byte[][] asn1DerEncodedX500Principals)
                 throws CertificateEncodingException, SSLException;
         /**
@@ -51,6 +51,6 @@ class NativeCrypto {
          * be after SSL_do_handshake returns when handshake cutthrough
          * is enabled.
          */
-        public void handshakeCompleted();
+        void handshakeCompleted();
     }
 }

--- a/android-stub/src/main/java/org/apache/harmony/xnet/provider/jsse/OpenSSLSocketImpl.java
+++ b/android-stub/src/main/java/org/apache/harmony/xnet/provider/jsse/OpenSSLSocketImpl.java
@@ -81,15 +81,18 @@ public class OpenSSLSocketImpl
     }
 
     @SuppressWarnings("unused") // used by NativeCrypto.SSLHandshakeCallbacks / client_cert_cb
+    @Override
     public void clientCertificateRequested(byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals)
             throws CertificateEncodingException, SSLException {
         throw new RuntimeException("Stub!");
     }
 
     @SuppressWarnings("unused") // used by NativeCrypto.SSLHandshakeCallbacks / info_callback
+    @Override
     public void handshakeCompleted() {
         throw new RuntimeException("Stub!");
     }
+
     @SuppressWarnings("unused") // used by NativeCrypto.SSLHandshakeCallbacks
     @Override
     public void verifyCertificateChain(byte[][] bytes, String authMethod)
@@ -106,6 +109,7 @@ public class OpenSSLSocketImpl
     public OutputStream getOutputStream() throws IOException {
         throw new RuntimeException("Stub!");
     }
+
     @Override
     public SSLSession getSession() {
         throw new RuntimeException("Stub!");
@@ -160,6 +164,7 @@ public class OpenSSLSocketImpl
     public void setEnabledProtocols(String[] protocols) {
         throw new RuntimeException("Stub!");
     }
+
     public void setUseSessionTickets(boolean useSessionTickets) {
         throw new RuntimeException("Stub!");
     }
@@ -175,6 +180,7 @@ public class OpenSSLSocketImpl
     public byte[] getChannelId() throws SSLException {
         throw new RuntimeException("Stub!");
     }
+
     public void setChannelIdPrivateKey(PrivateKey privateKey) {
         throw new RuntimeException("Stub!");
     }
@@ -219,11 +225,13 @@ public class OpenSSLSocketImpl
         throw new RuntimeException("Stub!");
     }
 
+    @SuppressWarnings("UnsynchronizedOverridesSynchronized")
     @Override
     public void setSoTimeout(int readTimeoutMilliseconds) throws SocketException {
         throw new RuntimeException("Stub!");
     }
 
+    @SuppressWarnings("UnsynchronizedOverridesSynchronized")
     @Override
     public int getSoTimeout() throws SocketException {
         throw new RuntimeException("Stub!");
@@ -251,6 +259,7 @@ public class OpenSSLSocketImpl
         throw new RuntimeException("Stub!");
     }
 
+    @SuppressWarnings("UnsynchronizedOverridesSynchronized")
     @Override
     public void close() throws IOException {
         throw new RuntimeException("Stub!");

--- a/common/src/main/java/org/conscrypt/AbstractOpenSSLSession.java
+++ b/common/src/main/java/org/conscrypt/AbstractOpenSSLSession.java
@@ -32,11 +32,8 @@ import javax.security.cert.CertificateException;
 
 /**
  * Extends the base SSLSession with some methods used exclusively in Conscrypt.
- *
- * @hide
  */
-@Internal
-public abstract class AbstractOpenSSLSession implements SSLSession {
+abstract class AbstractOpenSSLSession implements SSLSession {
     private final Map<String, Object> values = new HashMap<String, Object>();
 
     private volatile javax.security.cert.X509Certificate[] peerCertificateChain;
@@ -49,7 +46,7 @@ public abstract class AbstractOpenSSLSession implements SSLSession {
      * Class constructor creates an SSL session context given the appropriate
      * session context.
      */
-    protected AbstractOpenSSLSession(AbstractSessionContext sessionContext) {
+    AbstractOpenSSLSession(AbstractSessionContext sessionContext) {
         this.sessionContext = sessionContext;
     }
 

--- a/common/src/main/java/org/conscrypt/AbstractSessionContext.java
+++ b/common/src/main/java/org/conscrypt/AbstractSessionContext.java
@@ -45,19 +45,19 @@ abstract class AbstractSessionContext implements SSLSessionContext {
      */
     private static final int DEFAULT_SESSION_TIMEOUT_SECONDS = 8 * 60 * 60;
 
-    volatile int maximumSize;
-    volatile int timeout = DEFAULT_SESSION_TIMEOUT_SECONDS;
+    private volatile int maximumSize;
+    private volatile int timeout = DEFAULT_SESSION_TIMEOUT_SECONDS;
 
     final long sslCtxNativePointer = NativeCrypto.SSL_CTX_new();
 
     /** Identifies OpenSSL sessions. */
-    static final int OPEN_SSL = 1;
+    private static final int OPEN_SSL = 1;
 
     /** Identifies OpenSSL sessions with OCSP stapled data. */
-    static final int OPEN_SSL_WITH_OCSP = 2;
+    private static final int OPEN_SSL_WITH_OCSP = 2;
 
     /** Identifies OpenSSL sessions with TLS SCT data. */
-    static final int OPEN_SSL_WITH_TLS_SCT = 3;
+    private static final int OPEN_SSL_WITH_TLS_SCT = 3;
 
     @SuppressWarnings("serial")
     private final Map<ByteArray, SSLSession> sessions = new LinkedHashMap<ByteArray, SSLSession>() {
@@ -140,7 +140,7 @@ abstract class AbstractSessionContext implements SSLSessionContext {
     /**
      * Makes sure cache size is < maximumSize.
      */
-    protected void trimToSize() {
+    private void trimToSize() {
         synchronized (sessions) {
             int size = sessions.size();
             if (size > maximumSize) {
@@ -204,7 +204,7 @@ abstract class AbstractSessionContext implements SSLSessionContext {
      *
      * @return session data as bytes or null if the session can't be converted
      */
-    public byte[] toBytes(SSLSession session) {
+    byte[] toBytes(SSLSession session) {
         // TODO: Support SSLSessionImpl, too.
         if (!(session instanceof OpenSSLSessionImpl)) {
             return null;
@@ -274,7 +274,7 @@ abstract class AbstractSessionContext implements SSLSessionContext {
      *
      * @return a session or null if the session can't be converted
      */
-    public OpenSSLSessionImpl toSession(byte[] data, String host, int port) {
+    OpenSSLSessionImpl toSession(byte[] data, String host, int port) {
         ByteBuffer buf = ByteBuffer.wrap(data);
         try {
             int type = buf.getInt();
@@ -355,7 +355,7 @@ abstract class AbstractSessionContext implements SSLSessionContext {
         }
     }
 
-    protected SSLSession wrapSSLSessionIfNeeded(SSLSession session) {
+    SSLSession wrapSSLSessionIfNeeded(SSLSession session) {
         if (session instanceof AbstractOpenSSLSession) {
             return Platform.wrapSSLSession((AbstractOpenSSLSession) session);
         } else {
@@ -390,7 +390,7 @@ abstract class AbstractSessionContext implements SSLSessionContext {
         }
     }
 
-    static void log(Throwable t) {
+    private static void log(Throwable t) {
         System.out.println("Error inflating SSL session: "
                 + (t.getMessage() != null ? t.getMessage() : t.getClass().getName()));
     }

--- a/common/src/main/java/org/conscrypt/AddressUtils.java
+++ b/common/src/main/java/org/conscrypt/AddressUtils.java
@@ -20,11 +20,8 @@ import java.util.regex.Pattern;
 
 /**
  * Utilities to check whether IP addresses meet some criteria.
- *
- * Visible for testing only.
- * @hide
  */
-public final class AddressUtils {
+final class AddressUtils {
     /*
      * Regex that matches valid IPv4 and IPv6 addresses.
      */
@@ -33,33 +30,25 @@ public final class AddressUtils {
 
     private static Pattern ipPattern;
 
-    private AddressUtils() {
-    }
+    private AddressUtils() {}
 
     /**
      * Returns true when the supplied hostname is valid for SNI purposes.
      */
-    public static boolean isValidSniHostname(String sniHostname) {
+    static boolean isValidSniHostname(String sniHostname) {
         if (sniHostname == null) {
             return false;
         }
 
         // Must be a FQDN.
-        if (sniHostname.indexOf('.') == -1) {
-            return false;
-        }
+        return sniHostname.indexOf('.') != -1 && !Platform.isLiteralIpAddress(sniHostname);
 
-        if (Platform.isLiteralIpAddress(sniHostname)) {
-            return false;
-        }
-
-        return true;
     }
 
     /**
      * Returns true if the supplied hostname is an literal IP address.
      */
-    public static boolean isLiteralIpAddress(String hostname) {
+    static boolean isLiteralIpAddress(String hostname) {
         /* This is here for backwards compatibility for pre-Honeycomb devices. */
         Pattern ipPattern = AddressUtils.ipPattern;
         if (ipPattern == null) {

--- a/common/src/main/java/org/conscrypt/ArrayUtils.java
+++ b/common/src/main/java/org/conscrypt/ArrayUtils.java
@@ -20,8 +20,7 @@ package org.conscrypt;
  * Compatibility utility for Arrays.
  */
 final class ArrayUtils {
-    private ArrayUtils() {
-    }
+    private ArrayUtils() {}
 
     /**
      * Checks that the range described by {@code offset} and {@code count}

--- a/common/src/main/java/org/conscrypt/ChainStrengthAnalyzer.java
+++ b/common/src/main/java/org/conscrypt/ChainStrengthAnalyzer.java
@@ -25,11 +25,8 @@ import java.util.List;
 
 /**
  * Analyzes the cryptographic strength of a chain of X.509 certificates.
- *
- * @hide
  */
-@Internal
-public final class ChainStrengthAnalyzer {
+final class ChainStrengthAnalyzer {
 
     private static final int MIN_RSA_MODULUS_LEN_BITS = 1024;
 
@@ -44,7 +41,7 @@ public final class ChainStrengthAnalyzer {
         "1.2.840.113549.1.1.4", // md5WithRSAEncryption
     };
 
-    public static final void check(X509Certificate[] chain) throws CertificateException {
+    static final void check(X509Certificate[] chain) throws CertificateException {
         for (X509Certificate cert : chain) {
             try {
                 checkCert(cert);
@@ -55,7 +52,7 @@ public final class ChainStrengthAnalyzer {
         }
     }
 
-    public static final void check(List<X509Certificate> chain) throws CertificateException {
+    static final void check(List<X509Certificate> chain) throws CertificateException {
         for (X509Certificate cert : chain) {
             try {
                 checkCert(cert);
@@ -66,12 +63,12 @@ public final class ChainStrengthAnalyzer {
         }
     }
 
-    public static final void checkCert(X509Certificate cert) throws CertificateException {
+    static final void checkCert(X509Certificate cert) throws CertificateException {
         checkKeyLength(cert);
         checkSignatureAlgorithm(cert);
     }
 
-    private static final void checkKeyLength(X509Certificate cert) throws CertificateException {
+    private static void checkKeyLength(X509Certificate cert) throws CertificateException {
         Object pubkey = cert.getPublicKey();
         if (pubkey instanceof RSAPublicKey) {
             int modulusLength = ((RSAPublicKey) pubkey).getModulus().bitLength();
@@ -100,7 +97,7 @@ public final class ChainStrengthAnalyzer {
         }
     }
 
-    private static final void checkSignatureAlgorithm(
+    private static void checkSignatureAlgorithm(
             X509Certificate cert) throws CertificateException {
         String oid = cert.getSigAlgOID();
         for (String blacklisted : SIGNATURE_ALGORITHM_OID_BLACKLIST) {

--- a/common/src/main/java/org/conscrypt/ClientSessionContext.java
+++ b/common/src/main/java/org/conscrypt/ClientSessionContext.java
@@ -22,8 +22,11 @@ import javax.net.ssl.SSLSession;
 /**
  * Caches client sessions. Indexes by host and port. Users are typically
  * looking to reuse any session for a given host and port.
+ *
+ * @hide
  */
-class ClientSessionContext extends AbstractSessionContext {
+@Internal
+public class ClientSessionContext extends AbstractSessionContext {
 
     /**
      * Sessions indexed by host and port. Protect from concurrent
@@ -33,15 +36,15 @@ class ClientSessionContext extends AbstractSessionContext {
 
     private SSLClientSessionCache persistentCache;
 
-    ClientSessionContext() {
+    public ClientSessionContext() {
         super(10);
     }
 
-    int size() {
+    public int size() {
         return sessionsByHostAndPort.size();
     }
 
-    void setPersistentCache(SSLClientSessionCache persistentCache) {
+    public void setPersistentCache(SSLClientSessionCache persistentCache) {
         this.persistentCache = persistentCache;
     }
 
@@ -65,7 +68,7 @@ class ClientSessionContext extends AbstractSessionContext {
      * @param port of server
      * @return cached session or null if none found
      */
-    SSLSession getSession(String host, int port) {
+    public SSLSession getSession(String host, int port) {
         if (host == null) {
             return null;
         }

--- a/common/src/main/java/org/conscrypt/ClientSessionContext.java
+++ b/common/src/main/java/org/conscrypt/ClientSessionContext.java
@@ -22,11 +22,8 @@ import javax.net.ssl.SSLSession;
 /**
  * Caches client sessions. Indexes by host and port. Users are typically
  * looking to reuse any session for a given host and port.
- *
- * @hide
  */
-@Internal
-public class ClientSessionContext extends AbstractSessionContext {
+class ClientSessionContext extends AbstractSessionContext {
 
     /**
      * Sessions indexed by host and port. Protect from concurrent
@@ -36,15 +33,15 @@ public class ClientSessionContext extends AbstractSessionContext {
 
     private SSLClientSessionCache persistentCache;
 
-    public ClientSessionContext() {
+    ClientSessionContext() {
         super(10);
     }
 
-    public int size() {
+    int size() {
         return sessionsByHostAndPort.size();
     }
 
-    public void setPersistentCache(SSLClientSessionCache persistentCache) {
+    void setPersistentCache(SSLClientSessionCache persistentCache) {
         this.persistentCache = persistentCache;
     }
 
@@ -68,7 +65,7 @@ public class ClientSessionContext extends AbstractSessionContext {
      * @param port of server
      * @return cached session or null if none found
      */
-    public SSLSession getSession(String host, int port) {
+    SSLSession getSession(String host, int port) {
         if (host == null) {
             return null;
         }

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -19,6 +19,7 @@ import java.io.FileDescriptor;
 import java.io.UnsupportedEncodingException;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
+import java.security.KeyManagementException;
 import java.security.PrivateKey;
 import java.security.Provider;
 import javax.net.ssl.SSLContextSpi;
@@ -28,6 +29,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Core API for creating and configuring all Conscrypt types.
@@ -54,6 +56,14 @@ public final class Conscrypt {
      */
     public static SSLContextSpi newPreferredSSLContextSpi() {
         return OpenSSLContextImpl.getPreferred();
+    }
+
+    /**
+     * Gets the default X.509 trust manager.
+     */
+    @ExperimentalApi
+    public static X509TrustManager getDefaultX509TrustManager() throws KeyManagementException {
+        return SSLParametersImpl.getDefaultX509TrustManager();
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -21,6 +21,7 @@ import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.security.PrivateKey;
 import java.security.Provider;
+import javax.net.ssl.SSLContextSpi;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
@@ -46,6 +47,13 @@ public final class Conscrypt {
      */
     public static Provider newProvider(String providerName) {
         return new OpenSSLProvider(providerName);
+    }
+
+    /**
+     * Constructs a new instance of the preferred {@link SSLContextSpi}.
+     */
+    public static SSLContextSpi newPreferredSSLContextSpi() {
+        return OpenSSLContextImpl.getPreferred();
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/CryptoUpcalls.java
+++ b/common/src/main/java/org/conscrypt/CryptoUpcalls.java
@@ -32,11 +32,8 @@ import javax.crypto.NoSuchPaddingException;
  * usually backed by hardware so we don't have access directly to the private
  * key material. If it were a key where we can get to the private key, we
  * would not ever call into this class.
- *
- * @hide
  */
-@Internal
-public final class CryptoUpcalls {
+final class CryptoUpcalls {
 
     private CryptoUpcalls() {
     }
@@ -61,7 +58,7 @@ public final class CryptoUpcalls {
         return providers;
     }
 
-    public static byte[] rawSignDigestWithPrivateKey(PrivateKey javaKey, byte[] message) {
+    static byte[] rawSignDigestWithPrivateKey(PrivateKey javaKey, byte[] message) {
         // Get the raw signature algorithm for this key type.
         String algorithm;
         // Hint: Algorithm names come from:
@@ -132,7 +129,7 @@ public final class CryptoUpcalls {
         }
     }
 
-    public static byte[] rsaDecryptWithPrivateKey(PrivateKey javaKey, int openSSLPadding,
+    static byte[] rsaDecryptWithPrivateKey(PrivateKey javaKey, int openSSLPadding,
             byte[] input) {
         String keyAlgorithm = javaKey.getAlgorithm();
         if (!"RSA".equals(keyAlgorithm)) {

--- a/common/src/main/java/org/conscrypt/DuckTypedPSKKeyManager.java
+++ b/common/src/main/java/org/conscrypt/DuckTypedPSKKeyManager.java
@@ -31,10 +31,9 @@ import javax.net.ssl.SSLEngine;
  * Visible for testing only.
  *
  * @deprecated This abstraction is deprecated because it does not work with TLS 1.3.
- * @hide
  */
 @Deprecated
-public class DuckTypedPSKKeyManager implements PSKKeyManager {
+final class DuckTypedPSKKeyManager implements PSKKeyManager {
 
     private final Object mDelegate;
 
@@ -49,7 +48,7 @@ public class DuckTypedPSKKeyManager implements PSKKeyManager {
      * @throws NoSuchMethodException if {@code obj} does not implement a method of the
      *         {@code PSKKeyManager} interface.
      */
-    public static DuckTypedPSKKeyManager getInstance(Object obj) throws NoSuchMethodException {
+    static DuckTypedPSKKeyManager getInstance(Object obj) throws NoSuchMethodException {
         Class<?> sourceClass = obj.getClass();
         for (Method targetMethod : PSKKeyManager.class.getMethods()) {
             if (targetMethod.isSynthetic()) {

--- a/common/src/main/java/org/conscrypt/EvpMdRef.java
+++ b/common/src/main/java/org/conscrypt/EvpMdRef.java
@@ -21,19 +21,16 @@ import java.util.Locale;
 
 /**
  * Utility class to convert between BoringSSL- and JCE-style message digest identifiers.
- *
- * @hide
  */
-@Internal
-public final class EvpMdRef {
-    public static final String MGF1_ALGORITHM_NAME = "MGF1";
-    public static final String MGF1_OID = "1.2.840.113549.1.1.8";
+final class EvpMdRef {
+    static final String MGF1_ALGORITHM_NAME = "MGF1";
+    static final String MGF1_OID = "1.2.840.113549.1.1.8";
 
     /**
      * Returns the canonical JCA digest algorithm name for the provided digest
      * algorithm name or {@code null} if the digest algorithm is not known.
      */
-    public static String getJcaDigestAlgorithmStandardName(String algorithm) {
+    static String getJcaDigestAlgorithmStandardName(String algorithm) {
         String algorithmUpper = algorithm.toUpperCase(Locale.US);
         if ((SHA256.JCA_NAME.equals(algorithmUpper)) || (SHA256.OID.equals(algorithmUpper))) {
             return SHA256.JCA_NAME;
@@ -53,7 +50,7 @@ public final class EvpMdRef {
         }
     }
 
-    public static long getEVP_MDByJcaDigestAlgorithmStandardName(String algorithm)
+    static long getEVP_MDByJcaDigestAlgorithmStandardName(String algorithm)
             throws NoSuchAlgorithmException {
         String algorithmUpper = algorithm.toUpperCase(Locale.US);
         if (SHA256.JCA_NAME.equals(algorithmUpper)) {
@@ -71,7 +68,7 @@ public final class EvpMdRef {
         }
     }
 
-    public static int getDigestSizeBytesByJcaDigestAlgorithmStandardName(String algorithm)
+    static int getDigestSizeBytesByJcaDigestAlgorithmStandardName(String algorithm)
             throws NoSuchAlgorithmException {
         String algorithmUpper = algorithm.toUpperCase(Locale.US);
         if (SHA256.JCA_NAME.equals(algorithmUpper)) {
@@ -89,7 +86,7 @@ public final class EvpMdRef {
         }
     }
 
-    public static String getJcaDigestAlgorithmStandardNameFromEVP_MD(long evpMdRef) {
+    static String getJcaDigestAlgorithmStandardNameFromEVP_MD(long evpMdRef) {
         if (evpMdRef == MD5.EVP_MD) {
             return MD5.JCA_NAME;
         } else if (evpMdRef == SHA1.EVP_MD) {
@@ -107,55 +104,55 @@ public final class EvpMdRef {
         }
     }
 
-    public static final class MD5 {
-        public static final String JCA_NAME = "MD5";
-        public static final String OID = "1.2.840.113549.2.5";
-        public static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("md5");
-        public static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
+    static final class MD5 {
+        static final String JCA_NAME = "MD5";
+        static final String OID = "1.2.840.113549.2.5";
+        static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("md5");
+        static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
 
         private MD5() {}
     }
 
-    public static final class SHA1 {
-        public static final String JCA_NAME = "SHA-1";
-        public static final String OID = "1.3.14.3.2.26";
-        public static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha1");
-        public static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
+    static final class SHA1 {
+        static final String JCA_NAME = "SHA-1";
+        static final String OID = "1.3.14.3.2.26";
+        static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha1");
+        static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
         private SHA1() {}
     }
 
-    public static final class SHA224 {
-        public static final String JCA_NAME = "SHA-224";
-        public static final String OID = "2.16.840.1.101.3.4.2.4";
-        public static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha224");
-        public static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
+    static final class SHA224 {
+        static final String JCA_NAME = "SHA-224";
+        static final String OID = "2.16.840.1.101.3.4.2.4";
+        static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha224");
+        static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
 
         private SHA224() {}
     }
 
-    public static final class SHA256 {
-        public static final String JCA_NAME = "SHA-256";
-        public static final String OID = "2.16.840.1.101.3.4.2.1";
-        public static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha256");
-        public static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
+    static final class SHA256 {
+        static final String JCA_NAME = "SHA-256";
+        static final String OID = "2.16.840.1.101.3.4.2.1";
+        static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha256");
+        static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
 
         private SHA256() {}
     }
 
-    public static final class SHA384 {
-        public static final String JCA_NAME = "SHA-384";
-        public static final String OID = "2.16.840.1.101.3.4.2.2";
-        public static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha384");
-        public static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
+    static final class SHA384 {
+        static final String JCA_NAME = "SHA-384";
+        static final String OID = "2.16.840.1.101.3.4.2.2";
+        static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha384");
+        static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
 
         private SHA384() {}
     }
 
-    public static final class SHA512 {
-        public static final String JCA_NAME = "SHA-512";
-        public static final String OID = "2.16.840.1.101.3.4.2.3";
-        public static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha512");
-        public static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
+    static final class SHA512 {
+        static final String JCA_NAME = "SHA-512";
+        static final String OID = "2.16.840.1.101.3.4.2.3";
+        static final long EVP_MD = NativeCrypto.EVP_get_digestbyname("sha512");
+        static final int SIZE_BYTES = NativeCrypto.EVP_MD_size(EVP_MD);
 
         private SHA512() {}
     }

--- a/common/src/main/java/org/conscrypt/FileClientSessionCache.java
+++ b/common/src/main/java/org/conscrypt/FileClientSessionCache.java
@@ -38,7 +38,7 @@ import javax.net.ssl.SSLSession;
  * @hide
  */
 @Internal
-public class FileClientSessionCache {
+public final class FileClientSessionCache {
     public static final int MAX_SIZE = 12; // ~72k
 
     private FileClientSessionCache() {}

--- a/common/src/main/java/org/conscrypt/GCMParameters.java
+++ b/common/src/main/java/org/conscrypt/GCMParameters.java
@@ -20,18 +20,15 @@ package org.conscrypt;
  * GCM parameters used during an ciphering operation with {@link OpenSSLCipher}.
  * This class exists solely for backward compatibility with Android versions
  * that did not have the {@code GCMParameterSpec} class.
- *
- * @hide
  */
-@Internal
-public class GCMParameters {
+final class GCMParameters {
     /** The tag length in bits. */
-    public final int tLen;
+    private final int tLen;
 
     /** Actually the nonce value for the GCM operation. */
-    public final byte[] iv;
+    private final byte[] iv;
 
-    public GCMParameters(int tLen, byte[] iv) {
+    GCMParameters(int tLen, byte[] iv) {
         this.tLen = tLen;
         this.iv = iv;
     }
@@ -39,14 +36,14 @@ public class GCMParameters {
     /**
      * Returns the tag length in bits.
      */
-    public int getTLen() {
+    int getTLen() {
         return tLen;
     }
 
     /**
      * Returns a non-cloned version of the IV.
      */
-    public byte[] getIV() {
+    byte[] getIV() {
         return iv;
     }
 }

--- a/common/src/main/java/org/conscrypt/KeyManagerFactoryImpl.java
+++ b/common/src/main/java/org/conscrypt/KeyManagerFactoryImpl.java
@@ -33,10 +33,8 @@ import javax.net.ssl.ManagerFactoryParameters;
 /**
  * KeyManagerFactory implementation.
  * @see KeyManagerFactorySpi
- * @hide
  */
-@Internal
-public class KeyManagerFactoryImpl extends KeyManagerFactorySpi {
+final class KeyManagerFactoryImpl extends KeyManagerFactorySpi {
 
     // source of key material
     private KeyStore keyStore;
@@ -113,5 +111,4 @@ public class KeyManagerFactoryImpl extends KeyManagerFactorySpi {
         }
         return new KeyManager[] { new KeyManagerImpl(keyStore, pwd) };
     }
-
 }

--- a/common/src/main/java/org/conscrypt/KeyManagerImpl.java
+++ b/common/src/main/java/org/conscrypt/KeyManagerImpl.java
@@ -45,10 +45,8 @@ import javax.security.auth.x500.X500Principal;
  * from socket or engine.
  *
  * @see javax.net.ssl.KeyManager
- * @hide
  */
-@Internal
-public class KeyManagerImpl extends X509ExtendedKeyManager {
+class KeyManagerImpl extends X509ExtendedKeyManager {
 
     // hashed key store information
     private final Hashtable<String, PrivateKeyEntry> hash;
@@ -59,7 +57,7 @@ public class KeyManagerImpl extends X509ExtendedKeyManager {
      * @param keyStore
      * @param pwd
      */
-    public KeyManagerImpl(KeyStore keyStore, char[] pwd) {
+    KeyManagerImpl(KeyStore keyStore, char[] pwd) {
         this.hash = new Hashtable<String, PrivateKeyEntry>();
         final Enumeration<String> aliases;
         try {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -46,8 +46,11 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * Provides the Java side of our JNI glue for OpenSSL.
+ *
+ * @hide
  */
-final class NativeCrypto {
+@Internal
+public final class NativeCrypto {
     // --- OpenSSL library initialization --------------------------------------
     static {
         NativeCryptoJni.init();
@@ -326,7 +329,8 @@ final class NativeCrypto {
     static int X509_NAME_hash(X500Principal principal) {
         return X509_NAME_hash(principal, "SHA1");
     }
-    static int X509_NAME_hash_old(X500Principal principal) {
+
+    public static int X509_NAME_hash_old(X500Principal principal) {
         return X509_NAME_hash(principal, "MD5");
     }
     private static int X509_NAME_hash(X500Principal principal, String algorithm) {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -46,12 +46,8 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * Provides the Java side of our JNI glue for OpenSSL.
- *
- * @hide
  */
-@Internal
-public final class NativeCrypto {
-
+final class NativeCrypto {
     // --- OpenSSL library initialization --------------------------------------
     static {
         NativeCryptoJni.init();
@@ -62,495 +58,486 @@ public final class NativeCrypto {
 
     // --- DSA/RSA public/private key handling functions -----------------------
 
-    public static native long EVP_PKEY_new_RSA(byte[] n, byte[] e, byte[] d, byte[] p, byte[] q,
+    static native long EVP_PKEY_new_RSA(byte[] n, byte[] e, byte[] d, byte[] p, byte[] q,
             byte[] dmp1, byte[] dmq1, byte[] iqmp);
 
-    public static native int EVP_PKEY_size(NativeRef.EVP_PKEY pkey);
+    static native int EVP_PKEY_size(NativeRef.EVP_PKEY pkey);
 
-    public static native int EVP_PKEY_type(NativeRef.EVP_PKEY pkey);
+    static native int EVP_PKEY_type(NativeRef.EVP_PKEY pkey);
 
-    public static native String EVP_PKEY_print_public(NativeRef.EVP_PKEY pkeyRef);
+    static native String EVP_PKEY_print_public(NativeRef.EVP_PKEY pkeyRef);
 
-    public static native String EVP_PKEY_print_params(NativeRef.EVP_PKEY pkeyRef);
+    static native String EVP_PKEY_print_params(NativeRef.EVP_PKEY pkeyRef);
 
-    public static native void EVP_PKEY_free(long pkey);
+    static native void EVP_PKEY_free(long pkey);
 
-    public static native int EVP_PKEY_cmp(NativeRef.EVP_PKEY pkey1, NativeRef.EVP_PKEY pkey2);
+    static native int EVP_PKEY_cmp(NativeRef.EVP_PKEY pkey1, NativeRef.EVP_PKEY pkey2);
 
-    public static native byte[] i2d_PKCS8_PRIV_KEY_INFO(NativeRef.EVP_PKEY pkey);
+    static native byte[] i2d_PKCS8_PRIV_KEY_INFO(NativeRef.EVP_PKEY pkey);
 
-    public static native long d2i_PKCS8_PRIV_KEY_INFO(byte[] data);
+    static native long d2i_PKCS8_PRIV_KEY_INFO(byte[] data);
 
-    public static native byte[] i2d_PUBKEY(NativeRef.EVP_PKEY pkey);
+    static native byte[] i2d_PUBKEY(NativeRef.EVP_PKEY pkey);
 
-    public static native long d2i_PUBKEY(byte[] data);
+    static native long d2i_PUBKEY(byte[] data);
 
-    public static native long PEM_read_bio_PUBKEY(long bioCtx);
+    static native long PEM_read_bio_PUBKEY(long bioCtx);
 
-    public static native long PEM_read_bio_PrivateKey(long bioCtx);
+    static native long PEM_read_bio_PrivateKey(long bioCtx);
 
-    public static native long getRSAPrivateKeyWrapper(PrivateKey key, byte[] modulus);
+    static native long getRSAPrivateKeyWrapper(PrivateKey key, byte[] modulus);
 
-    public static native long getECPrivateKeyWrapper(PrivateKey key,
-            NativeRef.EC_GROUP ecGroupRef);
+    static native long getECPrivateKeyWrapper(PrivateKey key, NativeRef.EC_GROUP ecGroupRef);
 
-    public static native long RSA_generate_key_ex(int modulusBits, byte[] publicExponent);
+    static native long RSA_generate_key_ex(int modulusBits, byte[] publicExponent);
 
-    public static native int RSA_size(NativeRef.EVP_PKEY pkey);
+    static native int RSA_size(NativeRef.EVP_PKEY pkey);
 
-    public static native int RSA_private_encrypt(int flen, byte[] from, byte[] to,
-            NativeRef.EVP_PKEY pkey, int padding);
+    static native int RSA_private_encrypt(
+            int flen, byte[] from, byte[] to, NativeRef.EVP_PKEY pkey, int padding);
 
-    public static native int RSA_public_decrypt(int flen, byte[] from, byte[] to,
-            NativeRef.EVP_PKEY pkey, int padding) throws BadPaddingException, SignatureException;
+    static native int RSA_public_decrypt(int flen, byte[] from, byte[] to, NativeRef.EVP_PKEY pkey,
+            int padding) throws BadPaddingException, SignatureException;
 
-    public static native int RSA_public_encrypt(int flen, byte[] from, byte[] to,
-            NativeRef.EVP_PKEY pkey, int padding);
+    static native int RSA_public_encrypt(
+            int flen, byte[] from, byte[] to, NativeRef.EVP_PKEY pkey, int padding);
 
-    public static native int RSA_private_decrypt(int flen, byte[] from, byte[] to,
-            NativeRef.EVP_PKEY pkey, int padding) throws BadPaddingException, SignatureException;
+    static native int RSA_private_decrypt(int flen, byte[] from, byte[] to, NativeRef.EVP_PKEY pkey,
+            int padding) throws BadPaddingException, SignatureException;
 
     /**
      * @return array of {n, e}
      */
-    public static native byte[][] get_RSA_public_params(NativeRef.EVP_PKEY rsa);
+    static native byte[][] get_RSA_public_params(NativeRef.EVP_PKEY rsa);
 
     /**
      * @return array of {n, e, d, p, q, dmp1, dmq1, iqmp}
      */
-    public static native byte[][] get_RSA_private_params(NativeRef.EVP_PKEY rsa);
+    static native byte[][] get_RSA_private_params(NativeRef.EVP_PKEY rsa);
 
-    public static native byte[] i2d_RSAPublicKey(NativeRef.EVP_PKEY rsa);
+    static native byte[] i2d_RSAPublicKey(NativeRef.EVP_PKEY rsa);
 
-    public static native byte[] i2d_RSAPrivateKey(NativeRef.EVP_PKEY rsa);
+    static native byte[] i2d_RSAPrivateKey(NativeRef.EVP_PKEY rsa);
 
     // --- EC functions --------------------------
 
-    public static native long EVP_PKEY_new_EC_KEY(NativeRef.EC_GROUP groupRef,
-            NativeRef.EC_POINT pubkeyRef, byte[] privkey);
+    static native long EVP_PKEY_new_EC_KEY(
+            NativeRef.EC_GROUP groupRef, NativeRef.EC_POINT pubkeyRef, byte[] privkey);
 
-    public static native long EC_GROUP_new_by_curve_name(String curveName);
+    static native long EC_GROUP_new_by_curve_name(String curveName);
 
-    public static native long EC_GROUP_new_arbitrary(byte[] p, byte[] a, byte[] b, byte[] x,
-                                                     byte[] y, byte[] order, int cofactor);
+    static native long EC_GROUP_new_arbitrary(
+            byte[] p, byte[] a, byte[] b, byte[] x, byte[] y, byte[] order, int cofactor);
 
-    public static native String EC_GROUP_get_curve_name(NativeRef.EC_GROUP groupRef);
+    static native String EC_GROUP_get_curve_name(NativeRef.EC_GROUP groupRef);
 
-    public static native byte[][] EC_GROUP_get_curve(NativeRef.EC_GROUP groupRef);
+    static native byte[][] EC_GROUP_get_curve(NativeRef.EC_GROUP groupRef);
 
-    public static native void EC_GROUP_clear_free(long groupRef);
+    static native void EC_GROUP_clear_free(long groupRef);
 
-    public static native long EC_GROUP_get_generator(NativeRef.EC_GROUP groupRef);
+    static native long EC_GROUP_get_generator(NativeRef.EC_GROUP groupRef);
 
-    public static native byte[] EC_GROUP_get_order(NativeRef.EC_GROUP groupRef);
+    static native byte[] EC_GROUP_get_order(NativeRef.EC_GROUP groupRef);
 
-    public static native int EC_GROUP_get_degree(NativeRef.EC_GROUP groupRef);
+    static native int EC_GROUP_get_degree(NativeRef.EC_GROUP groupRef);
 
-    public static native byte[] EC_GROUP_get_cofactor(NativeRef.EC_GROUP groupRef);
+    static native byte[] EC_GROUP_get_cofactor(NativeRef.EC_GROUP groupRef);
 
-    public static native long EC_POINT_new(NativeRef.EC_GROUP groupRef);
+    static native long EC_POINT_new(NativeRef.EC_GROUP groupRef);
 
-    public static native void EC_POINT_clear_free(long pointRef);
+    static native void EC_POINT_clear_free(long pointRef);
 
-    public static native byte[][] EC_POINT_get_affine_coordinates(NativeRef.EC_GROUP groupRef,
-            NativeRef.EC_POINT pointRef);
+    static native byte[][] EC_POINT_get_affine_coordinates(
+            NativeRef.EC_GROUP groupRef, NativeRef.EC_POINT pointRef);
 
-    public static native void EC_POINT_set_affine_coordinates(NativeRef.EC_GROUP groupRef,
-            NativeRef.EC_POINT pointRef, byte[] x, byte[] y);
+    static native void EC_POINT_set_affine_coordinates(
+            NativeRef.EC_GROUP groupRef, NativeRef.EC_POINT pointRef, byte[] x, byte[] y);
 
-    public static native long EC_KEY_generate_key(NativeRef.EC_GROUP groupRef);
+    static native long EC_KEY_generate_key(NativeRef.EC_GROUP groupRef);
 
-    public static native long EC_KEY_get1_group(NativeRef.EVP_PKEY pkeyRef);
+    static native long EC_KEY_get1_group(NativeRef.EVP_PKEY pkeyRef);
 
-    public static native byte[] EC_KEY_get_private_key(NativeRef.EVP_PKEY keyRef);
+    static native byte[] EC_KEY_get_private_key(NativeRef.EVP_PKEY keyRef);
 
-    public static native long EC_KEY_get_public_key(NativeRef.EVP_PKEY keyRef);
+    static native long EC_KEY_get_public_key(NativeRef.EVP_PKEY keyRef);
 
-    public static native int ECDH_compute_key(byte[] out, int outOffset,
-            NativeRef.EVP_PKEY publicKeyRef, NativeRef.EVP_PKEY privateKeyRef) throws
-            InvalidKeyException;
+    static native int ECDH_compute_key(byte[] out, int outOffset, NativeRef.EVP_PKEY publicKeyRef,
+            NativeRef.EVP_PKEY privateKeyRef) throws InvalidKeyException;
 
     // --- Message digest functions --------------
 
     // These return const references
-    public static native long EVP_get_digestbyname(String name);
+    static native long EVP_get_digestbyname(String name);
 
-    public static native int EVP_MD_size(long evp_md_const);
+    static native int EVP_MD_size(long evp_md_const);
 
-    public static native int EVP_MD_block_size(long evp_md_const);
+    static native int EVP_MD_block_size(long evp_md_const);
 
     // --- Message digest context functions --------------
 
-    public static native long EVP_MD_CTX_create();
+    static native long EVP_MD_CTX_create();
 
-    public static native void EVP_MD_CTX_cleanup(NativeRef.EVP_MD_CTX ctx);
+    static native void EVP_MD_CTX_cleanup(NativeRef.EVP_MD_CTX ctx);
 
-    public static native void EVP_MD_CTX_destroy(long ctx);
+    static native void EVP_MD_CTX_destroy(long ctx);
 
-    public static native int EVP_MD_CTX_copy_ex(NativeRef.EVP_MD_CTX dst_ctx,
-            NativeRef.EVP_MD_CTX src_ctx);
+    static native int EVP_MD_CTX_copy_ex(
+            NativeRef.EVP_MD_CTX dst_ctx, NativeRef.EVP_MD_CTX src_ctx);
 
     // --- Digest handling functions -------------------------------------------
 
-    public static native int EVP_DigestInit_ex(NativeRef.EVP_MD_CTX ctx, long evp_md);
+    static native int EVP_DigestInit_ex(NativeRef.EVP_MD_CTX ctx, long evp_md);
 
-    public static native void EVP_DigestUpdate(NativeRef.EVP_MD_CTX ctx,
-            byte[] buffer, int offset, int length);
+    static native void EVP_DigestUpdate(
+            NativeRef.EVP_MD_CTX ctx, byte[] buffer, int offset, int length);
 
-    public static native void EVP_DigestUpdateDirect(NativeRef.EVP_MD_CTX ctx,
-            long ptr, int length);
+    static native void EVP_DigestUpdateDirect(NativeRef.EVP_MD_CTX ctx, long ptr, int length);
 
-    public static native int EVP_DigestFinal_ex(NativeRef.EVP_MD_CTX ctx, byte[] hash,
-            int offset);
+    static native int EVP_DigestFinal_ex(NativeRef.EVP_MD_CTX ctx, byte[] hash, int offset);
 
     // --- Signature handling functions ----------------------------------------
 
-    public static native long EVP_DigestSignInit(NativeRef.EVP_MD_CTX ctx,
-            long evpMdRef, NativeRef.EVP_PKEY key);
+    static native long EVP_DigestSignInit(
+            NativeRef.EVP_MD_CTX ctx, long evpMdRef, NativeRef.EVP_PKEY key);
 
-    public static native long EVP_DigestVerifyInit(NativeRef.EVP_MD_CTX ctx,
-            long evpMdRef, NativeRef.EVP_PKEY key);
+    static native long EVP_DigestVerifyInit(
+            NativeRef.EVP_MD_CTX ctx, long evpMdRef, NativeRef.EVP_PKEY key);
 
-    public static native void EVP_DigestSignUpdate(NativeRef.EVP_MD_CTX ctx,
-            byte[] buffer, int offset, int length);
+    static native void EVP_DigestSignUpdate(
+            NativeRef.EVP_MD_CTX ctx, byte[] buffer, int offset, int length);
 
-    public static native void EVP_DigestSignUpdateDirect(NativeRef.EVP_MD_CTX ctx,
-            long ptr, int length);
+    static native void EVP_DigestSignUpdateDirect(NativeRef.EVP_MD_CTX ctx, long ptr, int length);
 
-    public static native void EVP_DigestVerifyUpdate(NativeRef.EVP_MD_CTX ctx,
-            byte[] buffer, int offset, int length);
+    static native void EVP_DigestVerifyUpdate(
+            NativeRef.EVP_MD_CTX ctx, byte[] buffer, int offset, int length);
 
-    public static native void EVP_DigestVerifyUpdateDirect(NativeRef.EVP_MD_CTX ctx,
-            long ptr, int length);
+    static native void EVP_DigestVerifyUpdateDirect(NativeRef.EVP_MD_CTX ctx, long ptr, int length);
 
-    public static native byte[] EVP_DigestSignFinal(NativeRef.EVP_MD_CTX ctx);
+    static native byte[] EVP_DigestSignFinal(NativeRef.EVP_MD_CTX ctx);
 
-    public static native boolean EVP_DigestVerifyFinal(NativeRef.EVP_MD_CTX ctx,
-            byte[] signature, int offset, int length);
+    static native boolean EVP_DigestVerifyFinal(
+            NativeRef.EVP_MD_CTX ctx, byte[] signature, int offset, int length);
 
-    public static native long EVP_PKEY_encrypt_init(NativeRef.EVP_PKEY pkey);
+    static native long EVP_PKEY_encrypt_init(NativeRef.EVP_PKEY pkey);
 
-    public static native int EVP_PKEY_encrypt(NativeRef.EVP_PKEY_CTX ctx, byte[] out, int outOffset,
+    static native int EVP_PKEY_encrypt(NativeRef.EVP_PKEY_CTX ctx, byte[] out, int outOffset,
             byte[] input, int inOffset, int inLength);
 
-    public static native long EVP_PKEY_decrypt_init(NativeRef.EVP_PKEY pkey);
+    static native long EVP_PKEY_decrypt_init(NativeRef.EVP_PKEY pkey);
 
-    public static native int EVP_PKEY_decrypt(NativeRef.EVP_PKEY_CTX ctx, byte[] out, int outOffset,
+    static native int EVP_PKEY_decrypt(NativeRef.EVP_PKEY_CTX ctx, byte[] out, int outOffset,
             byte[] input, int inOffset, int inLength);
 
-    public static native void EVP_PKEY_CTX_free(long pkeyCtx);
+    static native void EVP_PKEY_CTX_free(long pkeyCtx);
 
-    public static native void EVP_PKEY_CTX_set_rsa_padding(long ctx, int pad)
+    static native void EVP_PKEY_CTX_set_rsa_padding(long ctx, int pad)
             throws InvalidAlgorithmParameterException;
 
-    public static native void EVP_PKEY_CTX_set_rsa_pss_saltlen(long ctx, int len)
+    static native void EVP_PKEY_CTX_set_rsa_pss_saltlen(long ctx, int len)
             throws InvalidAlgorithmParameterException;
 
-    public static native void EVP_PKEY_CTX_set_rsa_mgf1_md(long ctx, long evpMdRef)
+    static native void EVP_PKEY_CTX_set_rsa_mgf1_md(long ctx, long evpMdRef)
             throws InvalidAlgorithmParameterException;
 
-    public static native void EVP_PKEY_CTX_set_rsa_oaep_md(long ctx, long evpMdRef)
+    static native void EVP_PKEY_CTX_set_rsa_oaep_md(long ctx, long evpMdRef)
             throws InvalidAlgorithmParameterException;
 
-    public static native void EVP_PKEY_CTX_set_rsa_oaep_label(long ctx, byte[] label)
+    static native void EVP_PKEY_CTX_set_rsa_oaep_label(long ctx, byte[] label)
             throws InvalidAlgorithmParameterException;
 
     // --- Block ciphers -------------------------------------------------------
 
     // These return const references
-    public static native long EVP_get_cipherbyname(String string);
+    static native long EVP_get_cipherbyname(String string);
 
-    public static native void EVP_CipherInit_ex(NativeRef.EVP_CIPHER_CTX ctx, long evpCipher,
-            byte[] key, byte[] iv, boolean encrypting);
+    static native void EVP_CipherInit_ex(NativeRef.EVP_CIPHER_CTX ctx, long evpCipher, byte[] key,
+            byte[] iv, boolean encrypting);
 
-    public static native int EVP_CipherUpdate(NativeRef.EVP_CIPHER_CTX ctx, byte[] out,
-            int outOffset, byte[] in, int inOffset, int inLength);
+    static native int EVP_CipherUpdate(NativeRef.EVP_CIPHER_CTX ctx, byte[] out, int outOffset,
+            byte[] in, int inOffset, int inLength);
 
-    public static native int EVP_CipherFinal_ex(NativeRef.EVP_CIPHER_CTX ctx, byte[] out,
-            int outOffset) throws BadPaddingException, IllegalBlockSizeException;
+    static native int EVP_CipherFinal_ex(NativeRef.EVP_CIPHER_CTX ctx, byte[] out, int outOffset)
+            throws BadPaddingException, IllegalBlockSizeException;
 
-    public static native int EVP_CIPHER_iv_length(long evpCipher);
+    static native int EVP_CIPHER_iv_length(long evpCipher);
 
-    public static native long EVP_CIPHER_CTX_new();
+    static native long EVP_CIPHER_CTX_new();
 
-    public static native int EVP_CIPHER_CTX_block_size(NativeRef.EVP_CIPHER_CTX ctx);
+    static native int EVP_CIPHER_CTX_block_size(NativeRef.EVP_CIPHER_CTX ctx);
 
-    public static native int get_EVP_CIPHER_CTX_buf_len(NativeRef.EVP_CIPHER_CTX ctx);
+    static native int get_EVP_CIPHER_CTX_buf_len(NativeRef.EVP_CIPHER_CTX ctx);
 
-    public static native boolean get_EVP_CIPHER_CTX_final_used(NativeRef.EVP_CIPHER_CTX ctx);
+    static native boolean get_EVP_CIPHER_CTX_final_used(NativeRef.EVP_CIPHER_CTX ctx);
 
-    public static native void EVP_CIPHER_CTX_set_padding(NativeRef.EVP_CIPHER_CTX ctx,
-            boolean enablePadding);
+    static native void EVP_CIPHER_CTX_set_padding(
+            NativeRef.EVP_CIPHER_CTX ctx, boolean enablePadding);
 
-    public static native void EVP_CIPHER_CTX_set_key_length(NativeRef.EVP_CIPHER_CTX ctx,
-            int keyBitSize);
+    static native void EVP_CIPHER_CTX_set_key_length(NativeRef.EVP_CIPHER_CTX ctx, int keyBitSize);
 
-    public static native void EVP_CIPHER_CTX_free(long ctx);
+    static native void EVP_CIPHER_CTX_free(long ctx);
 
     // --- AEAD ----------------------------------------------------------------
-    public static native long EVP_aead_aes_128_gcm();
+    static native long EVP_aead_aes_128_gcm();
 
-    public static native long EVP_aead_aes_256_gcm();
+    static native long EVP_aead_aes_256_gcm();
 
-    public static native int EVP_AEAD_max_overhead(long evpAead);
+    static native int EVP_AEAD_max_overhead(long evpAead);
 
-    public static native int EVP_AEAD_nonce_length(long evpAead);
+    static native int EVP_AEAD_nonce_length(long evpAead);
 
-    public static native int EVP_AEAD_max_tag_len(long evpAead);
+    static native int EVP_AEAD_max_tag_len(long evpAead);
 
-    public static native int EVP_AEAD_CTX_seal(long evpAead, byte[] key, int tagLengthInBytes,
-            byte[] out, int outOffset, byte[] nonce, byte[] in, int inOffset, int inLength,
-            byte[] ad) throws BadPaddingException;
+    static native int EVP_AEAD_CTX_seal(long evpAead, byte[] key, int tagLengthInBytes, byte[] out,
+            int outOffset, byte[] nonce, byte[] in, int inOffset, int inLength, byte[] ad)
+            throws BadPaddingException;
 
-    public static native int EVP_AEAD_CTX_open(long evpAead, byte[] key, int tagLengthInBytes,
-            byte[] out, int outOffset, byte[] nonce, byte[] in, int inOffset, int inLength,
-            byte[] ad) throws BadPaddingException;
+    static native int EVP_AEAD_CTX_open(long evpAead, byte[] key, int tagLengthInBytes, byte[] out,
+            int outOffset, byte[] nonce, byte[] in, int inOffset, int inLength, byte[] ad)
+            throws BadPaddingException;
 
     // --- HMAC functions ------------------------------------------------------
 
-    public static native long HMAC_CTX_new();
+    static native long HMAC_CTX_new();
 
-    public static native void HMAC_CTX_free(long ctx);
+    static native void HMAC_CTX_free(long ctx);
 
-    public static native void HMAC_Init_ex(NativeRef.HMAC_CTX ctx, byte[] key, long evp_md);
+    static native void HMAC_Init_ex(NativeRef.HMAC_CTX ctx, byte[] key, long evp_md);
 
-    public static native void HMAC_Update(NativeRef.HMAC_CTX ctx, byte[] in, int inOffset, int inLength);
+    static native void HMAC_Update(NativeRef.HMAC_CTX ctx, byte[] in, int inOffset, int inLength);
 
-    public static native void HMAC_UpdateDirect(NativeRef.HMAC_CTX ctx, long inPtr, int inLength);
+    static native void HMAC_UpdateDirect(NativeRef.HMAC_CTX ctx, long inPtr, int inLength);
 
-    public static native byte[] HMAC_Final(NativeRef.HMAC_CTX ctx);
+    static native byte[] HMAC_Final(NativeRef.HMAC_CTX ctx);
 
     // --- RAND ----------------------------------------------------------------
 
-    public static native void RAND_bytes(byte[] output);
+    static native void RAND_bytes(byte[] output);
 
     // --- ASN.1 objects -------------------------------------------------------
 
-    public static native int OBJ_txt2nid(String oid);
+    static native int OBJ_txt2nid(String oid);
 
-    public static native String OBJ_txt2nid_longName(String oid);
+    static native String OBJ_txt2nid_longName(String oid);
 
-    public static native String OBJ_txt2nid_oid(String oid);
+    static native String OBJ_txt2nid_oid(String oid);
 
     // --- X509_NAME -----------------------------------------------------------
 
-    public static int X509_NAME_hash(X500Principal principal) {
+    static int X509_NAME_hash(X500Principal principal) {
         return X509_NAME_hash(principal, "SHA1");
     }
-    public static int X509_NAME_hash_old(X500Principal principal) {
+    static int X509_NAME_hash_old(X500Principal principal) {
         return X509_NAME_hash(principal, "MD5");
     }
     private static int X509_NAME_hash(X500Principal principal, String algorithm) {
         try {
             byte[] digest = MessageDigest.getInstance(algorithm).digest(principal.getEncoded());
             int offset = 0;
-            return (((digest[offset++] & 0xff) <<  0) |
-                    ((digest[offset++] & 0xff) <<  8) |
-                    ((digest[offset++] & 0xff) << 16) |
-                    ((digest[offset  ] & 0xff) << 24));
+            return (((digest[offset++] & 0xff) << 0) | ((digest[offset++] & 0xff) << 8)
+                    | ((digest[offset++] & 0xff) << 16) | ((digest[offset] & 0xff) << 24));
         } catch (NoSuchAlgorithmException e) {
             throw new AssertionError(e);
         }
     }
 
-    public static native String X509_NAME_print_ex(long x509nameCtx, long flags);
+    static native String X509_NAME_print_ex(long x509nameCtx, long flags);
 
     // --- X509 ----------------------------------------------------------------
 
     /** Used to request get_X509_GENERAL_NAME_stack get the "altname" field. */
-    public static final int GN_STACK_SUBJECT_ALT_NAME = 1;
+    static final int GN_STACK_SUBJECT_ALT_NAME = 1;
 
     /**
      * Used to request get_X509_GENERAL_NAME_stack get the issuerAlternativeName
      * extension.
      */
-    public static final int GN_STACK_ISSUER_ALT_NAME = 2;
+    static final int GN_STACK_ISSUER_ALT_NAME = 2;
 
     /**
      * Used to request only non-critical types in get_X509*_ext_oids.
      */
-    public static final int EXTENSION_TYPE_NON_CRITICAL = 0;
+    static final int EXTENSION_TYPE_NON_CRITICAL = 0;
 
     /**
      * Used to request only critical types in get_X509*_ext_oids.
      */
-    public static final int EXTENSION_TYPE_CRITICAL = 1;
+    static final int EXTENSION_TYPE_CRITICAL = 1;
 
-    public static native long d2i_X509_bio(long bioCtx);
+    static native long d2i_X509_bio(long bioCtx);
 
-    public static native long d2i_X509(byte[] encoded) throws ParsingException;
+    static native long d2i_X509(byte[] encoded) throws ParsingException;
 
-    public static native long PEM_read_bio_X509(long bioCtx);
+    static native long PEM_read_bio_X509(long bioCtx);
 
-    public static native byte[] i2d_X509(long x509ctx);
+    static native byte[] i2d_X509(long x509ctx);
 
     /** Takes an X509 context not an X509_PUBKEY context. */
-    public static native byte[] i2d_X509_PUBKEY(long x509ctx);
+    static native byte[] i2d_X509_PUBKEY(long x509ctx);
 
-    public static native byte[] ASN1_seq_pack_X509(long[] x509CertRefs);
+    static native byte[] ASN1_seq_pack_X509(long[] x509CertRefs);
 
-    public static native long[] ASN1_seq_unpack_X509_bio(long bioRef);
+    static native long[] ASN1_seq_unpack_X509_bio(long bioRef);
 
-    public static native void X509_free(long x509ctx);
+    static native void X509_free(long x509ctx);
 
-    public static native long X509_dup(long x509ctx);
+    static native long X509_dup(long x509ctx);
 
-    public static native int X509_cmp(long x509ctx1, long x509ctx2);
+    static native int X509_cmp(long x509ctx1, long x509ctx2);
 
-    public static native void X509_print_ex(long bioCtx, long x509ctx, long nmflag, long certflag);
+    static native void X509_print_ex(long bioCtx, long x509ctx, long nmflag, long certflag);
 
-    public static native byte[] X509_get_issuer_name(long x509ctx);
+    static native byte[] X509_get_issuer_name(long x509ctx);
 
-    public static native byte[] X509_get_subject_name(long x509ctx);
+    static native byte[] X509_get_subject_name(long x509ctx);
 
-    public static native String get_X509_sig_alg_oid(long x509ctx);
+    static native String get_X509_sig_alg_oid(long x509ctx);
 
-    public static native byte[] get_X509_sig_alg_parameter(long x509ctx);
+    static native byte[] get_X509_sig_alg_parameter(long x509ctx);
 
-    public static native boolean[] get_X509_issuerUID(long x509ctx);
+    static native boolean[] get_X509_issuerUID(long x509ctx);
 
-    public static native boolean[] get_X509_subjectUID(long x509ctx);
+    static native boolean[] get_X509_subjectUID(long x509ctx);
 
-    public static native long X509_get_pubkey(long x509ctx) throws NoSuchAlgorithmException,
-           InvalidKeyException;
+    static native long X509_get_pubkey(long x509ctx)
+            throws NoSuchAlgorithmException, InvalidKeyException;
 
-    public static native String get_X509_pubkey_oid(long x509ctx);
+    static native String get_X509_pubkey_oid(long x509ctx);
 
-    public static native byte[] X509_get_ext_oid(long x509ctx, String oid);
+    static native byte[] X509_get_ext_oid(long x509ctx, String oid);
 
-    public static native String[] get_X509_ext_oids(long x509ctx, int critical);
+    static native String[] get_X509_ext_oids(long x509ctx, int critical);
 
-    public static native Object[][] get_X509_GENERAL_NAME_stack(long x509ctx, int type)
+    static native Object[][] get_X509_GENERAL_NAME_stack(long x509ctx, int type)
             throws CertificateParsingException;
 
-    public static native boolean[] get_X509_ex_kusage(long x509ctx);
+    static native boolean[] get_X509_ex_kusage(long x509ctx);
 
-    public static native String[] get_X509_ex_xkusage(long x509ctx);
+    static native String[] get_X509_ex_xkusage(long x509ctx);
 
-    public static native int get_X509_ex_pathlen(long x509ctx);
+    static native int get_X509_ex_pathlen(long x509ctx);
 
-    public static native long X509_get_notBefore(long x509ctx);
+    static native long X509_get_notBefore(long x509ctx);
 
-    public static native long X509_get_notAfter(long x509ctx);
+    static native long X509_get_notAfter(long x509ctx);
 
-    public static native long X509_get_version(long x509ctx);
+    static native long X509_get_version(long x509ctx);
 
-    public static native byte[] X509_get_serialNumber(long x509ctx);
+    static native byte[] X509_get_serialNumber(long x509ctx);
 
-    public static native void X509_verify(long x509ctx, NativeRef.EVP_PKEY pkeyCtx)
+    static native void X509_verify(long x509ctx, NativeRef.EVP_PKEY pkeyCtx)
             throws BadPaddingException;
 
-    public static native byte[] get_X509_cert_info_enc(long x509ctx);
+    static native byte[] get_X509_cert_info_enc(long x509ctx);
 
-    public static native byte[] get_X509_signature(long x509ctx);
+    static native byte[] get_X509_signature(long x509ctx);
 
-    public static native int get_X509_ex_flags(long x509ctx);
+    static native int get_X509_ex_flags(long x509ctx);
 
-    public static native int X509_check_issued(long ctx, long ctx2);
+    static native int X509_check_issued(long ctx, long ctx2);
 
     // --- PKCS7 ---------------------------------------------------------------
 
     /** Used as the "which" field in d2i_PKCS7_bio and PEM_read_bio_PKCS7. */
-    public static final int PKCS7_CERTS = 1;
+    static final int PKCS7_CERTS = 1;
 
     /** Used as the "which" field in d2i_PKCS7_bio and PEM_read_bio_PKCS7. */
-    public static final int PKCS7_CRLS = 2;
+    static final int PKCS7_CRLS = 2;
 
     /** Returns an array of X509 or X509_CRL pointers. */
-    public static native long[] d2i_PKCS7_bio(long bioCtx, int which);
+    static native long[] d2i_PKCS7_bio(long bioCtx, int which);
 
     /** Returns an array of X509 or X509_CRL pointers. */
-    public static native byte[] i2d_PKCS7(long[] certs);
+    static native byte[] i2d_PKCS7(long[] certs);
 
     /** Returns an array of X509 or X509_CRL pointers. */
-    public static native long[] PEM_read_bio_PKCS7(long bioCtx, int which);
+    static native long[] PEM_read_bio_PKCS7(long bioCtx, int which);
 
     // --- X509_CRL ------------------------------------------------------------
 
-    public static native long d2i_X509_CRL_bio(long bioCtx);
+    static native long d2i_X509_CRL_bio(long bioCtx);
 
-    public static native long PEM_read_bio_X509_CRL(long bioCtx);
+    static native long PEM_read_bio_X509_CRL(long bioCtx);
 
-    public static native byte[] i2d_X509_CRL(long x509CrlCtx);
+    static native byte[] i2d_X509_CRL(long x509CrlCtx);
 
-    public static native void X509_CRL_free(long x509CrlCtx);
+    static native void X509_CRL_free(long x509CrlCtx);
 
-    public static native void X509_CRL_print(long bioCtx, long x509CrlCtx);
+    static native void X509_CRL_print(long bioCtx, long x509CrlCtx);
 
-    public static native String get_X509_CRL_sig_alg_oid(long x509CrlCtx);
+    static native String get_X509_CRL_sig_alg_oid(long x509CrlCtx);
 
-    public static native byte[] get_X509_CRL_sig_alg_parameter(long x509CrlCtx);
+    static native byte[] get_X509_CRL_sig_alg_parameter(long x509CrlCtx);
 
-    public static native byte[] X509_CRL_get_issuer_name(long x509CrlCtx);
-
-    /** Returns X509_REVOKED reference that is not duplicated! */
-    public static native long X509_CRL_get0_by_cert(long x509CrlCtx, long x509Ctx);
+    static native byte[] X509_CRL_get_issuer_name(long x509CrlCtx);
 
     /** Returns X509_REVOKED reference that is not duplicated! */
-    public static native long X509_CRL_get0_by_serial(long x509CrlCtx, byte[] serial);
+    static native long X509_CRL_get0_by_cert(long x509CrlCtx, long x509Ctx);
+
+    /** Returns X509_REVOKED reference that is not duplicated! */
+    static native long X509_CRL_get0_by_serial(long x509CrlCtx, byte[] serial);
 
     /** Returns an array of X509_REVOKED that are owned by the caller. */
-    public static native long[] X509_CRL_get_REVOKED(long x509CrlCtx);
+    static native long[] X509_CRL_get_REVOKED(long x509CrlCtx);
 
-    public static native String[] get_X509_CRL_ext_oids(long x509ctx, int critical);
+    static native String[] get_X509_CRL_ext_oids(long x509ctx, int critical);
 
-    public static native byte[] X509_CRL_get_ext_oid(long x509CrlCtx, String oid);
+    static native byte[] X509_CRL_get_ext_oid(long x509CrlCtx, String oid);
 
-    public static native void X509_delete_ext(long x509, String oid);
+    static native void X509_delete_ext(long x509, String oid);
 
-    public static native long X509_CRL_get_version(long x509CrlCtx);
+    static native long X509_CRL_get_version(long x509CrlCtx);
 
-    public static native long X509_CRL_get_ext(long x509CrlCtx, String oid);
+    static native long X509_CRL_get_ext(long x509CrlCtx, String oid);
 
-    public static native byte[] get_X509_CRL_signature(long x509ctx);
+    static native byte[] get_X509_CRL_signature(long x509ctx);
 
-    public static native void X509_CRL_verify(long x509CrlCtx, NativeRef.EVP_PKEY pkeyCtx);
+    static native void X509_CRL_verify(long x509CrlCtx, NativeRef.EVP_PKEY pkeyCtx);
 
-    public static native byte[] get_X509_CRL_crl_enc(long x509CrlCtx);
+    static native byte[] get_X509_CRL_crl_enc(long x509CrlCtx);
 
-    public static native long X509_CRL_get_lastUpdate(long x509CrlCtx);
+    static native long X509_CRL_get_lastUpdate(long x509CrlCtx);
 
-    public static native long X509_CRL_get_nextUpdate(long x509CrlCtx);
+    static native long X509_CRL_get_nextUpdate(long x509CrlCtx);
 
     // --- X509_REVOKED --------------------------------------------------------
 
-    public static native long X509_REVOKED_dup(long x509RevokedCtx);
+    static native long X509_REVOKED_dup(long x509RevokedCtx);
 
-    public static native byte[] i2d_X509_REVOKED(long x509RevokedCtx);
+    static native byte[] i2d_X509_REVOKED(long x509RevokedCtx);
 
-    public static native String[] get_X509_REVOKED_ext_oids(long x509ctx, int critical);
+    static native String[] get_X509_REVOKED_ext_oids(long x509ctx, int critical);
 
-    public static native byte[] X509_REVOKED_get_ext_oid(long x509RevokedCtx, String oid);
+    static native byte[] X509_REVOKED_get_ext_oid(long x509RevokedCtx, String oid);
 
-    public static native byte[] X509_REVOKED_get_serialNumber(long x509RevokedCtx);
+    static native byte[] X509_REVOKED_get_serialNumber(long x509RevokedCtx);
 
-    public static native long X509_REVOKED_get_ext(long x509RevokedCtx, String oid);
+    static native long X509_REVOKED_get_ext(long x509RevokedCtx, String oid);
 
     /** Returns ASN1_TIME reference. */
-    public static native long get_X509_REVOKED_revocationDate(long x509RevokedCtx);
+    static native long get_X509_REVOKED_revocationDate(long x509RevokedCtx);
 
-    public static native void X509_REVOKED_print(long bioRef, long x509RevokedCtx);
+    static native void X509_REVOKED_print(long bioRef, long x509RevokedCtx);
 
     // --- X509_EXTENSION ------------------------------------------------------
 
-    public static native int X509_supported_extension(long x509ExtensionRef);
+    static native int X509_supported_extension(long x509ExtensionRef);
 
     // --- ASN1_TIME -----------------------------------------------------------
 
-    public static native void ASN1_TIME_to_Calendar(long asn1TimeCtx, Calendar cal);
+    static native void ASN1_TIME_to_Calendar(long asn1TimeCtx, Calendar cal);
 
     // --- BIO stream creation -------------------------------------------------
 
-    public static native long create_BIO_InputStream(OpenSSLBIOInputStream is, boolean isFinite);
+    static native long create_BIO_InputStream(OpenSSLBIOInputStream is, boolean isFinite);
 
-    public static native long create_BIO_OutputStream(OutputStream os);
+    static native long create_BIO_OutputStream(OutputStream os);
 
-    public static native int BIO_read(long bioRef, byte[] buffer);
+    static native int BIO_read(long bioRef, byte[] buffer);
 
-    public static native void BIO_write(long bioRef, byte[] buffer, int offset, int length)
+    static native void BIO_write(long bioRef, byte[] buffer, int offset, int length)
             throws IOException;
 
-    public static native void BIO_free_all(long bioRef);
+    static native void BIO_free_all(long bioRef);
 
     // --- SSL handling --------------------------------------------------------
 
@@ -562,18 +549,18 @@ public final class NativeCrypto {
     // STANDARD_TO_OPENSSL_CIPHER_SUITES is a map from OpenSSL-style
     // cipher-suite names to the standard name for the same (i.e. the name that
     // is registered with IANA).
-    public static final Map<String, String> OPENSSL_TO_STANDARD_CIPHER_SUITES
-            = new HashMap<String, String>();
+    static final Map<String, String> OPENSSL_TO_STANDARD_CIPHER_SUITES =
+            new HashMap<String, String>();
 
     // STANDARD_TO_OPENSSL_CIPHER_SUITES is a map from "standard" cipher suite
     // names (i.e. the names that are registered with IANA) to the
     // OpenSSL-style name for the same.
-    public static final Map<String, String> STANDARD_TO_OPENSSL_CIPHER_SUITES
-            = new LinkedHashMap<String, String>();
+    static final Map<String, String> STANDARD_TO_OPENSSL_CIPHER_SUITES =
+            new LinkedHashMap<String, String>();
 
     // SUPPORTED_CIPHER_SUITES_SET contains all the cipher suites supported by
     // OpenSSL, named using "standard" (as opposed to OpenSSL-style) names.
-    public static final Set<String> SUPPORTED_CIPHER_SUITES_SET = new HashSet<String>();
+    static final Set<String> SUPPORTED_CIPHER_SUITES_SET = new HashSet<String>();
 
     private static void add(String openssl, String standard) {
         OPENSSL_TO_STANDARD_CIPHER_SUITES.put(openssl, standard);
@@ -599,8 +586,7 @@ public final class NativeCrypto {
      * be passed for compatibility as to provide the hint that we
      * support secure renegotiation.
      */
-    public static final String TLS_EMPTY_RENEGOTIATION_INFO_SCSV
-            = "TLS_EMPTY_RENEGOTIATION_INFO_SCSV";
+    static final String TLS_EMPTY_RENEGOTIATION_INFO_SCSV = "TLS_EMPTY_RENEGOTIATION_INFO_SCSV";
 
     /**
      * TLS_FALLBACK_SCSV is from
@@ -608,78 +594,78 @@ public final class NativeCrypto {
      * to indicate to the server that this is a fallback protocol
      * request.
      */
-    public static final String TLS_FALLBACK_SCSV = "TLS_FALLBACK_SCSV";
+    static final String TLS_FALLBACK_SCSV = "TLS_FALLBACK_SCSV";
 
     static {
-        add("ADH-AES128-GCM-SHA256",		"TLS_DH_anon_WITH_AES_128_GCM_SHA256");
-        add("ADH-AES128-SHA256",		"TLS_DH_anon_WITH_AES_128_CBC_SHA256");
-        add("ADH-AES128-SHA",			"TLS_DH_anon_WITH_AES_128_CBC_SHA");
-        add("ADH-AES256-GCM-SHA384",		"TLS_DH_anon_WITH_AES_256_GCM_SHA384");
-        add("ADH-AES256-SHA256",		"TLS_DH_anon_WITH_AES_256_CBC_SHA256");
-        add("ADH-AES256-SHA",			"TLS_DH_anon_WITH_AES_256_CBC_SHA");
-        add("ADH-DES-CBC3-SHA",			"SSL_DH_anon_WITH_3DES_EDE_CBC_SHA");
-        add("ADH-DES-CBC-SHA",			"SSL_DH_anon_WITH_DES_CBC_SHA");
-        add("AECDH-AES128-SHA",			"TLS_ECDH_anon_WITH_AES_128_CBC_SHA");
-        add("AECDH-AES256-SHA",			"TLS_ECDH_anon_WITH_AES_256_CBC_SHA");
-        add("AECDH-DES-CBC3-SHA",		"TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA");
-        add("AECDH-NULL-SHA",			"TLS_ECDH_anon_WITH_NULL_SHA");
-        add("AES128-GCM-SHA256",		"TLS_RSA_WITH_AES_128_GCM_SHA256");
-        add("AES128-SHA256",			"TLS_RSA_WITH_AES_128_CBC_SHA256");
-        add("AES128-SHA",			"TLS_RSA_WITH_AES_128_CBC_SHA");
-        add("AES256-GCM-SHA384",		"TLS_RSA_WITH_AES_256_GCM_SHA384");
-        add("AES256-SHA256",			"TLS_RSA_WITH_AES_256_CBC_SHA256");
-        add("AES256-SHA",			"TLS_RSA_WITH_AES_256_CBC_SHA");
-        add("DES-CBC3-SHA",			"SSL_RSA_WITH_3DES_EDE_CBC_SHA");
-        add("DES-CBC-SHA",			"SSL_RSA_WITH_DES_CBC_SHA");
-        add("ECDH-ECDSA-AES128-GCM-SHA256",    	"TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256");
-        add("ECDH-ECDSA-AES128-SHA256",		"TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256");
-        add("ECDH-ECDSA-AES128-SHA",		"TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA");
-        add("ECDH-ECDSA-AES256-GCM-SHA384",    	"TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384");
-        add("ECDH-ECDSA-AES256-SHA384",		"TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384");
-        add("ECDH-ECDSA-AES256-SHA",		"TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA");
-        add("ECDH-ECDSA-DES-CBC3-SHA",		"TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA");
-        add("ECDH-ECDSA-NULL-SHA",		"TLS_ECDH_ECDSA_WITH_NULL_SHA");
-        add("ECDHE-ECDSA-AES128-GCM-SHA256",   	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
-        add("ECDHE-ECDSA-AES128-SHA256",	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256");
-        add("ECDHE-ECDSA-AES128-SHA",		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA");
-        add("ECDHE-ECDSA-AES256-GCM-SHA384",   	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384");
-        add("ECDHE-ECDSA-AES256-SHA384",	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384");
-        add("ECDHE-ECDSA-AES256-SHA",		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA");
-        add("ECDHE-ECDSA-CHACHA20-POLY1305",   	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305");
-        add("ECDHE-ECDSA-CHACHA20-POLY1305",	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256");
-        add("ECDHE-ECDSA-DES-CBC3-SHA",		"TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA");
-        add("ECDHE-ECDSA-NULL-SHA",		"TLS_ECDHE_ECDSA_WITH_NULL_SHA");
-        add("ECDHE-PSK-AES128-CBC-SHA",		"TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA");
-        add("ECDHE-PSK-AES128-GCM-SHA256",     	"TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256");
-        add("ECDHE-PSK-AES256-CBC-SHA",		"TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA");
-        add("ECDHE-PSK-AES256-GCM-SHA384",     	"TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384");
-        add("ECDHE-PSK-CHACHA20-POLY1305",	"TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256");
-        add("ECDHE-RSA-AES128-GCM-SHA256",     	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
-        add("ECDHE-RSA-AES128-SHA256",		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256");
-        add("ECDHE-RSA-AES128-SHA",		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA");
-        add("ECDHE-RSA-AES256-GCM-SHA384",     	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
-        add("ECDHE-RSA-AES256-SHA384",		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384");
-        add("ECDHE-RSA-AES256-SHA",		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
-        add("ECDHE-RSA-CHACHA20-POLY1305",     	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305");
-        add("ECDHE-RSA-CHACHA20-POLY1305",	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
-        add("ECDHE-RSA-DES-CBC3-SHA",		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA");
-        add("ECDHE-RSA-NULL-SHA",		"TLS_ECDHE_RSA_WITH_NULL_SHA");
-        add("ECDH-RSA-AES128-GCM-SHA256",      	"TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256");
-        add("ECDH-RSA-AES128-SHA256",		"TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256");
-        add("ECDH-RSA-AES128-SHA",		"TLS_ECDH_RSA_WITH_AES_128_CBC_SHA");
-        add("ECDH-RSA-AES256-GCM-SHA384",      	"TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384");
-        add("ECDH-RSA-AES256-SHA384",		"TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384");
-        add("ECDH-RSA-AES256-SHA",		"TLS_ECDH_RSA_WITH_AES_256_CBC_SHA");
-        add("ECDH-RSA-DES-CBC3-SHA",		"TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA");
-        add("ECDH-RSA-NULL-SHA",		"TLS_ECDH_RSA_WITH_NULL_SHA");
-        add("EXP-ADH-DES-CBC-SHA",		"SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA");
-        add("EXP-DES-CBC-SHA",			"SSL_RSA_EXPORT_WITH_DES40_CBC_SHA");
-        add("NULL-MD5",				"SSL_RSA_WITH_NULL_MD5");
-        add("NULL-SHA256",			"TLS_RSA_WITH_NULL_SHA256");
-        add("NULL-SHA",				"SSL_RSA_WITH_NULL_SHA");
-        add("PSK-3DES-EDE-CBC-SHA",		"TLS_PSK_WITH_3DES_EDE_CBC_SHA");
-        add("PSK-AES128-CBC-SHA",		"TLS_PSK_WITH_AES_128_CBC_SHA");
-        add("PSK-AES256-CBC-SHA",		"TLS_PSK_WITH_AES_256_CBC_SHA");
+        add("ADH-AES128-GCM-SHA256", "TLS_DH_anon_WITH_AES_128_GCM_SHA256");
+        add("ADH-AES128-SHA256", "TLS_DH_anon_WITH_AES_128_CBC_SHA256");
+        add("ADH-AES128-SHA", "TLS_DH_anon_WITH_AES_128_CBC_SHA");
+        add("ADH-AES256-GCM-SHA384", "TLS_DH_anon_WITH_AES_256_GCM_SHA384");
+        add("ADH-AES256-SHA256", "TLS_DH_anon_WITH_AES_256_CBC_SHA256");
+        add("ADH-AES256-SHA", "TLS_DH_anon_WITH_AES_256_CBC_SHA");
+        add("ADH-DES-CBC3-SHA", "SSL_DH_anon_WITH_3DES_EDE_CBC_SHA");
+        add("ADH-DES-CBC-SHA", "SSL_DH_anon_WITH_DES_CBC_SHA");
+        add("AECDH-AES128-SHA", "TLS_ECDH_anon_WITH_AES_128_CBC_SHA");
+        add("AECDH-AES256-SHA", "TLS_ECDH_anon_WITH_AES_256_CBC_SHA");
+        add("AECDH-DES-CBC3-SHA", "TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA");
+        add("AECDH-NULL-SHA", "TLS_ECDH_anon_WITH_NULL_SHA");
+        add("AES128-GCM-SHA256", "TLS_RSA_WITH_AES_128_GCM_SHA256");
+        add("AES128-SHA256", "TLS_RSA_WITH_AES_128_CBC_SHA256");
+        add("AES128-SHA", "TLS_RSA_WITH_AES_128_CBC_SHA");
+        add("AES256-GCM-SHA384", "TLS_RSA_WITH_AES_256_GCM_SHA384");
+        add("AES256-SHA256", "TLS_RSA_WITH_AES_256_CBC_SHA256");
+        add("AES256-SHA", "TLS_RSA_WITH_AES_256_CBC_SHA");
+        add("DES-CBC3-SHA", "SSL_RSA_WITH_3DES_EDE_CBC_SHA");
+        add("DES-CBC-SHA", "SSL_RSA_WITH_DES_CBC_SHA");
+        add("ECDH-ECDSA-AES128-GCM-SHA256", "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256");
+        add("ECDH-ECDSA-AES128-SHA256", "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256");
+        add("ECDH-ECDSA-AES128-SHA", "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA");
+        add("ECDH-ECDSA-AES256-GCM-SHA384", "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384");
+        add("ECDH-ECDSA-AES256-SHA384", "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384");
+        add("ECDH-ECDSA-AES256-SHA", "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA");
+        add("ECDH-ECDSA-DES-CBC3-SHA", "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA");
+        add("ECDH-ECDSA-NULL-SHA", "TLS_ECDH_ECDSA_WITH_NULL_SHA");
+        add("ECDHE-ECDSA-AES128-GCM-SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
+        add("ECDHE-ECDSA-AES128-SHA256", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256");
+        add("ECDHE-ECDSA-AES128-SHA", "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA");
+        add("ECDHE-ECDSA-AES256-GCM-SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384");
+        add("ECDHE-ECDSA-AES256-SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384");
+        add("ECDHE-ECDSA-AES256-SHA", "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA");
+        add("ECDHE-ECDSA-CHACHA20-POLY1305", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305");
+        add("ECDHE-ECDSA-CHACHA20-POLY1305", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256");
+        add("ECDHE-ECDSA-DES-CBC3-SHA", "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA");
+        add("ECDHE-ECDSA-NULL-SHA", "TLS_ECDHE_ECDSA_WITH_NULL_SHA");
+        add("ECDHE-PSK-AES128-CBC-SHA", "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA");
+        add("ECDHE-PSK-AES128-GCM-SHA256", "TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256");
+        add("ECDHE-PSK-AES256-CBC-SHA", "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA");
+        add("ECDHE-PSK-AES256-GCM-SHA384", "TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384");
+        add("ECDHE-PSK-CHACHA20-POLY1305", "TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256");
+        add("ECDHE-RSA-AES128-GCM-SHA256", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        add("ECDHE-RSA-AES128-SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256");
+        add("ECDHE-RSA-AES128-SHA", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA");
+        add("ECDHE-RSA-AES256-GCM-SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+        add("ECDHE-RSA-AES256-SHA384", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384");
+        add("ECDHE-RSA-AES256-SHA", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
+        add("ECDHE-RSA-CHACHA20-POLY1305", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305");
+        add("ECDHE-RSA-CHACHA20-POLY1305", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256");
+        add("ECDHE-RSA-DES-CBC3-SHA", "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA");
+        add("ECDHE-RSA-NULL-SHA", "TLS_ECDHE_RSA_WITH_NULL_SHA");
+        add("ECDH-RSA-AES128-GCM-SHA256", "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256");
+        add("ECDH-RSA-AES128-SHA256", "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256");
+        add("ECDH-RSA-AES128-SHA", "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA");
+        add("ECDH-RSA-AES256-GCM-SHA384", "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384");
+        add("ECDH-RSA-AES256-SHA384", "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384");
+        add("ECDH-RSA-AES256-SHA", "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA");
+        add("ECDH-RSA-DES-CBC3-SHA", "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA");
+        add("ECDH-RSA-NULL-SHA", "TLS_ECDH_RSA_WITH_NULL_SHA");
+        add("EXP-ADH-DES-CBC-SHA", "SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA");
+        add("EXP-DES-CBC-SHA", "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA");
+        add("NULL-MD5", "SSL_RSA_WITH_NULL_MD5");
+        add("NULL-SHA256", "TLS_RSA_WITH_NULL_SHA256");
+        add("NULL-SHA", "SSL_RSA_WITH_NULL_SHA");
+        add("PSK-3DES-EDE-CBC-SHA", "TLS_PSK_WITH_3DES_EDE_CBC_SHA");
+        add("PSK-AES128-CBC-SHA", "TLS_PSK_WITH_AES_128_CBC_SHA");
+        add("PSK-AES256-CBC-SHA", "TLS_PSK_WITH_AES_256_CBC_SHA");
 
         // Signaling Cipher Suite Value for secure renegotiation handled as special case.
         // add("TLS_EMPTY_RENEGOTIATION_INFO_SCSV", null);
@@ -697,8 +683,8 @@ public final class NativeCrypto {
         for (int i = 0; i < size; i++) {
             String standardName = OPENSSL_TO_STANDARD_CIPHER_SUITES.get(allOpenSSLCipherSuites[i]);
             if (standardName == null) {
-                throw new IllegalArgumentException("Unknown cipher suite supported by native code: " +
-                                                   allOpenSSLCipherSuites[i]);
+                throw new IllegalArgumentException("Unknown cipher suite supported by native code: "
+                        + allOpenSSLCipherSuites[i]);
             }
             SUPPORTED_CIPHER_SUITES[i] = standardName;
             SUPPORTED_CIPHER_SUITES_SET.add(standardName);
@@ -711,9 +697,9 @@ public final class NativeCrypto {
      * Returns 1 if the BoringSSL believes the CPU has AES accelerated hardware
      * instructions. Used to determine cipher suite ordering.
      */
-    public static native int EVP_has_aes_hardware();
+    static native int EVP_has_aes_hardware();
 
-    public static native long SSL_CTX_new();
+    static native long SSL_CTX_new();
 
     // IMPLEMENTATION NOTE: The default list of cipher suites is a trade-off between what we'd like
     // to use and what servers currently support. We strive to be secure enough by default. We thus
@@ -770,99 +756,89 @@ public final class NativeCrypto {
 
     /** TLS-PSK cipher suites enabled by default (if requested), in preference order. */
     static final String[] DEFAULT_PSK_CIPHER_SUITES = new String[] {
-        "TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256",
-        "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA",
-        "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA",
-        "TLS_PSK_WITH_AES_128_CBC_SHA",
-        "TLS_PSK_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA", "TLS_PSK_WITH_AES_128_CBC_SHA",
+            "TLS_PSK_WITH_AES_256_CBC_SHA",
     };
 
-    public static String[] getSupportedCipherSuites() {
+    static String[] getSupportedCipherSuites() {
         return SUPPORTED_CIPHER_SUITES.clone();
     }
 
-    public static native void SSL_CTX_free(long ssl_ctx);
+    static native void SSL_CTX_free(long ssl_ctx);
 
-    public static native void SSL_CTX_set_session_id_context(long ssl_ctx, byte[] sid_ctx);
+    static native void SSL_CTX_set_session_id_context(long ssl_ctx, byte[] sid_ctx);
 
-    public static native long SSL_new(long ssl_ctx) throws SSLException;
+    static native long SSL_new(long ssl_ctx) throws SSLException;
 
-    public static native void SSL_enable_tls_channel_id(long ssl) throws SSLException;
+    static native void SSL_enable_tls_channel_id(long ssl) throws SSLException;
 
-    public static native byte[] SSL_get_tls_channel_id(long ssl) throws SSLException;
+    static native byte[] SSL_get_tls_channel_id(long ssl) throws SSLException;
 
-    public static native void SSL_set1_tls_channel_id(long ssl, NativeRef.EVP_PKEY pkey);
+    static native void SSL_set1_tls_channel_id(long ssl, NativeRef.EVP_PKEY pkey);
 
-    public static native void SSL_use_certificate(long ssl, long[] x509refs);
+    static native void SSL_use_certificate(long ssl, long[] x509refs);
 
-    public static native void SSL_use_PrivateKey(long ssl, NativeRef.EVP_PKEY pkey);
+    static native void SSL_use_PrivateKey(long ssl, NativeRef.EVP_PKEY pkey);
 
-    public static native void SSL_check_private_key(long ssl) throws SSLException;
+    static native void SSL_check_private_key(long ssl) throws SSLException;
 
-    public static native void SSL_set_client_CA_list(long ssl, byte[][] asn1DerEncodedX500Principals);
+    static native void SSL_set_client_CA_list(long ssl, byte[][] asn1DerEncodedX500Principals);
 
-    public static native long SSL_get_mode(long ssl);
+    static native long SSL_get_mode(long ssl);
 
-    public static native long SSL_set_mode(long ssl, long mode);
+    static native long SSL_set_mode(long ssl, long mode);
 
-    public static native long SSL_clear_mode(long ssl, long mode);
+    static native long SSL_clear_mode(long ssl, long mode);
 
-    public static native long SSL_get_options(long ssl);
+    static native long SSL_get_options(long ssl);
 
-    public static native long SSL_set_options(long ssl, long options);
+    static native long SSL_set_options(long ssl, long options);
 
-    public static native long SSL_clear_options(long ssl, long options);
+    static native long SSL_clear_options(long ssl, long options);
 
-    public static native void SSL_enable_signed_cert_timestamps(long ssl);
+    static native void SSL_enable_signed_cert_timestamps(long ssl);
 
-    public static native byte[] SSL_get_signed_cert_timestamp_list(long ssl);
+    static native byte[] SSL_get_signed_cert_timestamp_list(long ssl);
 
-    public static native void SSL_set_signed_cert_timestamp_list(long ssl, byte[] list);
+    static native void SSL_set_signed_cert_timestamp_list(long ssl, byte[] list);
 
-    public static native void SSL_enable_ocsp_stapling(long ssl);
+    static native void SSL_enable_ocsp_stapling(long ssl);
 
-    public static native byte[] SSL_get_ocsp_response(long ssl);
+    static native byte[] SSL_get_ocsp_response(long ssl);
 
-    public static native void SSL_set_ocsp_response(long ssl, byte[] response);
+    static native void SSL_set_ocsp_response(long ssl, byte[] response);
 
-    public static native void SSL_use_psk_identity_hint(long ssl, String identityHint)
-            throws SSLException;
+    static native void SSL_use_psk_identity_hint(long ssl, String identityHint) throws SSLException;
 
-    public static native void set_SSL_psk_client_callback_enabled(long ssl, boolean enabled);
+    static native void set_SSL_psk_client_callback_enabled(long ssl, boolean enabled);
 
-    public static native void set_SSL_psk_server_callback_enabled(long ssl, boolean enabled);
+    static native void set_SSL_psk_server_callback_enabled(long ssl, boolean enabled);
 
     /** Protocols to enable by default when "TLSv1.2" is requested. */
-    public static final String[] TLSV12_PROTOCOLS = new String[] {
-        SUPPORTED_PROTOCOL_TLSV1,
-        SUPPORTED_PROTOCOL_TLSV1_1,
-        SUPPORTED_PROTOCOL_TLSV1_2,
+    static final String[] TLSV12_PROTOCOLS = new String[] {
+            SUPPORTED_PROTOCOL_TLSV1, SUPPORTED_PROTOCOL_TLSV1_1, SUPPORTED_PROTOCOL_TLSV1_2,
     };
 
     /** Protocols to enable by default when "TLSv1.1" is requested. */
-    public static final String[] TLSV11_PROTOCOLS = new String[] {
-        SUPPORTED_PROTOCOL_TLSV1,
-        SUPPORTED_PROTOCOL_TLSV1_1,
-        SUPPORTED_PROTOCOL_TLSV1_2,
+    static final String[] TLSV11_PROTOCOLS = new String[] {
+            SUPPORTED_PROTOCOL_TLSV1, SUPPORTED_PROTOCOL_TLSV1_1, SUPPORTED_PROTOCOL_TLSV1_2,
     };
 
     /** Protocols to enable by default when "TLSv1" is requested. */
-    public static final String[] TLSV1_PROTOCOLS  = new String[] {
-        SUPPORTED_PROTOCOL_TLSV1,
-        SUPPORTED_PROTOCOL_TLSV1_1,
-        SUPPORTED_PROTOCOL_TLSV1_2,
+    static final String[] TLSV1_PROTOCOLS = new String[] {
+            SUPPORTED_PROTOCOL_TLSV1, SUPPORTED_PROTOCOL_TLSV1_1, SUPPORTED_PROTOCOL_TLSV1_2,
     };
 
-    public static final String[] DEFAULT_PROTOCOLS = TLSV12_PROTOCOLS;
+    static final String[] DEFAULT_PROTOCOLS = TLSV12_PROTOCOLS;
 
-    public static String[] getSupportedProtocols() {
-        return new String[] { SUPPORTED_PROTOCOL_TLSV1,
-                              SUPPORTED_PROTOCOL_TLSV1_1,
-                              SUPPORTED_PROTOCOL_TLSV1_2,
+    static String[] getSupportedProtocols() {
+        return new String[] {
+                SUPPORTED_PROTOCOL_TLSV1, SUPPORTED_PROTOCOL_TLSV1_1, SUPPORTED_PROTOCOL_TLSV1_2,
         };
     }
 
-    public static void setEnabledProtocols(long ssl, String[] protocols) {
+    static void setEnabledProtocols(long ssl, String[] protocols) {
         checkEnabledProtocols(protocols);
         // openssl uses negative logic letting you disable protocols.
         // so first, assume we need to set all (disable all) and clear none (enable none).
@@ -894,7 +870,7 @@ public final class NativeCrypto {
         SSL_clear_options(ssl, optionsToClear);
     }
 
-    public static String[] checkEnabledProtocols(String[] protocols) {
+    static String[] checkEnabledProtocols(String[] protocols) {
         if (protocols == null) {
             throw new IllegalArgumentException("protocols == null");
         }
@@ -912,16 +888,16 @@ public final class NativeCrypto {
         return protocols;
     }
 
-    public static native void SSL_set_cipher_lists(long ssl, String[] ciphers);
+    static native void SSL_set_cipher_lists(long ssl, String[] ciphers);
 
     /**
      * Gets the list of cipher suites enabled for the provided {@code SSL} instance.
      *
      * @return array of {@code SSL_CIPHER} references.
      */
-    public static native long[] SSL_get_ciphers(long ssl);
+    static native long[] SSL_get_ciphers(long ssl);
 
-    public static void setEnabledCipherSuites(long ssl, String[] cipherSuites) {
+    static void setEnabledCipherSuites(long ssl, String[] cipherSuites) {
         checkEnabledCipherSuites(cipherSuites);
         List<String> opensslSuites = new ArrayList<String>();
         for (int i = 0; i < cipherSuites.length; i++) {
@@ -940,7 +916,7 @@ public final class NativeCrypto {
         SSL_set_cipher_lists(ssl, opensslSuites.toArray(new String[opensslSuites.size()]));
     }
 
-    public static String[] checkEnabledCipherSuites(String[] cipherSuites) {
+    static String[] checkEnabledCipherSuites(String[] cipherSuites) {
         if (cipherSuites == null) {
             throw new IllegalArgumentException("cipherSuites == null");
         }
@@ -950,8 +926,8 @@ public final class NativeCrypto {
             if (cipherSuite == null) {
                 throw new IllegalArgumentException("cipherSuites[" + i + "] == null");
             }
-            if (cipherSuite.equals(TLS_EMPTY_RENEGOTIATION_INFO_SCSV) ||
-                    cipherSuite.equals(TLS_FALLBACK_SCSV)) {
+            if (cipherSuite.equals(TLS_EMPTY_RENEGOTIATION_INFO_SCSV)
+                    || cipherSuite.equals(TLS_FALLBACK_SCSV)) {
                 continue;
             }
             if (SUPPORTED_CIPHER_SUITES_SET.contains(cipherSuite)) {
@@ -974,36 +950,36 @@ public final class NativeCrypto {
      * See the OpenSSL ssl.h header file for more information.
      */
     // TODO(nathanmittler): Should these move to NativeConstants.java?
-    public static final int SSL_VERIFY_NONE =                 0x00;
-    public static final int SSL_VERIFY_PEER =                 0x01;
-    public static final int SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 0x02;
+    static final int SSL_VERIFY_NONE = 0x00;
+    static final int SSL_VERIFY_PEER = 0x01;
+    static final int SSL_VERIFY_FAIL_IF_NO_PEER_CERT = 0x02;
 
-    public static native void SSL_set_accept_state(long sslNativePointer);
+    static native void SSL_set_accept_state(long sslNativePointer);
 
-    public static native void SSL_set_connect_state(long sslNativePointer);
+    static native void SSL_set_connect_state(long sslNativePointer);
 
-    public static native void SSL_set_verify(long sslNativePointer, int mode);
+    static native void SSL_set_verify(long sslNativePointer, int mode);
 
-    public static native void SSL_set_session(long sslNativePointer, long sslSessionNativePointer)
-        throws SSLException;
+    static native void SSL_set_session(long sslNativePointer, long sslSessionNativePointer)
+            throws SSLException;
 
-    public static native void SSL_set_session_creation_enabled(
+    static native void SSL_set_session_creation_enabled(
             long sslNativePointer, boolean creationEnabled) throws SSLException;
 
-    public static native boolean SSL_session_reused(long sslNativePointer);
+    static native boolean SSL_session_reused(long sslNativePointer);
 
-    public static native void SSL_accept_renegotiations(long sslNativePointer) throws SSLException;
+    static native void SSL_accept_renegotiations(long sslNativePointer) throws SSLException;
 
-    public static native void SSL_set_tlsext_host_name(long sslNativePointer, String hostname)
+    static native void SSL_set_tlsext_host_name(long sslNativePointer, String hostname)
             throws SSLException;
-    public static native String SSL_get_servername(long sslNativePointer);
+    static native String SSL_get_servername(long sslNativePointer);
 
     /**
      * Returns the selected ALPN protocol. If the server did not select a
      * protocol, {@code null} will be returned.
      */
-    public static native byte[] SSL_get0_alpn_selected(long sslPointer);
-    public static native void SSL_do_handshake(
+    static native byte[] SSL_get0_alpn_selected(long sslPointer);
+    static native void SSL_do_handshake(
             long sslNativePointer, FileDescriptor fd, SSLHandshakeCallbacks shc, int timeoutMillis)
             throws SSLException, SocketTimeoutException, CertificateException;
 
@@ -1011,71 +987,64 @@ public final class NativeCrypto {
      * Currently only intended for forcing renegotiation for testing.
      * Not used within OpenSSLSocketImpl.
      */
-    public static native void SSL_renegotiate(long sslNativePointer) throws SSLException;
+    static native void SSL_renegotiate(long sslNativePointer) throws SSLException;
 
     /**
      * Returns the local X509 certificate references. Must X509_free when done.
      */
-    public static native long[] SSL_get_certificate(long sslNativePointer);
+    static native long[] SSL_get_certificate(long sslNativePointer);
 
     /**
      * Returns the peer X509 certificate references. Must X509_free when done.
      */
-    public static native long[] SSL_get_peer_cert_chain(long sslNativePointer);
+    static native long[] SSL_get_peer_cert_chain(long sslNativePointer);
 
     /**
      * Reads with the native SSL_read function from the encrypted data stream
      * @return -1 if error or the end of the stream is reached.
      */
-    public static native int SSL_read(long sslNativePointer,
-                                      FileDescriptor fd,
-                                      SSLHandshakeCallbacks shc,
-                                      byte[] b, int off, int len, int readTimeoutMillis)
-        throws IOException;
+    static native int SSL_read(long sslNativePointer, FileDescriptor fd, SSLHandshakeCallbacks shc,
+            byte[] b, int off, int len, int readTimeoutMillis) throws IOException;
 
     /**
      * Writes with the native SSL_write function to the encrypted data stream.
      */
-    public static native void SSL_write(long sslNativePointer,
-                                        FileDescriptor fd,
-                                        SSLHandshakeCallbacks shc,
-                                        byte[] b, int off, int len, int writeTimeoutMillis)
-        throws IOException;
+    static native void SSL_write(long sslNativePointer, FileDescriptor fd,
+            SSLHandshakeCallbacks shc, byte[] b, int off, int len, int writeTimeoutMillis)
+            throws IOException;
 
-    public static native void SSL_interrupt(long sslNativePointer);
-    public static native void SSL_shutdown(long sslNativePointer,
-                                           FileDescriptor fd,
-                                           SSLHandshakeCallbacks shc) throws IOException;
+    static native void SSL_interrupt(long sslNativePointer);
+    static native void SSL_shutdown(
+            long sslNativePointer, FileDescriptor fd, SSLHandshakeCallbacks shc) throws IOException;
 
-    public static native void SSL_shutdown_BIO(long sslNativePointer,
-                                               long sourceBioRef, long sinkBioRef,
-                                               SSLHandshakeCallbacks shc) throws IOException;
+    static native void SSL_shutdown_BIO(long sslNativePointer, long sourceBioRef, long sinkBioRef,
+            SSLHandshakeCallbacks shc) throws IOException;
 
-    public static native int SSL_get_shutdown(long sslNativePointer);
+    static native int SSL_get_shutdown(long sslNativePointer);
 
-    public static native void SSL_free(long sslNativePointer);
+    static native void SSL_free(long sslNativePointer);
 
-    public static native byte[] SSL_SESSION_session_id(long sslSessionNativePointer);
+    static native byte[] SSL_SESSION_session_id(long sslSessionNativePointer);
 
-    public static native long SSL_SESSION_get_time(long sslSessionNativePointer);
+    static native long SSL_SESSION_get_time(long sslSessionNativePointer);
 
-    public static native String SSL_SESSION_get_version(long sslSessionNativePointer);
+    static native String SSL_SESSION_get_version(long sslSessionNativePointer);
 
-    public static native String SSL_SESSION_cipher(long sslSessionNativePointer);
+    static native String SSL_SESSION_cipher(long sslSessionNativePointer);
 
-    public static native String get_SSL_SESSION_tlsext_hostname(long sslSessionNativePointer);
+    static native String get_SSL_SESSION_tlsext_hostname(long sslSessionNativePointer);
 
-    public static native void SSL_SESSION_free(long sslSessionNativePointer);
+    static native void SSL_SESSION_free(long sslSessionNativePointer);
 
-    public static native byte[] i2d_SSL_SESSION(long sslSessionNativePointer);
+    static native byte[] i2d_SSL_SESSION(long sslSessionNativePointer);
 
-    public static native long d2i_SSL_SESSION(byte[] data) throws IOException;
+    static native long d2i_SSL_SESSION(byte[] data) throws IOException;
 
     /**
      * A collection of callbacks from the native OpenSSL code that are
      * related to the SSL handshake initiated by SSL_do_handshake.
      */
-    public interface SSLHandshakeCallbacks {
+    interface SSLHandshakeCallbacks {
         /**
          * Verify that we trust the certificate chain is trusted.
          *
@@ -1136,14 +1105,14 @@ public final class NativeCrypto {
         void onSSLStateChange(int type, int val);
     }
 
-    public static native long ERR_peek_last_error();
+    static native long ERR_peek_last_error();
 
-    public static native String SSL_CIPHER_get_kx_name(long cipherAddress);
+    static native String SSL_CIPHER_get_kx_name(long cipherAddress);
 
-    public static native String[] get_cipher_names(String selection);
+    static native String[] get_cipher_names(String selection);
 
-    public static native byte[] get_ocsp_single_extension(byte[] ocspResponse, String oid,
-                                                          long x509Ref, long issuerX509Ref);
+    static native byte[] get_ocsp_single_extension(
+            byte[] ocspResponse, String oid, long x509Ref, long issuerX509Ref);
 
     /**
      * Returns the starting address of the memory region referenced by the provided direct
@@ -1152,99 +1121,99 @@ public final class NativeCrypto {
      *
      * <p>NOTE: This method ignores the buffer's current {@code position}.
      */
-    public static native long getDirectBufferAddress(Buffer buf);
+    static native long getDirectBufferAddress(Buffer buf);
 
-    public static native long SSL_BIO_new(long ssl) throws SSLException;
+    static native long SSL_BIO_new(long ssl) throws SSLException;
 
-    public static native int SSL_get_last_error_number();
+    static native int SSL_get_last_error_number();
 
-    public static native int SSL_get_error(long ssl, int ret);
+    static native int SSL_get_error(long ssl, int ret);
 
-    public static native String SSL_get_error_string(long errorNumber);
+    static native String SSL_get_error_string(long errorNumber);
 
-    public static native void SSL_clear_error();
+    static native void SSL_clear_error();
 
-    public static native int SSL_pending_readable_bytes(long ssl);
+    static native int SSL_pending_readable_bytes(long ssl);
 
-    public static native int SSL_pending_written_bytes_in_BIO(long bio);
+    static native int SSL_pending_written_bytes_in_BIO(long bio);
 
-    public static native long SSL_get0_session(long ssl);
+    static native long SSL_get0_session(long ssl);
 
-    public static native long SSL_get1_session(long ssl);
+    static native long SSL_get1_session(long ssl);
 
     /**
      * Returns the maximum overhead, in bytes, of sealing a record with SSL.
      */
-    public static native int SSL_max_seal_overhead(long ssl);
+    static native int SSL_max_seal_overhead(long ssl);
 
     /**
      * Sets the list of supported ALPN protocols in wire-format (length-prefixed 8-bit strings).
      */
-    public static native void SSL_configure_alpn(
+    static native void SSL_configure_alpn(
             long sslNativePointer, boolean clientMode, byte[] alpnProtocols) throws IOException;
 
     /**
      * Variant of the {@link #SSL_do_handshake} used by {@link OpenSSLEngineImpl}. This version
      * does not lock and does no error preprocessing.
      */
-    public static native int ENGINE_SSL_do_handshake(long ssl, SSLHandshakeCallbacks shc);
+    static native int ENGINE_SSL_do_handshake(long ssl, SSLHandshakeCallbacks shc);
 
     /**
      * Variant of the {@link #SSL_read} for a direct {@link java.nio.ByteBuffer} used by {@link
      * OpenSSLEngineImpl}. This version does not lock or and does no error pre-processing.
      */
-    public static native int ENGINE_SSL_read_direct(long sslNativePointer, long address, int length,
+    static native int ENGINE_SSL_read_direct(long sslNativePointer, long address, int length,
             SSLHandshakeCallbacks shc) throws IOException;
 
     /**
      * Variant of the {@link #SSL_read} for a heap {@link java.nio.ByteBuffer} used by {@link
      * OpenSSLEngineImpl}. This version does not lock or and does no error pre-processing.
      */
-    public static native int ENGINE_SSL_read_heap(long sslNativePointer, byte[] destJava,
-            int destOffset, int destLength, SSLHandshakeCallbacks shc) throws IOException;
+    static native int ENGINE_SSL_read_heap(long sslNativePointer, byte[] destJava, int destOffset,
+            int destLength, SSLHandshakeCallbacks shc) throws IOException;
 
     /**
      * Variant of the {@link #SSL_write} for a direct {@link java.nio.ByteBuffer} used by {@link
      * OpenSSLEngineImpl}. This version does not lock or and does no error pre-processing.
      */
-    public static native int ENGINE_SSL_write_direct(long sslNativePointer, long address,
-            int length, SSLHandshakeCallbacks shc) throws IOException;
+    static native int ENGINE_SSL_write_direct(long sslNativePointer, long address, int length,
+            SSLHandshakeCallbacks shc) throws IOException;
 
     /**
      * Variant of the {@link #SSL_write} for a heap {@link java.nio.ByteBuffer} used by {@link
      * OpenSSLEngineImpl}. This version does not lock or and does no error pre-processing.
      */
-    public static native int ENGINE_SSL_write_heap(long sslNativePointer, byte[] sourceJava,
+    static native int ENGINE_SSL_write_heap(long sslNativePointer, byte[] sourceJava,
             int sourceOffset, int sourceLength, SSLHandshakeCallbacks shc) throws IOException;
 
     /**
      * Writes data from the given direct {@link java.nio.ByteBuffer} to the BIO.
      */
-    public static native int ENGINE_SSL_write_BIO_direct(long sslRef, long bioRef, long pos,
-            int length, SSLHandshakeCallbacks shc) throws IOException;
+    static native int ENGINE_SSL_write_BIO_direct(long sslRef, long bioRef, long pos, int length,
+            SSLHandshakeCallbacks shc) throws IOException;
 
     /**
      * Writes data from the given array to the BIO.
      */
-    public static native int ENGINE_SSL_write_BIO_heap(long sslRef, long bioRef, byte[] sourceJava,
+    static native int ENGINE_SSL_write_BIO_heap(long sslRef, long bioRef, byte[] sourceJava,
             int sourceOffset, int sourceLength, SSLHandshakeCallbacks shc) throws IOException;
 
     /**
      * Reads data from the given BIO into a direct {@link java.nio.ByteBuffer}.
      */
-    public static native int ENGINE_SSL_read_BIO_direct(long sslRef, long bioRef, long address,
-            int len, SSLHandshakeCallbacks shc) throws IOException;
+    static native int ENGINE_SSL_read_BIO_direct(long sslRef, long bioRef, long address, int len,
+            SSLHandshakeCallbacks shc) throws IOException;
 
     /**
      * Reads data from the given BIO into an array.
      */
-    public static native int ENGINE_SSL_read_BIO_heap(long sslRef, long bioRef, byte[] destJava,
+    static native int ENGINE_SSL_read_BIO_heap(long sslRef, long bioRef, byte[] destJava,
             int destOffset, int destLength, SSLHandshakeCallbacks shc) throws IOException;
 
     /**
      * Variant of the {@link #SSL_shutdown} used by {@link OpenSSLEngineImpl}. This version does not
      * lock.
      */
-    public static native void ENGINE_SSL_shutdown(long sslNativePointer, SSLHandshakeCallbacks shc)
+    static native void ENGINE_SSL_shutdown(long sslNativePointer, SSLHandshakeCallbacks shc)
             throws IOException;
 }

--- a/common/src/main/java/org/conscrypt/NativeRef.java
+++ b/common/src/main/java/org/conscrypt/NativeRef.java
@@ -19,14 +19,11 @@ package org.conscrypt;
 /**
  * Used to hold onto native OpenSSL references and run finalization on those
  * objects. Individual types must subclass this and implement finalizer.
- *
- * @hide
  */
-@Internal
-public abstract class NativeRef {
+abstract class NativeRef {
     final long context;
 
-    public NativeRef(long ctx) {
+    NativeRef(long ctx) {
         if (ctx == 0) {
             throw new NullPointerException("ctx == 0");
         }
@@ -48,8 +45,8 @@ public abstract class NativeRef {
         return (int) context;
     }
 
-    public static class EC_GROUP extends NativeRef {
-        public EC_GROUP(long ctx) {
+    static class EC_GROUP extends NativeRef {
+        EC_GROUP(long ctx) {
             super(ctx);
         }
 
@@ -63,8 +60,8 @@ public abstract class NativeRef {
         }
     }
 
-    public static class EC_POINT extends NativeRef {
-        public EC_POINT(long ctx) {
+    static class EC_POINT extends NativeRef {
+        EC_POINT(long ctx) {
             super(ctx);
         }
 
@@ -78,8 +75,8 @@ public abstract class NativeRef {
         }
     }
 
-    public static class EVP_CIPHER_CTX extends NativeRef {
-        public EVP_CIPHER_CTX(long ctx) {
+    static class EVP_CIPHER_CTX extends NativeRef {
+        EVP_CIPHER_CTX(long ctx) {
             super(ctx);
         }
 
@@ -93,8 +90,8 @@ public abstract class NativeRef {
         }
     }
 
-    public static class EVP_MD_CTX extends NativeRef {
-        public EVP_MD_CTX(long ctx) {
+    static class EVP_MD_CTX extends NativeRef {
+        EVP_MD_CTX(long ctx) {
             super(ctx);
         }
 
@@ -108,8 +105,8 @@ public abstract class NativeRef {
         }
     }
 
-    public static class EVP_PKEY extends NativeRef {
-        public EVP_PKEY(long ctx) {
+    static class EVP_PKEY extends NativeRef {
+        EVP_PKEY(long ctx) {
             super(ctx);
         }
 
@@ -123,8 +120,8 @@ public abstract class NativeRef {
         }
     }
 
-    public static class EVP_PKEY_CTX extends NativeRef {
-        public EVP_PKEY_CTX(long ctx) {
+    static class EVP_PKEY_CTX extends NativeRef {
+        EVP_PKEY_CTX(long ctx) {
             super(ctx);
         }
 
@@ -138,8 +135,8 @@ public abstract class NativeRef {
         }
     }
 
-    public static class HMAC_CTX extends NativeRef {
-        public HMAC_CTX(long ctx) {
+    static class HMAC_CTX extends NativeRef {
+        HMAC_CTX(long ctx) {
             super(ctx);
         }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLBIOInputStream.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLBIOInputStream.java
@@ -24,24 +24,21 @@ import java.io.InputStream;
  * Provides an interface to OpenSSL's BIO system directly from a Java
  * InputStream. It allows an OpenSSL API to read directly from something more
  * flexible interface than a byte array.
- *
- * @hide
  */
-@Internal
-public class OpenSSLBIOInputStream extends FilterInputStream {
+class OpenSSLBIOInputStream extends FilterInputStream {
     private long ctx;
 
-    public OpenSSLBIOInputStream(InputStream is, boolean isFinite) {
+    OpenSSLBIOInputStream(InputStream is, boolean isFinite) {
         super(is);
 
         ctx = NativeCrypto.create_BIO_InputStream(this, isFinite);
     }
 
-    public long getBioContext() {
+    long getBioContext() {
         return ctx;
     }
 
-    public void release() {
+    void release() {
         NativeCrypto.BIO_free_all(ctx);
     }
 
@@ -49,7 +46,7 @@ public class OpenSSLBIOInputStream extends FilterInputStream {
      * Similar to a {@code readLine} method, but matches what OpenSSL expects
      * from a {@code BIO_gets} method.
      */
-    public int gets(byte[] buffer) throws IOException {
+    int gets(byte[] buffer) throws IOException {
         if (buffer == null || buffer.length == 0) {
             return 0;
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLBIOSink.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLBIOSink.java
@@ -20,16 +20,13 @@ import java.io.ByteArrayOutputStream;
 
 /**
  * Wraps a BoringSSL BIO to act as a place to write out data.
- *
- * @hide
  */
-@Internal
-public final class OpenSSLBIOSink {
+final class OpenSSLBIOSink {
     private final long ctx;
     private final ByteArrayOutputStream buffer;
     private int position;
 
-    public static OpenSSLBIOSink create() {
+    static OpenSSLBIOSink create() {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         return new OpenSSLBIOSink(buffer);
     }
@@ -39,16 +36,16 @@ public final class OpenSSLBIOSink {
         this.buffer = buffer;
     }
 
-    public int available() {
+    int available() {
         return buffer.size() - position;
     }
 
-    public void reset() {
+    void reset() {
         buffer.reset();
         position = 0;
     }
 
-    public long skip(long byteCount) {
+    long skip(long byteCount) {
         int maxLength = Math.min(available(), (int) byteCount);
         position += maxLength;
         if (position == buffer.size()) {
@@ -57,15 +54,15 @@ public final class OpenSSLBIOSink {
         return maxLength;
     }
 
-    public long getContext() {
+    long getContext() {
         return ctx;
     }
 
-    public byte[] toByteArray() {
+    byte[] toByteArray() {
         return buffer.toByteArray();
     }
 
-    public int position() {
+    int position() {
         return position;
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLBIOSource.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLBIOSource.java
@@ -22,27 +22,24 @@ import java.nio.ByteBuffer;
 
 /**
  * Wrapped by a BoringSSL BIO to act as a source of bytes.
- *
- * @hide
  */
-@Internal
-public final class OpenSSLBIOSource {
+final class OpenSSLBIOSource {
     private OpenSSLBIOInputStream source;
 
-    public static OpenSSLBIOSource wrap(ByteBuffer buffer) {
+    static OpenSSLBIOSource wrap(ByteBuffer buffer) {
         return new OpenSSLBIOSource(
             new OpenSSLBIOInputStream(new ByteBufferInputStream(buffer), false));
     }
 
-    public OpenSSLBIOSource(OpenSSLBIOInputStream source) {
+    private OpenSSLBIOSource(OpenSSLBIOInputStream source) {
         this.source = source;
     }
 
-    public long getContext() {
+    long getContext() {
         return source.getBioContext();
     }
 
-    public synchronized void release() {
+    private synchronized void release() {
         if (source != null) {
             NativeCrypto.BIO_free_all(source.getBioContext());
             source = null;
@@ -61,7 +58,7 @@ public final class OpenSSLBIOSource {
     private static class ByteBufferInputStream extends InputStream {
         private final ByteBuffer source;
 
-        public ByteBufferInputStream(ByteBuffer source) {
+        ByteBufferInputStream(ByteBuffer source) {
             this.source = source;
         }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipher.java
@@ -56,7 +56,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
     /**
      * Modes that a block cipher may support.
      */
-    protected static enum Mode {
+    enum Mode {
         CBC,
         CTR,
         ECB,
@@ -66,7 +66,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
     /**
      * Paddings that a block cipher may support.
      */
-    protected static enum Padding {
+    enum Padding {
         NOPADDING,
         PKCS5PADDING,
         ISO10126PADDING,
@@ -75,7 +75,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
     /**
      * The current cipher mode.
      */
-    protected Mode mode = Mode.ECB;
+    Mode mode = Mode.ECB;
 
     /**
      * The current cipher padding.
@@ -86,12 +86,12 @@ public abstract class OpenSSLCipher extends CipherSpi {
      * May be used when reseting the cipher instance after calling
      * {@code doFinal}.
      */
-    protected byte[] encodedKey;
+    byte[] encodedKey;
 
     /**
      * The Initial Vector (IV) used for the current cipher.
      */
-    protected byte[] iv;
+    byte[] iv;
 
     /**
      * Current cipher mode: encrypting or decrypting.
@@ -103,10 +103,10 @@ public abstract class OpenSSLCipher extends CipherSpi {
      */
     private int blockSize;
 
-    protected OpenSSLCipher() {
+    OpenSSLCipher() {
     }
 
-    protected OpenSSLCipher(Mode mode, Padding padding) {
+    OpenSSLCipher(Mode mode, Padding padding) {
         this.mode = mode;
         this.padding = padding;
         blockSize = getCipherBlockSize();
@@ -118,7 +118,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
      * initialized for encryption or decryption. The {@code encodedKey} will be
      * the bytes of a supported key size.
      */
-    protected abstract void engineInitInternal(byte[] encodedKey, AlgorithmParameterSpec params,
+    abstract void engineInitInternal(byte[] encodedKey, AlgorithmParameterSpec params,
             SecureRandom random) throws InvalidKeyException, InvalidAlgorithmParameterException;
 
     /**
@@ -128,7 +128,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
      * number of bytes processed and placed into {@code output}. On error, an
      * exception must be thrown.
      */
-    protected abstract int updateInternal(byte[] input, int inputOffset, int inputLen,
+    abstract int updateInternal(byte[] input, int inputOffset, int inputLen,
             byte[] output, int outputOffset, int maximumLen) throws ShortBufferException;
 
     /**
@@ -138,39 +138,39 @@ public abstract class OpenSSLCipher extends CipherSpi {
      * of bytes processed and placed into {@code output}. On error, an exception
      * must be thrown.
      */
-    protected abstract int doFinalInternal(byte[] output, int outputOffset, int maximumLen)
+    abstract int doFinalInternal(byte[] output, int outputOffset, int maximumLen)
             throws IllegalBlockSizeException, BadPaddingException, ShortBufferException;
 
     /**
      * Returns the standard name for the particular algorithm.
      */
-    protected abstract String getBaseCipherName();
+    abstract String getBaseCipherName();
 
     /**
      * Checks whether the cipher supports this particular {@code keySize} (in
      * bytes) and throws {@code InvalidKeyException} if it doesn't.
      */
-    protected abstract void checkSupportedKeySize(int keySize) throws InvalidKeyException;
+    abstract void checkSupportedKeySize(int keySize) throws InvalidKeyException;
 
     /**
      * Checks whether the cipher supports this particular cipher {@code mode}
      * and throws {@code NoSuchAlgorithmException} if it doesn't.
      */
-    protected abstract void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException;
+    abstract void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException;
 
     /**
      * Checks whether the cipher supports this particular cipher {@code padding}
      * and throws {@code NoSuchPaddingException} if it doesn't.
      */
-    protected abstract void checkSupportedPadding(Padding padding) throws NoSuchPaddingException;
+    abstract void checkSupportedPadding(Padding padding) throws NoSuchPaddingException;
 
-    protected abstract int getCipherBlockSize();
+    abstract int getCipherBlockSize();
 
-    protected boolean supportsVariableSizeKey() {
+    boolean supportsVariableSizeKey() {
         return false;
     }
 
-    protected boolean supportsVariableSizeIv() {
+    boolean supportsVariableSizeIv() {
         return false;
     }
 
@@ -207,7 +207,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
     /**
      * Returns the padding type for which this cipher is initialized.
      */
-    protected Padding getPadding() {
+    Padding getPadding() {
         return padding;
     }
 
@@ -221,14 +221,14 @@ public abstract class OpenSSLCipher extends CipherSpi {
      * {@code inputLen}. If padding is enabled and the size of the input puts it
      * right at the block size, it will add another block for the padding.
      */
-    protected abstract int getOutputSizeForFinal(int inputLen);
+    abstract int getOutputSizeForFinal(int inputLen);
 
     /**
      * The size of output if {@code update()} is called with this
      * {@code inputLen}. If padding is enabled and the size of the input puts it
      * right at the block size, it will add another block for the padding.
      */
-    protected abstract int getOutputSizeForUpdate(int inputLen);
+    abstract int getOutputSizeForUpdate(int inputLen);
 
     @Override
     protected int engineGetOutputSize(int inputLen) {
@@ -445,7 +445,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         return encodedKey;
     }
 
-    protected boolean isEncrypting() {
+    boolean isEncrypting() {
         return encrypting;
     }
 
@@ -461,7 +461,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
          * like calling "doFinal()" in decryption mode without processing any
          * updates.
          */
-        protected boolean calledUpdate;
+        boolean calledUpdate;
 
         /**
          * The block size of the current mode.
@@ -473,7 +473,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected void engineInitInternal(byte[] encodedKey, AlgorithmParameterSpec params,
+        void engineInitInternal(byte[] encodedKey, AlgorithmParameterSpec params,
                 SecureRandom random) throws InvalidKeyException,
                 InvalidAlgorithmParameterException {
             byte[] iv;
@@ -531,7 +531,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected int updateInternal(byte[] input, int inputOffset, int inputLen, byte[] output,
+        int updateInternal(byte[] input, int inputOffset, int inputLen, byte[] output,
                 int outputOffset, int maximumLen) throws ShortBufferException {
             final int intialOutputOffset = outputOffset;
 
@@ -550,7 +550,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected int doFinalInternal(byte[] output, int outputOffset, int maximumLen)
+        int doFinalInternal(byte[] output, int outputOffset, int maximumLen)
                 throws IllegalBlockSizeException, BadPaddingException, ShortBufferException {
             /* Remember this so we can tell how many characters were written. */
             final int initialOutputOffset = outputOffset;
@@ -586,7 +586,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected int getOutputSizeForFinal(int inputLen) {
+        int getOutputSizeForFinal(int inputLen) {
             if (modeBlockSize == 1) {
                 return inputLen;
             } else {
@@ -610,7 +610,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected int getOutputSizeForUpdate(int inputLen) {
+        int getOutputSizeForUpdate(int inputLen) {
             return getOutputSizeForFinal(inputLen);
         }
 
@@ -618,7 +618,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
          * Returns the OpenSSL cipher name for the particular {@code keySize}
          * and cipher {@code mode}.
          */
-        protected abstract String getCipherName(int keySize, Mode mode);
+        abstract String getCipherName(int keySize, Mode mode);
 
         /**
          * Reset this Cipher instance state to process a new chunk of data.
@@ -628,15 +628,15 @@ public abstract class OpenSSLCipher extends CipherSpi {
             calledUpdate = false;
         }
 
-        protected abstract static class AES_BASE extends EVP_CIPHER {
+        abstract static class AES_BASE extends EVP_CIPHER {
             private static final int AES_BLOCK_SIZE = 16;
 
-            protected AES_BASE(Mode mode, Padding padding) {
+            AES_BASE(Mode mode, Padding padding) {
                 super(mode, padding);
             }
 
             @Override
-            protected void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
+            void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
                 switch (mode) {
                     case CBC:
                     case CTR:
@@ -648,7 +648,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
+            void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
                 switch (padding) {
                     case NOPADDING:
                     case PKCS5PADDING:
@@ -660,23 +660,23 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected String getBaseCipherName() {
+            String getBaseCipherName() {
                 return "AES";
             }
 
             @Override
-            protected String getCipherName(int keyLength, Mode mode) {
+            String getCipherName(int keyLength, Mode mode) {
                 return "aes-" + (keyLength * 8) + "-" + mode.toString().toLowerCase(Locale.US);
             }
 
             @Override
-            protected int getCipherBlockSize() {
+            int getCipherBlockSize() {
                 return AES_BLOCK_SIZE;
             }
         }
 
         public static class AES extends AES_BASE {
-            protected AES(Mode mode, Padding padding) {
+            AES(Mode mode, Padding padding) {
                 super(mode, padding);
             }
 
@@ -723,7 +723,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
+            void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
                 switch (keyLength) {
                     case 16: // AES 128
                     case 24: // AES 192
@@ -737,7 +737,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         public static class AES_128 extends AES_BASE {
-            protected AES_128(Mode mode, Padding padding) {
+            AES_128(Mode mode, Padding padding) {
                 super(mode, padding);
             }
 
@@ -784,7 +784,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
+            void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
                 if (keyLength != 16) { // 128 bits
                     throw new InvalidKeyException("Unsupported key size: " + keyLength + " bytes");
                 }
@@ -792,7 +792,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         public static class AES_256 extends AES_BASE {
-            protected AES_256(Mode mode, Padding padding) {
+            AES_256(Mode mode, Padding padding) {
                 super(mode, padding);
             }
 
@@ -839,7 +839,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
+            void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
                 if (keyLength != 32) { // 256 bits
                     throw new InvalidKeyException("Unsupported key size: " + keyLength + " bytes");
                 }
@@ -872,12 +872,12 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected String getBaseCipherName() {
+            String getBaseCipherName() {
                 return "DESede";
             }
 
             @Override
-            protected String getCipherName(int keySize, Mode mode) {
+            String getCipherName(int keySize, Mode mode) {
                 final String baseCipherName;
                 if (keySize == 16) {
                     baseCipherName = "des-ede";
@@ -889,21 +889,21 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected void checkSupportedKeySize(int keySize) throws InvalidKeyException {
+            void checkSupportedKeySize(int keySize) throws InvalidKeyException {
                 if (keySize != 16 && keySize != 24) {
                     throw new InvalidKeyException("key size must be 128 or 192 bits");
                 }
             }
 
             @Override
-            protected void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
+            void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
                 if (mode != Mode.CBC) {
                     throw new NoSuchAlgorithmException("Unsupported mode " + mode.toString());
                 }
             }
 
             @Override
-            protected void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
+            void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
                 switch (padding) {
                     case NOPADDING:
                     case PKCS5PADDING:
@@ -915,7 +915,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected int getCipherBlockSize() {
+            int getCipherBlockSize() {
                 return DES_BLOCK_SIZE;
             }
         }
@@ -927,36 +927,36 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected String getBaseCipherName() {
+            String getBaseCipherName() {
                 return "ARCFOUR";
             }
 
             @Override
-            protected String getCipherName(int keySize, Mode mode) {
+            String getCipherName(int keySize, Mode mode) {
                 return "rc4";
             }
 
             @Override
-            protected void checkSupportedKeySize(int keySize) throws InvalidKeyException {
+            void checkSupportedKeySize(int keySize) throws InvalidKeyException {
             }
 
             @Override
-            protected void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
+            void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
                 throw new NoSuchAlgorithmException("ARC4 does not support modes");
             }
 
             @Override
-            protected void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
+            void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
                 throw new NoSuchPaddingException("ARC4 does not support padding");
             }
 
             @Override
-            protected int getCipherBlockSize() {
+            int getCipherBlockSize() {
                 return 0;
             }
 
             @Override
-            protected boolean supportsVariableSizeKey() {
+            boolean supportsVariableSizeKey() {
                 return true;
             }
         }
@@ -977,17 +977,17 @@ public abstract class OpenSSLCipher extends CipherSpi {
         /**
          * The byte array containing the bytes written.
          */
-        protected byte[] buf;
+        byte[] buf;
 
         /**
          * The number of bytes written.
          */
-        protected int bufCount;
+        int bufCount;
 
         /**
          * AEAD cipher reference.
          */
-        protected long evpAead;
+        long evpAead;
 
         /**
          * Additional authenticated data.
@@ -1029,7 +1029,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected void engineInitInternal(byte[] encodedKey, AlgorithmParameterSpec params,
+        void engineInitInternal(byte[] encodedKey, AlgorithmParameterSpec params,
                 SecureRandom random) throws InvalidKeyException,
                 InvalidAlgorithmParameterException {
             byte[] iv;
@@ -1088,7 +1088,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected int updateInternal(byte[] input, int inputOffset, int inputLen, byte[] output,
+        int updateInternal(byte[] input, int inputOffset, int inputLen, byte[] output,
                 int outputOffset, int maximumLen) throws ShortBufferException {
             if (buf == null) {
                 throw new IllegalStateException("Cipher not initialized");
@@ -1132,7 +1132,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected int doFinalInternal(byte[] output, int outputOffset, int maximumLen)
+        int doFinalInternal(byte[] output, int outputOffset, int maximumLen)
                 throws IllegalBlockSizeException, BadPaddingException {
             final int bytesWritten;
             try {
@@ -1152,14 +1152,14 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
 
         @Override
-        protected void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
+        void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
             if (padding != Padding.NOPADDING) {
                 throw new NoSuchPaddingException("Must be NoPadding for AEAD ciphers");
             }
         }
 
         @Override
-        protected int getOutputSizeForFinal(int inputLen) {
+        int getOutputSizeForFinal(int inputLen) {
             return bufCount + inputLen
                     + (isEncrypting() ? NativeCrypto.EVP_AEAD_max_overhead(evpAead) : 0);
         }
@@ -1203,17 +1203,17 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
         }
 
-        protected abstract long getEVP_AEAD(int keyLength) throws InvalidKeyException;
+        abstract long getEVP_AEAD(int keyLength) throws InvalidKeyException;
 
         public abstract static class AES extends EVP_AEAD {
             private static final int AES_BLOCK_SIZE = 16;
 
-            protected AES(Mode mode) {
+            AES(Mode mode) {
                 super(mode);
             }
 
             @Override
-            protected void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
+            void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
                 switch (keyLength) {
                     case 16: // AES 128
                     case 32: // AES 256
@@ -1225,12 +1225,12 @@ public abstract class OpenSSLCipher extends CipherSpi {
             }
 
             @Override
-            protected String getBaseCipherName() {
+            String getBaseCipherName() {
                 return "AES";
             }
 
             @Override
-            protected int getCipherBlockSize() {
+            int getCipherBlockSize() {
                 return AES_BLOCK_SIZE;
             }
 
@@ -1238,7 +1238,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
              * AEAD buffers everything until a final output.
              */
             @Override
-            protected int getOutputSizeForUpdate(int inputLen) {
+            int getOutputSizeForUpdate(int inputLen) {
                 return 0;
             }
 
@@ -1284,7 +1284,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
                 }
 
                 @Override
-                protected void engineInitInternal(
+                void engineInitInternal(
                         byte[] encodedKey, AlgorithmParameterSpec params, SecureRandom random)
                         throws InvalidKeyException, InvalidAlgorithmParameterException {
                     super.engineInitInternal(encodedKey, params, random);
@@ -1305,7 +1305,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
                 }
 
                 @Override
-                protected int updateInternal(byte[] input, int inputOffset, int inputLen,
+                int updateInternal(byte[] input, int inputOffset, int inputLen,
                         byte[] output, int outputOffset, int maximumLen)
                         throws ShortBufferException {
                     checkInitialization();
@@ -1314,7 +1314,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
                 }
 
                 @Override
-                protected int doFinalInternal(byte[] output, int outputOffset, int maximumLen)
+                int doFinalInternal(byte[] output, int outputOffset, int maximumLen)
                         throws IllegalBlockSizeException, BadPaddingException {
                     checkInitialization();
                     int retVal = super.doFinalInternal(output, outputOffset, maximumLen);
@@ -1331,14 +1331,14 @@ public abstract class OpenSSLCipher extends CipherSpi {
                 }
 
                 @Override
-                protected void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
+                void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
                     if (mode != Mode.GCM) {
                         throw new NoSuchAlgorithmException("Mode must be GCM");
                     }
                 }
 
                 @Override
-                protected long getEVP_AEAD(int keyLength) throws InvalidKeyException {
+                long getEVP_AEAD(int keyLength) throws InvalidKeyException {
                     if (keyLength == 16) {
                         return NativeCrypto.EVP_aead_aes_128_gcm();
                     } else if (keyLength == 32) {
@@ -1350,7 +1350,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
 
                 public static class AES_128 extends GCM {
                     @Override
-                    protected void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
+                    void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
                         if (keyLength != 16) { // 128 bits
                             throw new InvalidKeyException(
                                     "Unsupported key size: " + keyLength + " bytes (must be 16)");
@@ -1360,7 +1360,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
 
                 public static class AES_256 extends GCM {
                     @Override
-                    protected void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
+                    void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
                         if (keyLength != 32) { // 256 bits
                             throw new InvalidKeyException(
                                     "Unsupported key size: " + keyLength + " bytes (must be 32)");

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -46,22 +46,25 @@ import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
 
+/**
+ * @hide
+ */
 @Internal
 abstract class OpenSSLCipherRSA extends CipherSpi {
     /**
      * The current OpenSSL key we're operating on.
      */
-    protected OpenSSLKey key;
+    OpenSSLKey key;
 
     /**
      * Current key type: private or public.
      */
-    protected boolean usingPrivateKey;
+    boolean usingPrivateKey;
 
     /**
      * Current cipher mode: encrypting or decrypting.
      */
-    protected boolean encrypting;
+    boolean encrypting;
 
     /**
      * Buffer for operations
@@ -82,9 +85,9 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
     /**
      * Current padding mode
      */
-    protected int padding = NativeConstants.RSA_PKCS1_PADDING;
+    int padding = NativeConstants.RSA_PKCS1_PADDING;
 
-    protected OpenSSLCipherRSA(int padding) {
+    OpenSSLCipherRSA(int padding) {
         this.padding = padding;
     }
 
@@ -129,7 +132,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         return paddedBlockSizeBytes();
     }
 
-    protected int paddedBlockSizeBytes() {
+    int paddedBlockSizeBytes() {
         int paddedBlockSizeBytes = keySizeBytes();
         if (padding == NativeConstants.RSA_PKCS1_PADDING) {
             paddedBlockSizeBytes--;  // for 0 prefix
@@ -138,7 +141,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         return paddedBlockSizeBytes;
     }
 
-    protected int keySizeBytes() {
+    int keySizeBytes() {
         if (!isInitialized()) {
             throw new IllegalStateException("cipher is not initialized");
         }
@@ -148,7 +151,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
     /**
      * Returns {@code true} if the cipher has been initialized.
      */
-    protected boolean isInitialized() {
+    boolean isInitialized() {
         return key != null;
     }
 
@@ -162,10 +165,10 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         return null;
     }
 
-    protected void doCryptoInit(AlgorithmParameterSpec spec)
+    void doCryptoInit(AlgorithmParameterSpec spec)
             throws InvalidAlgorithmParameterException {}
 
-    protected void engineInitInternal(int opmode, Key key, AlgorithmParameterSpec spec)
+    void engineInitInternal(int opmode, Key key, AlgorithmParameterSpec spec)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
         if (opmode == Cipher.ENCRYPT_MODE || opmode == Cipher.WRAP_MODE) {
             encrypting = true;
@@ -289,7 +292,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         return output;
     }
 
-    protected abstract int doCryptoOperation(final byte[] tmpBuf, byte[] output)
+    abstract int doCryptoOperation(final byte[] tmpBuf, byte[] output)
             throws BadPaddingException, IllegalBlockSizeException;
 
     @Override
@@ -351,7 +354,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         }
 
         @Override
-        protected int doCryptoOperation(final byte[] tmpBuf, byte[] output)
+        int doCryptoOperation(final byte[] tmpBuf, byte[] output)
                 throws BadPaddingException, IllegalBlockSizeException {
             int resultSize;
             if (encrypting) {
@@ -393,7 +396,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         }
     }
 
-    protected static class OAEP extends OpenSSLCipherRSA {
+    static class OAEP extends OpenSSLCipherRSA {
         private long oaepMd;
         private int oaepMdSizeBytes;
 
@@ -478,7 +481,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         }
 
         @Override
-        protected void doCryptoInit(AlgorithmParameterSpec spec)
+        void doCryptoInit(AlgorithmParameterSpec spec)
                 throws InvalidAlgorithmParameterException {
             pkeyCtx = new NativeRef.EVP_PKEY_CTX(encrypting
                             ? NativeCrypto.EVP_PKEY_encrypt_init(key.getNativeRef())
@@ -498,7 +501,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         }
 
         @Override
-        protected int paddedBlockSizeBytes() {
+        int paddedBlockSizeBytes() {
             int paddedBlockSizeBytes = keySizeBytes();
             // Size described in step 2 of decoding algorithm, but extra byte
             // needed to make sure it's smaller than the RSA key modulus size.
@@ -539,7 +542,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         }
 
         @Override
-        protected int doCryptoOperation(byte[] tmpBuf, byte[] output)
+        int doCryptoOperation(byte[] tmpBuf, byte[] output)
                 throws BadPaddingException, IllegalBlockSizeException {
             if (encrypting) {
                 return NativeCrypto.EVP_PKEY_encrypt(pkeyCtx, output, 0, tmpBuf, 0, tmpBuf.length);

--- a/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
@@ -33,7 +33,7 @@ import javax.net.ssl.TrustManager;
  * @hide
  */
 @Internal
-public class OpenSSLContextImpl extends SSLContextSpi {
+public abstract class OpenSSLContextImpl extends SSLContextSpi {
 
     /**
      * The default SSLContextImpl for use with
@@ -51,14 +51,14 @@ public class OpenSSLContextImpl extends SSLContextSpi {
     /** Server session cache. */
     private final ServerSessionContext serverSessionContext;
 
-    protected SSLParametersImpl sslParameters;
+    SSLParametersImpl sslParameters;
 
     /** Allows outside callers to get the preferred SSLContext. */
-    public static OpenSSLContextImpl getPreferred() {
+    static OpenSSLContextImpl getPreferred() {
         return new TLSv12();
     }
 
-    protected OpenSSLContextImpl(String[] algorithms) {
+    OpenSSLContextImpl(String[] algorithms) {
         this.algorithms = algorithms;
         clientSessionContext = new ClientSessionContext();
         serverSessionContext = new ServerSessionContext();
@@ -67,7 +67,7 @@ public class OpenSSLContextImpl extends SSLContextSpi {
     /**
      * Constuctor for the DefaultSSLContextImpl.
      */
-    protected OpenSSLContextImpl() throws GeneralSecurityException, IOException {
+    OpenSSLContextImpl() throws GeneralSecurityException, IOException {
         synchronized (DefaultSSLContextImpl.class) {
             this.algorithms = null;
             if (DEFAULT_SSL_CONTEXT_IMPL == null) {
@@ -147,19 +147,19 @@ public class OpenSSLContextImpl extends SSLContextSpi {
         return clientSessionContext;
     }
 
-    public static class TLSv12 extends OpenSSLContextImpl {
+    public static final class TLSv12 extends OpenSSLContextImpl {
         public TLSv12() {
             super(NativeCrypto.TLSV12_PROTOCOLS);
         }
     }
 
-    public static class TLSv11 extends OpenSSLContextImpl {
+    public static final class TLSv11 extends OpenSSLContextImpl {
         public TLSv11() {
             super(NativeCrypto.TLSV11_PROTOCOLS);
         }
     }
 
-    public static class TLSv1 extends OpenSSLContextImpl {
+    public static final class TLSv1 extends OpenSSLContextImpl {
         public TLSv1() {
             super(NativeCrypto.TLSV1_PROTOCOLS);
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLECGroupContext.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECGroupContext.java
@@ -27,18 +27,15 @@ import java.security.spec.EllipticCurve;
 
 /**
  * Represents a BoringSSL EC_GROUP object.
- *
- * @hide
  */
-@Internal
-public final class OpenSSLECGroupContext {
+final class OpenSSLECGroupContext {
     private final NativeRef.EC_GROUP groupCtx;
 
-    public OpenSSLECGroupContext(NativeRef.EC_GROUP groupCtx) {
+    OpenSSLECGroupContext(NativeRef.EC_GROUP groupCtx) {
         this.groupCtx = groupCtx;
     }
 
-    public static OpenSSLECGroupContext getCurveByName(String curveName) {
+    static OpenSSLECGroupContext getCurveByName(String curveName) {
         // Workaround for OpenSSL not supporting SECG names for NIST P-192 and P-256
         // (aka ANSI X9.62 prime192v1 and prime256v1) curve names.
         if ("secp256r1".equals(curveName)) {
@@ -67,11 +64,11 @@ public final class OpenSSLECGroupContext {
         return super.hashCode();
     }
 
-    public NativeRef.EC_GROUP getNativeRef() {
+    NativeRef.EC_GROUP getNativeRef() {
         return groupCtx;
     }
 
-    public static OpenSSLECGroupContext getInstance(ECParameterSpec params)
+    static OpenSSLECGroupContext getInstance(ECParameterSpec params)
             throws InvalidAlgorithmParameterException {
         String curveName = Platform.getCurveName(params);
         if (curveName != null) {
@@ -159,7 +156,7 @@ public final class OpenSSLECGroupContext {
         return new OpenSSLECGroupContext(groupRef);
     }
 
-    public ECParameterSpec getECParameterSpec() {
+    ECParameterSpec getECParameterSpec() {
         final String curveName = NativeCrypto.EC_GROUP_get_curve_name(groupCtx);
 
         final byte[][] curveParams = NativeCrypto.EC_GROUP_get_curve(groupCtx);

--- a/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
@@ -34,12 +34,12 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
 /**
- * An implementation of a {@link KeyFactory} for EC keys based on BoringSSL.
+ * An implementation of a {@link KeyFactorySpi} for EC keys based on BoringSSL.
  *
  * @hide
  */
 @Internal
-public class OpenSSLECKeyFactory extends KeyFactorySpi {
+public final class OpenSSLECKeyFactory extends KeyFactorySpi {
 
     @Override
     protected PublicKey engineGeneratePublic(KeySpec keySpec) throws InvalidKeySpecException {
@@ -200,5 +200,4 @@ public class OpenSSLECKeyFactory extends KeyFactorySpi {
                     + key.getClass().getName());
         }
     }
-
 }

--- a/common/src/main/java/org/conscrypt/OpenSSLECPointContext.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECPointContext.java
@@ -33,7 +33,7 @@ final class OpenSSLECPointContext {
         throw new IllegalArgumentException("OpenSSLECPointContext.equals is not defined.");
     }
 
-    public ECPoint getECPoint() {
+    ECPoint getECPoint() {
         final byte[][] generatorCoords = NativeCrypto.EC_POINT_get_affine_coordinates(
                 group.getNativeRef(), pointCtx);
         final BigInteger x = new BigInteger(generatorCoords[0]);
@@ -47,11 +47,11 @@ final class OpenSSLECPointContext {
         return super.hashCode();
     }
 
-    public NativeRef.EC_POINT getNativeRef() {
+    NativeRef.EC_POINT getNativeRef() {
         return pointCtx;
     }
 
-    public static OpenSSLECPointContext getInstance(OpenSSLECGroupContext group,
+    static OpenSSLECPointContext getInstance(OpenSSLECGroupContext group,
             ECPoint javaPoint) {
         OpenSSLECPointContext point = new OpenSSLECPointContext(group, new NativeRef.EC_POINT(
                 NativeCrypto.EC_POINT_new(group.getNativeRef())));

--- a/common/src/main/java/org/conscrypt/OpenSSLECPrivateKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECPrivateKey.java
@@ -33,11 +33,8 @@ import java.util.Arrays;
 
 /**
  * An implementation of a {@link PrivateKey} for EC keys based on BoringSSL.
- *
- * @hide
  */
-@Internal
-public final class OpenSSLECPrivateKey implements ECPrivateKey, OpenSSLKeyHolder {
+final class OpenSSLECPrivateKey implements ECPrivateKey, OpenSSLKeyHolder {
     private static final long serialVersionUID = -4036633595001083922L;
 
     private static final String ALGORITHM = "EC";
@@ -46,18 +43,18 @@ public final class OpenSSLECPrivateKey implements ECPrivateKey, OpenSSLKeyHolder
 
     protected transient OpenSSLECGroupContext group;
 
-    public OpenSSLECPrivateKey(OpenSSLECGroupContext group, OpenSSLKey key) {
+    OpenSSLECPrivateKey(OpenSSLECGroupContext group, OpenSSLKey key) {
         this.group = group;
         this.key = key;
     }
 
-    public OpenSSLECPrivateKey(OpenSSLKey key) {
+    OpenSSLECPrivateKey(OpenSSLKey key) {
         this.group = new OpenSSLECGroupContext(new NativeRef.EC_GROUP(
                 NativeCrypto.EC_KEY_get1_group(key.getNativeRef())));
         this.key = key;
     }
 
-    public OpenSSLECPrivateKey(ECPrivateKeySpec ecKeySpec) throws InvalidKeySpecException {
+    OpenSSLECPrivateKey(ECPrivateKeySpec ecKeySpec) throws InvalidKeySpecException {
         try {
             group = OpenSSLECGroupContext.getInstance(ecKeySpec.getParams());
             final BigInteger privKey = ecKeySpec.getS();
@@ -68,7 +65,7 @@ public final class OpenSSLECPrivateKey implements ECPrivateKey, OpenSSLKeyHolder
         }
     }
 
-    public static OpenSSLKey wrapPlatformKey(ECPrivateKey ecPrivateKey) throws InvalidKeyException {
+    static OpenSSLKey wrapPlatformKey(ECPrivateKey ecPrivateKey) throws InvalidKeyException {
         OpenSSLECGroupContext group;
         try {
             group = OpenSSLECGroupContext.getInstance(ecPrivateKey.getParams());
@@ -131,12 +128,12 @@ public final class OpenSSLECPrivateKey implements ECPrivateKey, OpenSSLKeyHolder
                 group.getNativeRef()), true);
     }
 
-    public static OpenSSLKey getInstance(ECPrivateKey ecPrivateKey) throws InvalidKeyException {
+    static OpenSSLKey getInstance(ECPrivateKey ecPrivateKey) throws InvalidKeyException {
         try {
             OpenSSLECGroupContext group = OpenSSLECGroupContext.getInstance(ecPrivateKey
                     .getParams());
 
-            /**
+            /*
              * If the key is not encodable (PKCS11-like key), then wrap it and
              * use JNI upcalls to satisfy requests.
              */

--- a/common/src/main/java/org/conscrypt/OpenSSLECPublicKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECPublicKey.java
@@ -29,11 +29,8 @@ import java.util.Arrays;
 
 /**
  * An implementation of a {@link java.security.PublicKey} for EC keys based on BoringSSL.
- *
- * @hide
  */
-@Internal
-public final class OpenSSLECPublicKey implements ECPublicKey, OpenSSLKeyHolder {
+final class OpenSSLECPublicKey implements ECPublicKey, OpenSSLKeyHolder {
     private static final long serialVersionUID = 3215842926808298020L;
 
     private static final String ALGORITHM = "EC";
@@ -42,18 +39,18 @@ public final class OpenSSLECPublicKey implements ECPublicKey, OpenSSLKeyHolder {
 
     protected transient OpenSSLECGroupContext group;
 
-    public OpenSSLECPublicKey(OpenSSLECGroupContext group, OpenSSLKey key) {
+    OpenSSLECPublicKey(OpenSSLECGroupContext group, OpenSSLKey key) {
         this.group = group;
         this.key = key;
     }
 
-    public OpenSSLECPublicKey(OpenSSLKey key) {
+    OpenSSLECPublicKey(OpenSSLKey key) {
         this.group = new OpenSSLECGroupContext(new NativeRef.EC_GROUP(
                 NativeCrypto.EC_KEY_get1_group(key.getNativeRef())));
         this.key = key;
     }
 
-    public OpenSSLECPublicKey(ECPublicKeySpec ecKeySpec) throws InvalidKeySpecException {
+    OpenSSLECPublicKey(ECPublicKeySpec ecKeySpec) throws InvalidKeySpecException {
         try {
             group = OpenSSLECGroupContext.getInstance(ecKeySpec.getParams());
             OpenSSLECPointContext pubKey = OpenSSLECPointContext.getInstance(group,
@@ -65,7 +62,7 @@ public final class OpenSSLECPublicKey implements ECPublicKey, OpenSSLKeyHolder {
         }
     }
 
-    public static OpenSSLKey getInstance(ECPublicKey ecPublicKey) throws InvalidKeyException {
+    static OpenSSLKey getInstance(ECPublicKey ecPublicKey) throws InvalidKeyException {
         try {
             OpenSSLECGroupContext group = OpenSSLECGroupContext
                     .getInstance(ecPublicKey.getParams());

--- a/common/src/main/java/org/conscrypt/OpenSSLEngineSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineSocketImpl.java
@@ -39,8 +39,6 @@ import javax.security.auth.x500.X500Principal;
 /**
  * Implements crypto handling by delegating to OpenSSLEngine. Used for socket implementations
  * that are not backed by a real OS socket.
- *
- * @hide
  */
 final class OpenSSLEngineSocketImpl extends OpenSSLSocketImplWrapper {
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);

--- a/common/src/main/java/org/conscrypt/OpenSSLExtendedSessionImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLExtendedSessionImpl.java
@@ -29,18 +29,15 @@ import javax.security.cert.X509Certificate;
 /**
  * Implementation of the ExtendedSSLSession class for OpenSSL. Uses a delegate to maintain backward
  * compatibility with previous versions of Android which don't have ExtendedSSLSession.
- *
- * @hide
  */
-@Internal
-public class OpenSSLExtendedSessionImpl extends ExtendedSSLSession {
+final class OpenSSLExtendedSessionImpl extends ExtendedSSLSession {
     private final AbstractOpenSSLSession delegate;
 
-    public OpenSSLExtendedSessionImpl(AbstractOpenSSLSession delegate) {
+    OpenSSLExtendedSessionImpl(AbstractOpenSSLSession delegate) {
         this.delegate = delegate;
     }
 
-    public AbstractOpenSSLSession getDelegate() {
+    AbstractOpenSSLSession getDelegate() {
         return delegate;
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLKey.java
@@ -30,20 +30,17 @@ import java.security.spec.X509EncodedKeySpec;
 
 /**
  * Represents a BoringSSL {@code EVP_PKEY}.
- *
- * @hide
  */
-@Internal
-public class OpenSSLKey {
+final class OpenSSLKey {
     private final NativeRef.EVP_PKEY ctx;
 
     private final boolean wrapped;
 
-    public OpenSSLKey(long ctx) {
+    OpenSSLKey(long ctx) {
         this(ctx, false);
     }
 
-    public OpenSSLKey(long ctx, boolean wrapped) {
+    OpenSSLKey(long ctx, boolean wrapped) {
         this.ctx = new NativeRef.EVP_PKEY(ctx);
         this.wrapped = wrapped;
     }
@@ -51,15 +48,15 @@ public class OpenSSLKey {
     /**
      * Returns the EVP_PKEY context for use in JNI calls.
      */
-    public NativeRef.EVP_PKEY getNativeRef() {
+    NativeRef.EVP_PKEY getNativeRef() {
         return ctx;
     }
 
-    public boolean isWrapped() {
+    boolean isWrapped() {
         return wrapped;
     }
 
-    public static OpenSSLKey fromPrivateKey(PrivateKey key) throws InvalidKeyException {
+    static OpenSSLKey fromPrivateKey(PrivateKey key) throws InvalidKeyException {
         if (key instanceof OpenSSLKeyHolder) {
             return ((OpenSSLKeyHolder) key).getOpenSSLKey();
         }
@@ -84,7 +81,7 @@ public class OpenSSLKey {
      *
      * @throws InvalidKeyException if parsing fails
      */
-    public static OpenSSLKey fromPrivateKeyPemInputStream(InputStream is)
+    static OpenSSLKey fromPrivateKeyPemInputStream(InputStream is)
             throws InvalidKeyException {
         OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
         try {
@@ -109,7 +106,7 @@ public class OpenSSLKey {
      * @param publicKey corresponding public key or {@code null} if not available. Some opaque
      *        private keys cannot be used by the TLS/SSL stack without the public key.
      */
-    public static OpenSSLKey fromPrivateKeyForTLSStackOnly(
+    static OpenSSLKey fromPrivateKeyForTLSStackOnly(
             PrivateKey privateKey, PublicKey publicKey) throws InvalidKeyException {
         OpenSSLKey result = getOpenSSLKey(privateKey);
         if (result != null) {
@@ -133,7 +130,7 @@ public class OpenSSLKey {
      *        be used by the TLS/SSL stack without the parameters because the private key itself
      *        might not expose the parameters.
      */
-    public static OpenSSLKey fromECPrivateKeyForTLSStackOnly(
+    static OpenSSLKey fromECPrivateKeyForTLSStackOnly(
             PrivateKey key, ECParameterSpec ecParams) throws InvalidKeyException {
         OpenSSLKey result = getOpenSSLKey(key);
         if (result != null) {
@@ -210,7 +207,7 @@ public class OpenSSLKey {
         }
     }
 
-    public static OpenSSLKey fromPublicKey(PublicKey key) throws InvalidKeyException {
+    static OpenSSLKey fromPublicKey(PublicKey key) throws InvalidKeyException {
         if (key instanceof OpenSSLKeyHolder) {
             return ((OpenSSLKeyHolder) key).getOpenSSLKey();
         }
@@ -236,7 +233,7 @@ public class OpenSSLKey {
      *
      * @throws InvalidKeyException if parsing fails
      */
-    public static OpenSSLKey fromPublicKeyPemInputStream(InputStream is)
+    static OpenSSLKey fromPublicKeyPemInputStream(InputStream is)
             throws InvalidKeyException {
         OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
         try {
@@ -253,7 +250,7 @@ public class OpenSSLKey {
         }
     }
 
-    public PublicKey getPublicKey() throws NoSuchAlgorithmException {
+    PublicKey getPublicKey() throws NoSuchAlgorithmException {
         switch (NativeCrypto.EVP_PKEY_type(ctx)) {
             case NativeConstants.EVP_PKEY_RSA:
                 return new OpenSSLRSAPublicKey(this);
@@ -286,7 +283,7 @@ public class OpenSSLKey {
         }
     }
 
-    public PrivateKey getPrivateKey() throws NoSuchAlgorithmException {
+    PrivateKey getPrivateKey() throws NoSuchAlgorithmException {
         switch (NativeCrypto.EVP_PKEY_type(ctx)) {
             case NativeConstants.EVP_PKEY_RSA:
                 return new OpenSSLRSAPrivateKey(this);

--- a/common/src/main/java/org/conscrypt/OpenSSLMac.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLMac.java
@@ -157,37 +157,37 @@ public abstract class OpenSSLMac extends MacSpi {
         resetContext();
     }
 
-    public static class HmacMD5 extends OpenSSLMac {
+    public static final class HmacMD5 extends OpenSSLMac {
         public HmacMD5() {
             super(EvpMdRef.MD5.EVP_MD, EvpMdRef.MD5.SIZE_BYTES);
         }
     }
 
-    public static class HmacSHA1 extends OpenSSLMac {
+    public static final class HmacSHA1 extends OpenSSLMac {
         public HmacSHA1() {
             super(EvpMdRef.SHA1.EVP_MD, EvpMdRef.SHA1.SIZE_BYTES);
         }
     }
 
-    public static class HmacSHA224 extends OpenSSLMac {
+    public static final class HmacSHA224 extends OpenSSLMac {
         public HmacSHA224() throws NoSuchAlgorithmException {
             super(EvpMdRef.SHA224.EVP_MD, EvpMdRef.SHA224.SIZE_BYTES);
         }
     }
 
-    public static class HmacSHA256 extends OpenSSLMac {
+    public static final class HmacSHA256 extends OpenSSLMac {
         public HmacSHA256() throws NoSuchAlgorithmException {
             super(EvpMdRef.SHA256.EVP_MD, EvpMdRef.SHA256.SIZE_BYTES);
         }
     }
 
-    public static class HmacSHA384 extends OpenSSLMac {
+    public static final class HmacSHA384 extends OpenSSLMac {
         public HmacSHA384() throws NoSuchAlgorithmException {
             super(EvpMdRef.SHA384.EVP_MD, EvpMdRef.SHA384.SIZE_BYTES);
         }
     }
 
-    public static class HmacSHA512 extends OpenSSLMac {
+    public static final class HmacSHA512 extends OpenSSLMac {
         public HmacSHA512() {
             super(EvpMdRef.SHA512.EVP_MD, EvpMdRef.SHA512.SIZE_BYTES);
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLMessageDigestJDK.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLMessageDigestJDK.java
@@ -157,37 +157,37 @@ public class OpenSSLMessageDigestJDK extends MessageDigestSpi implements Cloneab
         return result;
     }
 
-    public static class MD5 extends OpenSSLMessageDigestJDK {
+    public static final class MD5 extends OpenSSLMessageDigestJDK {
         public MD5() throws NoSuchAlgorithmException {
             super(EvpMdRef.MD5.EVP_MD, EvpMdRef.MD5.SIZE_BYTES);
         }
     }
 
-    public static class SHA1 extends OpenSSLMessageDigestJDK {
+    public static final class SHA1 extends OpenSSLMessageDigestJDK {
         public SHA1() throws NoSuchAlgorithmException {
             super(EvpMdRef.SHA1.EVP_MD, EvpMdRef.SHA1.SIZE_BYTES);
         }
     }
 
-    public static class SHA224 extends OpenSSLMessageDigestJDK {
+    public static final class SHA224 extends OpenSSLMessageDigestJDK {
         public SHA224() throws NoSuchAlgorithmException {
             super(EvpMdRef.SHA224.EVP_MD, EvpMdRef.SHA224.SIZE_BYTES);
         }
     }
 
-    public static class SHA256 extends OpenSSLMessageDigestJDK {
+    public static final class SHA256 extends OpenSSLMessageDigestJDK {
         public SHA256() throws NoSuchAlgorithmException {
             super(EvpMdRef.SHA256.EVP_MD, EvpMdRef.SHA256.SIZE_BYTES);
         }
     }
 
-    public static class SHA384 extends OpenSSLMessageDigestJDK {
+    public static final class SHA384 extends OpenSSLMessageDigestJDK {
         public SHA384() throws NoSuchAlgorithmException {
             super(EvpMdRef.SHA384.EVP_MD, EvpMdRef.SHA384.SIZE_BYTES);
         }
     }
 
-    public static class SHA512 extends OpenSSLMessageDigestJDK {
+    public static final class SHA512 extends OpenSSLMessageDigestJDK {
         public SHA512() throws NoSuchAlgorithmException {
             super(EvpMdRef.SHA512.EVP_MD, EvpMdRef.SHA512.SIZE_BYTES);
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -29,6 +29,8 @@ import java.security.Provider;
  * href="http://csrc.nist.gov/groups/ST/crypto_apps_infra/csor/algorithms.html">NIST cryptographic
  * algorithms</a></li>
  * </ul>
+ *
+ * @hide
  */
 @Internal
 public final class OpenSSLProvider extends Provider {
@@ -38,7 +40,7 @@ public final class OpenSSLProvider extends Provider {
      * Default name used in the {@link java.security.Security JCE system} by {@code OpenSSLProvider}
      * if the {@link #OpenSSLProvider() default constructor} is used.
      */
-    public static final String PROVIDER_NAME = "AndroidOpenSSL";
+    private static final String PROVIDER_NAME = "AndroidOpenSSL";
 
     private static final String PREFIX = OpenSSLProvider.class.getPackage().getName() + ".";
 

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
@@ -40,7 +40,7 @@ import java.security.spec.X509EncodedKeySpec;
  * @hide
  */
 @Internal
-public class OpenSSLRSAKeyFactory extends KeyFactorySpi {
+public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
 
     @Override
     protected PublicKey engineGeneratePublic(KeySpec keySpec) throws InvalidKeySpecException {

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAKeyPairGenerator.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAKeyPairGenerator.java
@@ -33,7 +33,7 @@ import java.security.spec.RSAKeyGenParameterSpec;
  * @hide
  */
 @Internal
-public class OpenSSLRSAKeyPairGenerator extends KeyPairGeneratorSpi {
+public final class OpenSSLRSAKeyPairGenerator extends KeyPairGeneratorSpi {
     /**
      * Default modulus size is 0x10001 (65537)
      */

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateCrtKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateCrtKey.java
@@ -29,11 +29,8 @@ import java.security.spec.RSAPrivateCrtKeySpec;
 /**
  * An implementation of {@link java.security.PrivateKey} for RSA keys which uses BoringSSL to
  * perform all the operations.
- *
- * @hide
  */
-@Internal
-public class OpenSSLRSAPrivateCrtKey extends OpenSSLRSAPrivateKey implements RSAPrivateCrtKey {
+final class OpenSSLRSAPrivateCrtKey extends OpenSSLRSAPrivateKey implements RSAPrivateCrtKey {
     private static final long serialVersionUID = 3785291944868707197L;
 
     private BigInteger publicExponent;
@@ -56,7 +53,7 @@ public class OpenSSLRSAPrivateCrtKey extends OpenSSLRSAPrivateKey implements RSA
         super(key, params);
     }
 
-    public OpenSSLRSAPrivateCrtKey(RSAPrivateCrtKeySpec rsaKeySpec) throws InvalidKeySpecException {
+    OpenSSLRSAPrivateCrtKey(RSAPrivateCrtKeySpec rsaKeySpec) throws InvalidKeySpecException {
         super(init(rsaKeySpec));
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateKey.java
@@ -34,17 +34,16 @@ import java.security.spec.RSAPrivateKeySpec;
  *
  * @hide
  */
-@Internal
-public class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
+class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
     private static final long serialVersionUID = 4872170254439578735L;
 
-    protected transient OpenSSLKey key;
+    transient OpenSSLKey key;
 
-    protected transient boolean fetchedParams;
+    transient boolean fetchedParams;
 
-    protected BigInteger modulus;
+    BigInteger modulus;
 
-    protected BigInteger privateExponent;
+    BigInteger privateExponent;
 
     OpenSSLRSAPrivateKey(OpenSSLKey key) {
         this.key = key;
@@ -98,7 +97,7 @@ public class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
         return new OpenSSLRSAPrivateKey(key, params);
     }
 
-    protected static OpenSSLKey wrapPlatformKey(RSAPrivateKey rsaPrivateKey)
+    static OpenSSLKey wrapPlatformKey(RSAPrivateKey rsaPrivateKey)
             throws InvalidKeyException {
         OpenSSLKey wrapper = Platform.wrapRsaKey(rsaPrivateKey);
         if (wrapper != null) {

--- a/common/src/main/java/org/conscrypt/OpenSSLRandom.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRandom.java
@@ -25,7 +25,7 @@ import java.security.SecureRandomSpi;
  * @hide
  */
 @Internal
-public class OpenSSLRandom extends SecureRandomSpi implements Serializable {
+public final class OpenSSLRandom extends SecureRandomSpi implements Serializable {
     private static final long serialVersionUID = 8506210602917522861L;
 
     @Override

--- a/common/src/main/java/org/conscrypt/OpenSSLServerSocketFactoryImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLServerSocketFactoryImpl.java
@@ -20,21 +20,19 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.security.KeyManagementException;
+import javax.net.ssl.SSLServerSocketFactory;
 
 /**
- * An implementation of {@link javax.net.ssl.SSLServerSocketFactory} using BoringSSL.
- *
- * @hide
+ * An implementation of {@link SSLServerSocketFactory} using BoringSSL.
  */
-@Internal
-public class OpenSSLServerSocketFactoryImpl extends javax.net.ssl.SSLServerSocketFactory {
+final class OpenSSLServerSocketFactoryImpl extends SSLServerSocketFactory {
     private static boolean useEngineSocketByDefault = SSLUtils.USE_ENGINE_SOCKET_BY_DEFAULT;
 
     private SSLParametersImpl sslParameters;
     private IOException instantiationException;
     private boolean useEngineSocket = useEngineSocketByDefault;
 
-    public OpenSSLServerSocketFactoryImpl() {
+    OpenSSLServerSocketFactoryImpl() {
         try {
             this.sslParameters = SSLParametersImpl.getDefault();
             this.sslParameters.setUseClientMode(false);
@@ -45,7 +43,7 @@ public class OpenSSLServerSocketFactoryImpl extends javax.net.ssl.SSLServerSocke
         }
     }
 
-    public OpenSSLServerSocketFactoryImpl(SSLParametersImpl sslParameters) {
+    OpenSSLServerSocketFactoryImpl(SSLParametersImpl sslParameters) {
         this.sslParameters = (SSLParametersImpl) sslParameters.clone();
         this.sslParameters.setUseClientMode(false);
     }
@@ -53,7 +51,7 @@ public class OpenSSLServerSocketFactoryImpl extends javax.net.ssl.SSLServerSocke
     /**
      * Configures the default socket to be created for all instances.
      */
-    public static void setUseEngineSocketByDefault(boolean useEngineSocket) {
+    static void setUseEngineSocketByDefault(boolean useEngineSocket) {
         useEngineSocketByDefault = useEngineSocket;
     }
 
@@ -61,7 +59,7 @@ public class OpenSSLServerSocketFactoryImpl extends javax.net.ssl.SSLServerSocke
      * Configures the socket to be created for this instance. If not called,
      * {@link #useEngineSocketByDefault} will be used.
      */
-    public void setUseEngineSocket(boolean useEngineSocket) {
+    void setUseEngineSocket(boolean useEngineSocket) {
         this.useEngineSocket = useEngineSocket;
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLServerSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLServerSocketImpl.java
@@ -22,32 +22,29 @@ import java.net.Socket;
 
 /**
  * BoringSSL-based implementation of server sockets.
- *
- * @hide
  */
-@Internal
-public class OpenSSLServerSocketImpl extends javax.net.ssl.SSLServerSocket {
+final class OpenSSLServerSocketImpl extends javax.net.ssl.SSLServerSocket {
     private final SSLParametersImpl sslParameters;
     private boolean channelIdEnabled;
     private boolean useEngineSocket;
 
-    protected OpenSSLServerSocketImpl(SSLParametersImpl sslParameters) throws IOException {
+    OpenSSLServerSocketImpl(SSLParametersImpl sslParameters) throws IOException {
         this.sslParameters = sslParameters;
     }
 
-    protected OpenSSLServerSocketImpl(int port, SSLParametersImpl sslParameters)
+    OpenSSLServerSocketImpl(int port, SSLParametersImpl sslParameters)
         throws IOException {
         super(port);
         this.sslParameters = sslParameters;
     }
 
-    protected OpenSSLServerSocketImpl(int port, int backlog, SSLParametersImpl sslParameters)
+    OpenSSLServerSocketImpl(int port, int backlog, SSLParametersImpl sslParameters)
         throws IOException {
         super(port, backlog);
         this.sslParameters = sslParameters;
     }
 
-    protected OpenSSLServerSocketImpl(int port,
+    OpenSSLServerSocketImpl(int port,
                                       int backlog,
                                       InetAddress iAddress,
                                       SSLParametersImpl sslParameters)
@@ -59,7 +56,7 @@ public class OpenSSLServerSocketImpl extends javax.net.ssl.SSLServerSocket {
     /**
      * Configures the socket to be created for this instance.
      */
-    public OpenSSLServerSocketImpl setUseEngineSocket(boolean useEngineSocket) {
+    OpenSSLServerSocketImpl setUseEngineSocket(boolean useEngineSocket) {
         this.useEngineSocket = useEngineSocket;
         return this;
     }
@@ -121,14 +118,14 @@ public class OpenSSLServerSocketImpl extends javax.net.ssl.SSLServerSocket {
     /**
      * Enables/disables the TLS Channel ID extension for this server socket.
      */
-    public void setChannelIdEnabled(boolean enabled) {
+    void setChannelIdEnabled(boolean enabled) {
       channelIdEnabled = enabled;
     }
 
     /**
      * Checks whether the TLS Channel ID extension is enabled for this server socket.
      */
-    public boolean isChannelIdEnabled() {
+    boolean isChannelIdEnabled() {
       return channelIdEnabled;
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLSessionImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSessionImpl.java
@@ -29,11 +29,8 @@ import javax.net.ssl.SSLSessionBindingListener;
 /**
  * Implementation of the class OpenSSLSessionImpl
  * based on BoringSSL.
- *
- * @hide
  */
-@Internal
-public class OpenSSLSessionImpl extends AbstractOpenSSLSession {
+class OpenSSLSessionImpl extends AbstractOpenSSLSession {
     private long creationTime = 0;
     long lastAccessedTime = 0;
     final X509Certificate[] localCertificates;
@@ -42,7 +39,7 @@ public class OpenSSLSessionImpl extends AbstractOpenSSLSession {
     private final Map<String, Object> values = new HashMap<String, Object>();
     private byte[] peerCertificateOcspData;
     private byte[] peerTlsSctData;
-    protected long sslSessionNativePointer;
+    long sslSessionNativePointer;
     private String peerHost;
     private int peerPort = -1;
     private String cipherSuite;
@@ -53,7 +50,7 @@ public class OpenSSLSessionImpl extends AbstractOpenSSLSession {
      * Class constructor creates an SSL session context given the appropriate
      * SSL parameters.
      */
-    protected OpenSSLSessionImpl(long sslSessionNativePointer, X509Certificate[] localCertificates,
+    OpenSSLSessionImpl(long sslSessionNativePointer, X509Certificate[] localCertificates,
             X509Certificate[] peerCertificates, byte[] peerCertificateOcspData,
             byte[] peerTlsSctData, String peerHost, int peerPort,
             AbstractSessionContext sessionContext) {

--- a/common/src/main/java/org/conscrypt/OpenSSLSignature.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignature.java
@@ -40,7 +40,7 @@ import java.security.spec.PSSParameterSpec;
  */
 @Internal
 public class OpenSSLSignature extends SignatureSpi {
-    private static enum EngineType {
+    private enum EngineType {
         RSA, EC,
     }
 
@@ -86,7 +86,7 @@ public class OpenSSLSignature extends SignatureSpi {
         this.evpMdRef = evpMdRef;
     }
 
-    private final void resetContext() throws InvalidAlgorithmParameterException {
+    private void resetContext() throws InvalidAlgorithmParameterException {
         NativeRef.EVP_MD_CTX ctxLocal = new NativeRef.EVP_MD_CTX(NativeCrypto.EVP_MD_CTX_create());
         if (signing) {
             evpPkeyCtx = NativeCrypto.EVP_DigestSignInit(ctxLocal, evpMdRef, key.getNativeRef());
@@ -354,7 +354,7 @@ public class OpenSSLSignature extends SignatureSpi {
         private long mgf1EvpMdRef;
         private int saltSizeBytes;
 
-        public RSAPSSPadding(
+        RSAPSSPadding(
                 long contentDigestEvpMdRef, String contentDigestAlgorithm, int saltSizeBytes) {
             super(contentDigestEvpMdRef, EngineType.RSA);
             this.contentDigestAlgorithm = contentDigestAlgorithm;

--- a/common/src/main/java/org/conscrypt/OpenSSLSignatureRawRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignatureRawRSA.java
@@ -33,7 +33,7 @@ import java.security.interfaces.RSAPublicKey;
  * @hide
  */
 @Internal
-public class OpenSSLSignatureRawRSA extends SignatureSpi {
+public final class OpenSSLSignatureRawRSA extends SignatureSpi {
     /**
      * The current OpenSSL key we're operating on.
      */

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketFactoryImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketFactoryImpl.java
@@ -21,34 +21,31 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.security.KeyManagementException;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
- * An implementation of {@link javax.net.ssl.SSLSocketFactory} based on BoringSSL.
- *
- * @hide
+ * An implementation of {@link SSLSocketFactory} based on BoringSSL.
  */
-@Internal
-public class OpenSSLSocketFactoryImpl extends javax.net.ssl.SSLSocketFactory {
+final class OpenSSLSocketFactoryImpl extends SSLSocketFactory {
     private static boolean useEngineSocketByDefault = SSLUtils.USE_ENGINE_SOCKET_BY_DEFAULT;
 
     private final SSLParametersImpl sslParameters;
     private final IOException instantiationException;
     private boolean useEngineSocket = useEngineSocketByDefault;
 
-    public OpenSSLSocketFactoryImpl() {
+    OpenSSLSocketFactoryImpl() {
         SSLParametersImpl sslParametersLocal = null;
         IOException instantiationExceptionLocal = null;
         try {
             sslParametersLocal = SSLParametersImpl.getDefault();
         } catch (KeyManagementException e) {
-            instantiationExceptionLocal = new IOException("Delayed instantiation exception:");
-            instantiationExceptionLocal.initCause(e);
+            instantiationExceptionLocal = new IOException("Delayed instantiation exception:", e);
         }
         this.sslParameters = sslParametersLocal;
         this.instantiationException = instantiationExceptionLocal;
     }
 
-    public OpenSSLSocketFactoryImpl(SSLParametersImpl sslParameters) {
+    OpenSSLSocketFactoryImpl(SSLParametersImpl sslParameters) {
         this.sslParameters = sslParameters;
         this.instantiationException = null;
     }
@@ -64,7 +61,7 @@ public class OpenSSLSocketFactoryImpl extends javax.net.ssl.SSLSocketFactory {
      * Configures the socket to be created for this instance. If not called,
      * {@link #useEngineSocketByDefault} will be used.
      */
-    public void setUseEngineSocket(boolean useEngineSocket) {
+    void setUseEngineSocket(boolean useEngineSocket) {
         this.useEngineSocket = useEngineSocket;
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -177,7 +177,7 @@ public class OpenSSLSocketImpl
 
     private int handshakeTimeoutMilliseconds = -1;  // -1 = same as timeout; 0 = infinite
 
-    protected OpenSSLSocketImpl(SSLParametersImpl sslParameters) throws IOException {
+    OpenSSLSocketImpl(SSLParametersImpl sslParameters) throws IOException {
         this.socket = this;
         this.peerHostname = null;
         this.peerPort = -1;
@@ -185,7 +185,7 @@ public class OpenSSLSocketImpl
         this.sslParameters = sslParameters;
     }
 
-    protected OpenSSLSocketImpl(String hostname, int port, SSLParametersImpl sslParameters)
+    OpenSSLSocketImpl(String hostname, int port, SSLParametersImpl sslParameters)
             throws IOException {
         super(hostname, port);
         this.socket = this;
@@ -195,7 +195,7 @@ public class OpenSSLSocketImpl
         this.sslParameters = sslParameters;
     }
 
-    protected OpenSSLSocketImpl(InetAddress address, int port, SSLParametersImpl sslParameters)
+    OpenSSLSocketImpl(InetAddress address, int port, SSLParametersImpl sslParameters)
             throws IOException {
         super(address, port);
         this.socket = this;
@@ -206,7 +206,7 @@ public class OpenSSLSocketImpl
     }
 
 
-    protected OpenSSLSocketImpl(String hostname, int port,
+    OpenSSLSocketImpl(String hostname, int port,
                                 InetAddress clientAddress, int clientPort,
                                 SSLParametersImpl sslParameters) throws IOException {
         super(hostname, port, clientAddress, clientPort);
@@ -217,7 +217,7 @@ public class OpenSSLSocketImpl
         this.sslParameters = sslParameters;
     }
 
-    protected OpenSSLSocketImpl(InetAddress address, int port,
+    OpenSSLSocketImpl(InetAddress address, int port,
                                 InetAddress clientAddress, int clientPort,
                                 SSLParametersImpl sslParameters) throws IOException {
         super(address, port, clientAddress, clientPort);
@@ -232,7 +232,7 @@ public class OpenSSLSocketImpl
      * Create an SSL socket that wraps another socket. Invoked by
      * OpenSSLSocketImplWrapper constructor.
      */
-    protected OpenSSLSocketImpl(Socket socket, String hostname, int port,
+    OpenSSLSocketImpl(Socket socket, String hostname, int port,
             boolean autoClose, SSLParametersImpl sslParameters) throws IOException {
         this.socket = socket;
         this.peerHostname = hostname;
@@ -672,10 +672,7 @@ public class OpenSSLSocketImpl
                     stateLock.wait();
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    IOException ioe = new IOException("Interrupted waiting for handshake");
-                    ioe.initCause(e);
-
-                    throw ioe;
+                    throw new IOException("Interrupted waiting for handshake", e);
                 }
             }
 
@@ -743,7 +740,7 @@ public class OpenSSLSocketImpl
             }
         }
 
-        public void awaitPendingOps() {
+        void awaitPendingOps() {
             if (DBG_STATE) {
                 synchronized (stateLock) {
                     if (state != STATE_CLOSED) throw new AssertionError("State is: " + state);
@@ -810,7 +807,7 @@ public class OpenSSLSocketImpl
         }
 
 
-        public void awaitPendingOps() {
+        void awaitPendingOps() {
             if (DBG_STATE) {
                 synchronized (stateLock) {
                     if (state != STATE_CLOSED) throw new AssertionError("State is: " + state);

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImplWrapper.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImplWrapper.java
@@ -25,15 +25,12 @@ import java.net.SocketException;
 
 /**
  * This class wraps the SSL functionality over an existing connected socket.
- *
- * @hide
  */
-@Internal
-public class OpenSSLSocketImplWrapper extends OpenSSLSocketImpl {
+class OpenSSLSocketImplWrapper extends OpenSSLSocketImpl {
 
     private Socket socket;
 
-    protected OpenSSLSocketImplWrapper(Socket socket, String hostname, int port,
+    OpenSSLSocketImplWrapper(Socket socket, String hostname, int port,
             boolean autoClose, SSLParametersImpl sslParameters) throws IOException {
         super(socket, hostname, port, autoClose, sslParameters);
         if (!socket.isConnected()) {

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
@@ -45,18 +45,15 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * An implementation of {@link X509CRL} based on BoringSSL.
- *
- * @hide
  */
-@Internal
-public class OpenSSLX509CRL extends X509CRL {
+final class OpenSSLX509CRL extends X509CRL {
     private final long mContext;
 
     private OpenSSLX509CRL(long ctx) {
         mContext = ctx;
     }
 
-    public static OpenSSLX509CRL fromX509DerInputStream(InputStream is) throws ParsingException {
+    static OpenSSLX509CRL fromX509DerInputStream(InputStream is) throws ParsingException {
         final OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
 
         try {
@@ -72,7 +69,7 @@ public class OpenSSLX509CRL extends X509CRL {
         }
     }
 
-    public static List<OpenSSLX509CRL> fromPkcs7DerInputStream(InputStream is)
+    static List<OpenSSLX509CRL> fromPkcs7DerInputStream(InputStream is)
             throws ParsingException {
         OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
 
@@ -95,7 +92,7 @@ public class OpenSSLX509CRL extends X509CRL {
         return certs;
     }
 
-    public static OpenSSLX509CRL fromX509PemInputStream(InputStream is) throws ParsingException {
+    static OpenSSLX509CRL fromX509PemInputStream(InputStream is) throws ParsingException {
         final OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
 
         try {
@@ -111,7 +108,7 @@ public class OpenSSLX509CRL extends X509CRL {
         }
     }
 
-    public static List<OpenSSLX509CRL> fromPkcs7PemInputStream(InputStream is)
+    static List<OpenSSLX509CRL> fromPkcs7PemInputStream(InputStream is)
             throws ParsingException {
         OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
 

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRLEntry.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRLEntry.java
@@ -29,11 +29,8 @@ import java.util.TimeZone;
 
 /**
  * An implementation of {@link X509CRLEntry} based on BoringSSL.
- *
- * @hide
  */
-@Internal
-public class OpenSSLX509CRLEntry extends X509CRLEntry {
+final class OpenSSLX509CRLEntry extends X509CRLEntry {
     private final long mContext;
 
     OpenSSLX509CRLEntry(long ctx) {

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CertPath.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CertPath.java
@@ -33,11 +33,8 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * An implementation of {@link CertPath} based on BoringSSL.
- *
- * @hide
  */
-@Internal
-public class OpenSSLX509CertPath extends CertPath {
+final class OpenSSLX509CertPath extends CertPath {
     private static final long serialVersionUID = -3249106005255170761L;
 
     private static final byte[] PKCS7_MARKER = new byte[] {
@@ -86,7 +83,7 @@ public class OpenSSLX509CertPath extends CertPath {
         return ALL_ENCODINGS.iterator();
     }
 
-    protected OpenSSLX509CertPath(List<? extends X509Certificate> certificates) {
+    OpenSSLX509CertPath(List<? extends X509Certificate> certificates) {
         super("X.509");
 
         mCertificates = certificates;
@@ -236,7 +233,7 @@ public class OpenSSLX509CertPath extends CertPath {
         }
     }
 
-    public static CertPath fromEncoding(InputStream inStream, String encoding)
+    static CertPath fromEncoding(InputStream inStream, String encoding)
             throws CertificateException {
         if (inStream == null) {
             throw new CertificateException("inStream == null");
@@ -250,7 +247,7 @@ public class OpenSSLX509CertPath extends CertPath {
         return fromEncoding(inStream, enc);
     }
 
-    public static CertPath fromEncoding(InputStream inStream) throws CertificateException {
+    static CertPath fromEncoding(InputStream inStream) throws CertificateException {
         if (inStream == null) {
             throw new CertificateException("inStream == null");
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -57,7 +57,7 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
  * @hide
  */
 @Internal
-public class OpenSSLX509Certificate extends X509Certificate {
+public final class OpenSSLX509Certificate extends X509Certificate {
     private static final long serialVersionUID = 1992239142393372128L;
 
     private transient final long mContext;

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
@@ -49,15 +49,15 @@ public class OpenSSLX509CertificateFactory extends CertificateFactorySpi {
     static class ParsingException extends Exception {
         private static final long serialVersionUID = 8390802697728301325L;
 
-        public ParsingException(String message) {
+        ParsingException(String message) {
             super(message);
         }
 
-        public ParsingException(Exception cause) {
+        ParsingException(Exception cause) {
             super(cause);
         }
 
-        public ParsingException(String message, Exception cause) {
+        ParsingException(String message, Exception cause) {
             super(message, cause);
         }
     }
@@ -68,7 +68,7 @@ public class OpenSSLX509CertificateFactory extends CertificateFactorySpi {
      * but it's already written in this language anyway.
      */
     private static abstract class Parser<T> {
-        public T generateItem(InputStream inStream) throws ParsingException {
+        T generateItem(InputStream inStream) throws ParsingException {
             if (inStream == null) {
                 throw new ParsingException("inStream == null");
             }
@@ -122,7 +122,7 @@ public class OpenSSLX509CertificateFactory extends CertificateFactorySpi {
             }
         }
 
-        public Collection<? extends T> generateItems(InputStream inStream)
+        Collection<? extends T> generateItems(InputStream inStream)
                 throws ParsingException {
             if (inStream == null) {
                 throw new ParsingException("inStream == null");
@@ -175,7 +175,7 @@ public class OpenSSLX509CertificateFactory extends CertificateFactorySpi {
              * can't anymore.
              */
             final List<T> coll = new ArrayList<T>();
-            T c = null;
+            T c;
             do {
                 /*
                  * If this stream supports marking, try to mark here in case

--- a/common/src/main/java/org/conscrypt/PSKKeyManager.java
+++ b/common/src/main/java/org/conscrypt/PSKKeyManager.java
@@ -95,9 +95,11 @@ import javax.net.ssl.SSLEngine;
  * }</pre>
  *
  * @deprecated This abstraction is deprecated because it does not work with TLS 1.3.
+ * @hide
  */
 @Deprecated
-interface PSKKeyManager extends KeyManager {
+@Internal
+public interface PSKKeyManager extends KeyManager {
 
     /**
      * Maximum supported length (in bytes) for PSK identity hint (in modified UTF-8 representation).

--- a/common/src/main/java/org/conscrypt/PSKKeyManager.java
+++ b/common/src/main/java/org/conscrypt/PSKKeyManager.java
@@ -97,8 +97,7 @@ import javax.net.ssl.SSLEngine;
  * @deprecated This abstraction is deprecated because it does not work with TLS 1.3.
  */
 @Deprecated
-@Internal
-public interface PSKKeyManager extends KeyManager {
+interface PSKKeyManager extends KeyManager {
 
     /**
      * Maximum supported length (in bytes) for PSK identity hint (in modified UTF-8 representation).

--- a/common/src/main/java/org/conscrypt/SSLNullSession.java
+++ b/common/src/main/java/org/conscrypt/SSLNullSession.java
@@ -26,30 +26,27 @@ import javax.net.ssl.*;
  * This is returned in the place of a {@link SSLSession} when no TLS connection could be negotiated,
  * but one was requested from a method that can't throw an exception such as {@link
  * SSLSocket#getSession()} before {@link SSLSocket#startHandshake()} is called.
- *
- * @hide
  */
-@Internal
-public final class SSLNullSession implements SSLSession, Cloneable {
+final class SSLNullSession implements SSLSession, Cloneable {
 
     /*
      * Holds default instances so class preloading doesn't create an instance of
      * it.
      */
     private static class DefaultHolder {
-        public static final SSLNullSession NULL_SESSION = new SSLNullSession();
+        static final SSLNullSession NULL_SESSION = new SSLNullSession();
     }
 
     private final HashMap<String, Object> values = new HashMap<String, Object>();
 
-    long creationTime;
-    long lastAccessedTime;
+    private long creationTime;
+    private long lastAccessedTime;
 
-    public static SSLSession getNullSession() {
+    static SSLSession getNullSession() {
         return DefaultHolder.NULL_SESSION;
     }
 
-    public SSLNullSession() {
+    SSLNullSession() {
         creationTime = System.currentTimeMillis();
         lastAccessedTime = creationTime;
     }

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -937,8 +937,6 @@ final class SSLParametersImpl implements Cloneable {
 
     /**
      * Gets the default X.509 trust manager.
-     * <p>
-     * TODO: Move this to a published API under dalvik.system.
      */
     static X509TrustManager getDefaultX509TrustManager()
             throws KeyManagementException {

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -54,11 +54,8 @@ import javax.security.auth.x500.X500Principal;
  * ssl socket, whether it require/want client authentication or not,
  * and controls whether new SSL sessions may be established by this
  * socket or not.
- *
- * @hide
  */
-@Internal
-public class SSLParametersImpl implements Cloneable {
+final class SSLParametersImpl implements Cloneable {
 
     // default source of X.509 certificate based authentication keys
     private static volatile X509KeyManager defaultX509KeyManager;
@@ -130,7 +127,7 @@ public class SSLParametersImpl implements Cloneable {
      * See {@link javax.net.ssl.SSLContext#init(KeyManager[],TrustManager[],
      * SecureRandom)} for more information
      */
-    protected SSLParametersImpl(KeyManager[] kms, TrustManager[] tms,
+    SSLParametersImpl(KeyManager[] kms, TrustManager[] tms,
             SecureRandom sr, ClientSessionContext clientSessionContext,
             ServerSessionContext serverSessionContext, String[] protocols)
             throws KeyManagementException {
@@ -170,7 +167,7 @@ public class SSLParametersImpl implements Cloneable {
                 x509CipherSuitesNeeded, pskCipherSuitesNeeded);
     }
 
-    protected static SSLParametersImpl getDefault() throws KeyManagementException {
+    static SSLParametersImpl getDefault() throws KeyManagementException {
         SSLParametersImpl result = defaultParameters;
         if (result == null) {
             // single-check idiom
@@ -187,28 +184,28 @@ public class SSLParametersImpl implements Cloneable {
     /**
      * Returns the appropriate session context.
      */
-    public AbstractSessionContext getSessionContext() {
+    AbstractSessionContext getSessionContext() {
         return client_mode ? clientSessionContext : serverSessionContext;
     }
 
     /**
      * @return server session context
      */
-    protected ServerSessionContext getServerSessionContext() {
+    ServerSessionContext getServerSessionContext() {
         return serverSessionContext;
     }
 
     /**
      * @return client session context
      */
-    protected ClientSessionContext getClientSessionContext() {
+    ClientSessionContext getClientSessionContext() {
         return clientSessionContext;
     }
 
     /**
      * @return X.509 key manager or {@code null} for none.
      */
-    protected X509KeyManager getX509KeyManager() {
+    X509KeyManager getX509KeyManager() {
         return x509KeyManager;
     }
 
@@ -216,21 +213,21 @@ public class SSLParametersImpl implements Cloneable {
      * @return Pre-Shared Key (PSK) key manager or {@code null} for none.
      */
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
-    protected PSKKeyManager getPSKKeyManager() {
+    PSKKeyManager getPSKKeyManager() {
         return pskKeyManager;
     }
 
     /**
      * @return X.509 trust manager or {@code null} for none.
      */
-    protected X509TrustManager getX509TrustManager() {
+    X509TrustManager getX509TrustManager() {
         return x509TrustManager;
     }
 
     /**
      * @return secure random
      */
-    protected SecureRandom getSecureRandom() {
+    SecureRandom getSecureRandom() {
         if (secureRandom != null) {
             return secureRandom;
         }
@@ -246,28 +243,28 @@ public class SSLParametersImpl implements Cloneable {
     /**
      * @return the secure random member reference, even it is null
      */
-    protected SecureRandom getSecureRandomMember() {
+    SecureRandom getSecureRandomMember() {
         return secureRandom;
     }
 
     /**
      * @return the names of enabled cipher suites
      */
-    protected String[] getEnabledCipherSuites() {
+    String[] getEnabledCipherSuites() {
         return enabledCipherSuites.clone();
     }
 
     /**
      * Sets the enabled cipher suites after filtering through OpenSSL.
      */
-    protected void setEnabledCipherSuites(String[] cipherSuites) {
+    void setEnabledCipherSuites(String[] cipherSuites) {
         enabledCipherSuites = NativeCrypto.checkEnabledCipherSuites(cipherSuites).clone();
     }
 
     /**
      * @return the set of enabled protocols
      */
-    protected String[] getEnabledProtocols() {
+    String[] getEnabledProtocols() {
         return enabledProtocols.clone();
     }
 
@@ -275,7 +272,7 @@ public class SSLParametersImpl implements Cloneable {
      * Sets the list of available protocols for use in SSL connection.
      * @throws IllegalArgumentException if {@code protocols == null}
      */
-    protected void setEnabledProtocols(String[] protocols) {
+    void setEnabledProtocols(String[] protocols) {
         if (protocols == null) {
             throw new IllegalArgumentException("protocols == null");
         }
@@ -315,7 +312,7 @@ public class SSLParametersImpl implements Cloneable {
      * Tunes the peer holding this parameters to work in client mode.
      * @param   mode if the peer is configured to work in client mode
      */
-    protected void setUseClientMode(boolean mode) {
+    void setUseClientMode(boolean mode) {
         client_mode = mode;
     }
 
@@ -323,14 +320,14 @@ public class SSLParametersImpl implements Cloneable {
      * Returns the value indicating if the parameters configured to work
      * in client mode.
      */
-    protected boolean getUseClientMode() {
+    boolean getUseClientMode() {
         return client_mode;
     }
 
     /**
      * Tunes the peer holding this parameters to require client authentication
      */
-    protected void setNeedClientAuth(boolean need) {
+    void setNeedClientAuth(boolean need) {
         need_client_auth = need;
         // reset the want_client_auth setting
         want_client_auth = false;
@@ -340,14 +337,14 @@ public class SSLParametersImpl implements Cloneable {
      * Returns the value indicating if the peer with this parameters tuned
      * to require client authentication
      */
-    protected boolean getNeedClientAuth() {
+    boolean getNeedClientAuth() {
         return need_client_auth;
     }
 
     /**
      * Tunes the peer holding this parameters to request client authentication
      */
-    protected void setWantClientAuth(boolean want) {
+    void setWantClientAuth(boolean want) {
         want_client_auth = want;
         // reset the need_client_auth setting
         need_client_auth = false;
@@ -357,7 +354,7 @@ public class SSLParametersImpl implements Cloneable {
      * Returns the value indicating if the peer with this parameters
      * tuned to request client authentication
      */
-    protected boolean getWantClientAuth() {
+    boolean getWantClientAuth() {
         return want_client_auth;
     }
 
@@ -365,7 +362,7 @@ public class SSLParametersImpl implements Cloneable {
      * Allows/disallows the peer holding this parameters to
      * create new SSL session
      */
-    protected void setEnableSessionCreation(boolean flag) {
+    void setEnableSessionCreation(boolean flag) {
         enable_session_creation = flag;
     }
 
@@ -373,7 +370,7 @@ public class SSLParametersImpl implements Cloneable {
      * Returns the value indicating if the peer with this parameters
      * allowed to cteate new SSL session
      */
-    protected boolean getEnableSessionCreation() {
+    boolean getEnableSessionCreation() {
         return enable_session_creation;
     }
 
@@ -385,7 +382,7 @@ public class SSLParametersImpl implements Cloneable {
      * Whether connections using this SSL connection should use the TLS
      * extension Server Name Indication (SNI).
      */
-    protected void setUseSni(boolean flag) {
+    void setUseSni(boolean flag) {
         useSni = Boolean.valueOf(flag);
     }
 
@@ -393,23 +390,23 @@ public class SSLParametersImpl implements Cloneable {
      * Returns whether connections using this SSL connection should use the TLS
      * extension Server Name Indication (SNI).
      */
-    protected boolean getUseSni() {
+    boolean getUseSni() {
         return useSni != null ? useSni.booleanValue() : isSniEnabledByDefault();
     }
 
-    public void setCTVerificationEnabled(boolean enabled) {
+    void setCTVerificationEnabled(boolean enabled) {
         ctVerificationEnabled = enabled;
     }
 
-    public void setSCTExtension(byte[] extension) {
+    void setSCTExtension(byte[] extension) {
         sctExtension = extension;
     }
 
-    public void setOCSPResponse(byte[] response) {
+    void setOCSPResponse(byte[] response) {
         ocspResponse = response;
     }
 
-    public byte[] getOCSPResponse() {
+    byte[] getOCSPResponse() {
         return ocspResponse;
     }
 
@@ -845,7 +842,7 @@ public class SSLParametersImpl implements Cloneable {
      * and
      * {@link X509ExtendedKeyManager#chooseEngineClientAlias(String[], java.security.Principal[], javax.net.ssl.SSLEngine)}
      */
-    public interface AliasChooser {
+    interface AliasChooser {
         String chooseClientAlias(X509KeyManager keyManager, X500Principal[] issuers,
                 String[] keyTypes);
 
@@ -857,7 +854,7 @@ public class SSLParametersImpl implements Cloneable {
      * those taking an {@code SSLEngine}.
      */
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
-    public interface PSKCallbacks {
+    interface PSKCallbacks {
         String chooseServerPSKIdentityHint(PSKKeyManager keyManager);
         String chooseClientPSKIdentity(PSKKeyManager keyManager, String identityHint);
         SecretKey getPSKKey(PSKKeyManager keyManager, String identityHint, String identity);
@@ -943,7 +940,7 @@ public class SSLParametersImpl implements Cloneable {
      * <p>
      * TODO: Move this to a published API under dalvik.system.
      */
-    public static X509TrustManager getDefaultX509TrustManager()
+    static X509TrustManager getDefaultX509TrustManager()
             throws KeyManagementException {
         X509TrustManager result = defaultX509TrustManager;
         if (result == null) {
@@ -975,8 +972,7 @@ public class SSLParametersImpl implements Cloneable {
     }
 
     /**
-     * Finds the first {@link X509ExtendedTrustManager} or
-     * {@link X509TrustManager} element in the provided array.
+     * Finds the first {@link X509TrustManager} element in the provided array.
      *
      * @return the first {@code X509ExtendedTrustManager} or
      *         {@code X509TrustManager} or {@code null} if not found.
@@ -990,19 +986,19 @@ public class SSLParametersImpl implements Cloneable {
         return null;
     }
 
-    public String getEndpointIdentificationAlgorithm() {
+    String getEndpointIdentificationAlgorithm() {
         return endpointIdentificationAlgorithm;
     }
 
-    public void setEndpointIdentificationAlgorithm(String endpointIdentificationAlgorithm) {
+    void setEndpointIdentificationAlgorithm(String endpointIdentificationAlgorithm) {
         this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
     }
 
-    public boolean getUseCipherSuitesOrder() {
+    boolean getUseCipherSuitesOrder() {
         return useCipherSuitesOrder;
     }
 
-    public void setUseCipherSuitesOrder(boolean useCipherSuitesOrder) {
+    void setUseCipherSuitesOrder(boolean useCipherSuitesOrder) {
         this.useCipherSuitesOrder = useCipherSuitesOrder;
     }
 
@@ -1051,7 +1047,7 @@ public class SSLParametersImpl implements Cloneable {
      * <p>
      * Visible for testing.
      */
-    public static String getClientKeyType(byte clientCertificateType) {
+    static String getClientKeyType(byte clientCertificateType) {
         // See also http://www.ietf.org/assignments/tls-parameters/tls-parameters.xml
         switch (clientCertificateType) {
             case NativeConstants.TLS_CT_RSA_SIGN:
@@ -1080,7 +1076,7 @@ public class SSLParametersImpl implements Cloneable {
      *
      * Visible for testing.
      */
-    public static Set<String> getSupportedClientKeyTypes(byte[] clientCertificateTypes) {
+    static Set<String> getSupportedClientKeyTypes(byte[] clientCertificateTypes) {
         Set<String> result = new HashSet<String>(clientCertificateTypes.length);
         for (byte keyTypeCode : clientCertificateTypes) {
             String keyType = getClientKeyType(keyTypeCode);
@@ -1143,7 +1139,7 @@ public class SSLParametersImpl implements Cloneable {
     /**
      * Check if SCT verification is enforced for a given hostname.
      */
-    public boolean isCTVerificationEnabled(String hostname) {
+    boolean isCTVerificationEnabled(String hostname) {
         if (hostname == null) {
             return false;
         }

--- a/common/src/main/java/org/conscrypt/SSLServerSessionCache.java
+++ b/common/src/main/java/org/conscrypt/SSLServerSessionCache.java
@@ -29,11 +29,8 @@ import javax.net.ssl.SSLSession;
  * {@code SSLSession}s into raw bytes and vice versa. The exact makeup of the
  * session data is dependent upon the caller's implementation and is opaque to
  * the {@code SSLServerSessionCache} implementation.
- *
- * @hide
  */
-@Internal
-public interface SSLServerSessionCache {
+interface SSLServerSessionCache {
     /**
      * Gets the session data for given session ID.
      *

--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -48,13 +48,11 @@ import javax.net.ssl.SSLHandshakeException;
  * Utility methods for SSL packet processing. Copied from the Netty project.
  * <p>
  * This is a public class to allow testing to occur on Android via CTS.
- *
- * @hide
  */
-public final class SSLUtils {
+final class SSLUtils {
     static final boolean USE_ENGINE_SOCKET_BY_DEFAULT =
             Boolean.parseBoolean(System.getProperty("org.conscrypt.useEngineSocketByDefault"));
-    static final int MAX_PROTOCOL_LENGTH = 255;
+    private static final int MAX_PROTOCOL_LENGTH = 255;
 
     /**
      * This is the maximum overhead when encrypting plaintext as defined by
@@ -80,7 +78,7 @@ public final class SSLUtils {
      * Calculates the minimum bytes required in the encrypted output buffer for the given number of
      * plaintext source bytes.
      */
-    public static int calculateOutNetBufSize(int pendingBytes) {
+    static int calculateOutNetBufSize(int pendingBytes) {
         return min(SSL3_RT_MAX_PACKET_SIZE,
                 MAX_ENCRYPTION_OVERHEAD_LENGTH + min(MAX_ENCRYPTION_OVERHEAD_DIFF, pendingBytes));
     }
@@ -119,7 +117,7 @@ public final class SSLUtils {
      * @throws IllegalArgumentException Is thrown if the given {@link ByteBuffer} has not at least
      * {@link org.conscrypt.NativeConstants#SSL3_RT_HEADER_LENGTH} bytes to read.
      */
-    public static int getEncryptedPacketLength(ByteBuffer[] buffers, int offset) {
+    static int getEncryptedPacketLength(ByteBuffer[] buffers, int offset) {
         ByteBuffer buffer = buffers[offset];
 
         // Check if everything we need is in one ByteBuffer. If so we can make use of the fast-path.
@@ -158,7 +156,7 @@ public final class SSLUtils {
      * @param protocols the list of protocols to be encoded
      * @return the encoded form of the protocol list.
      */
-    public static byte[] toLengthPrefixedList(String... protocols) {
+    static byte[] toLengthPrefixedList(String... protocols) {
         // Calculate the encoded length.
         int length = 0;
         for (int i = 0; i < protocols.length; ++i) {

--- a/common/src/main/java/org/conscrypt/ServerSessionContext.java
+++ b/common/src/main/java/org/conscrypt/ServerSessionContext.java
@@ -25,7 +25,7 @@ import javax.net.ssl.SSLSession;
  * @hide
  */
 @Internal
-public class ServerSessionContext extends AbstractSessionContext {
+public final class ServerSessionContext extends AbstractSessionContext {
 
     private SSLServerSessionCache persistentCache;
 

--- a/common/src/main/java/org/conscrypt/X509PublicKey.java
+++ b/common/src/main/java/org/conscrypt/X509PublicKey.java
@@ -22,18 +22,15 @@ import java.util.Arrays;
 /**
  * A simple but useless key class that holds X.509 public key information when
  * the appropriate KeyFactory for the key algorithm is not available.
- *
- * @hide
  */
-@Internal
-public class X509PublicKey implements PublicKey {
+final class X509PublicKey implements PublicKey {
     private static final long serialVersionUID = -8610156854731664298L;
 
     private final String algorithm;
 
     private final byte[] encoded;
 
-    public X509PublicKey(String algorithm, byte[] encoded) {
+    X509PublicKey(String algorithm, byte[] encoded) {
         this.algorithm = algorithm;
         this.encoded = encoded;
     }

--- a/constants/build.gradle
+++ b/constants/build.gradle
@@ -70,3 +70,6 @@ model {
 // Don't include this artifact in the distribution.
 tasks.install.enabled = false
 tasks.uploadArchives.enabled = false;
+
+// Disable the javadoc task.
+tasks.withType(Javadoc).all { enabled = false }

--- a/libcore-stub/src/main/java/libcore/java/io/NullPrintStream.java
+++ b/libcore-stub/src/main/java/libcore/java/io/NullPrintStream.java
@@ -29,52 +29,118 @@ public final class NullPrintStream extends PrintStream {
         // super class complains if argument is null
         super((OutputStream) new ByteArrayOutputStream());
     }
+
+    @Override
     public boolean checkError() {
         return false;
     }
+
+    @Override
     protected void clearError() {}
+
+    @Override
     public void close() {}
+
+    @Override
     public void flush() {}
+
+    @Override
     public PrintStream format(String format, Object... args) {
         return this;
     }
+
+    @Override
     public PrintStream format(Locale l, String format, Object... args) {
         return this;
     }
+
+    @Override
     public PrintStream printf(String format, Object... args) {
         return this;
     }
+
+    @Override
     public PrintStream printf(Locale l, String format, Object... args) {
         return this;
     }
+
+    @Override
     public void print(char[] charArray) {}
+
+    @Override
     public void print(char ch) {}
+
+    @Override
     public void print(double dnum) {}
+
+    @Override
     public void print(float fnum) {}
+
+    @Override
     public void print(int inum) {}
+
+    @Override
     public void print(long lnum) {}
+
+    @Override
     public void print(Object obj) {}
+
+    @Override
     public void print(String str) {}
+
+    @Override
     public void print(boolean bool) {}
+
+    @Override
     public void println() {}
+
+    @Override
     public void println(char[] charArray) {}
+
+    @Override
     public void println(char ch) {}
+
+    @Override
     public void println(double dnum) {}
+
+    @Override
     public void println(float fnum) {}
+
+    @Override
     public void println(int inum) {}
+
+    @Override
     public void println(long lnum) {}
+
+    @Override
     public void println(Object obj) {}
+
+    @Override
     public void println(String str) {}
+
+    @Override
     public void println(boolean bool) {}
+
+    @Override
     protected void setError() {}
+
+    @Override
     public void write(byte[] buffer, int offset, int length) {}
+
+    @Override
     public void write(int oneByte) {}
+
+    @Override
     public PrintStream append(char c) {
         return this;
     }
+
+    @Override
     public PrintStream append(CharSequence csq) {
         return this;
     }
+
+    @Override
     public PrintStream append(CharSequence csq, int start, int end) {
         return this;
     }

--- a/libcore-stub/src/main/java/libcore/java/security/CpuFeatures.java
+++ b/libcore-stub/src/main/java/libcore/java/security/CpuFeatures.java
@@ -58,6 +58,7 @@ public class CpuFeatures {
 
     private static String getFieldFromCpuinfo(String field) {
         try {
+            @SuppressWarnings("DefaultCharset")
             BufferedReader br = new BufferedReader(new FileReader("/proc/cpuinfo"));
             Pattern p = Pattern.compile(field + "\\s*:\\s*(.*)");
 

--- a/libcore-stub/src/main/java/libcore/javax/net/ssl/FakeSSLSession.java
+++ b/libcore-stub/src/main/java/libcore/javax/net/ssl/FakeSSLSession.java
@@ -16,98 +16,121 @@
 
 package libcore.javax.net.ssl;
 
+import java.nio.charset.Charset;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
 
 public class FakeSSLSession implements SSLSession {
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
     final String host;
 
     public FakeSSLSession(String host) {
         this.host = host;
     }
 
+    @Override
     public int getApplicationBufferSize() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public String getCipherSuite() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public long getCreationTime() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public byte[] getId() {
-        return host.getBytes();
+        return host.getBytes(UTF_8);
     }
 
+    @Override
     public long getLastAccessedTime() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public Certificate[] getLocalCertificates() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public Principal getLocalPrincipal() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public int getPacketBufferSize() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public javax.security.cert.X509Certificate[] getPeerCertificateChain() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public Certificate[] getPeerCertificates() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public String getPeerHost() {
         return host;
     }
 
+    @Override
     public int getPeerPort() {
         return 443;
     }
 
+    @Override
     public Principal getPeerPrincipal() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public String getProtocol() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public SSLSessionContext getSessionContext() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public Object getValue(String name) {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public String[] getValueNames() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public void invalidate() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public boolean isValid() {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public void putValue(String name, Object value) {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public void removeValue(String name) {
         throw new UnsupportedOperationException();
     }

--- a/libcore-stub/src/main/java/libcore/javax/net/ssl/TestKeyManager.java
+++ b/libcore-stub/src/main/java/libcore/javax/net/ssl/TestKeyManager.java
@@ -58,6 +58,7 @@ public final class TestKeyManager extends X509ExtendedKeyManager {
         this.keyManager = keyManager;
     }
 
+    @Override
     public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
         out.print("TestKeyManager.chooseClientAlias");
         out.print(" | keyTypes: ");
@@ -83,6 +84,7 @@ public final class TestKeyManager extends X509ExtendedKeyManager {
         }
     }
 
+    @Override
     public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
         out.print("TestKeyManager.chooseServerAlias");
         out.print(" | keyType: ");
@@ -117,6 +119,7 @@ public final class TestKeyManager extends X509ExtendedKeyManager {
         return alias;
     }
 
+    @Override
     public X509Certificate[] getCertificateChain(String alias) {
         out.print("TestKeyManager.getCertificateChain");
         out.print(" | alias: ");
@@ -134,6 +137,7 @@ public final class TestKeyManager extends X509ExtendedKeyManager {
         return certs;
     }
 
+    @Override
     public String[] getClientAliases(String keyType, Principal[] issuers) {
         out.print("TestKeyManager.getClientAliases");
         out.print(" | keyType: ");
@@ -143,6 +147,7 @@ public final class TestKeyManager extends X509ExtendedKeyManager {
         return dumpAliases(keyManager.getClientAliases(keyType, issuers));
     }
 
+    @Override
     public String[] getServerAliases(String keyType, Principal[] issuers) {
         out.print("TestKeyManager.getServerAliases");
         out.print(" | keyType: ");
@@ -162,6 +167,7 @@ public final class TestKeyManager extends X509ExtendedKeyManager {
         return aliases;
     }
 
+    @Override
     public PrivateKey getPrivateKey(String alias) {
         out.print("TestKeyManager.getPrivateKey");
         out.print(" | alias: ");
@@ -172,6 +178,7 @@ public final class TestKeyManager extends X509ExtendedKeyManager {
         return pk;
     }
 
+    @Override
     public String chooseEngineClientAlias(String[] keyTypes, Principal[] issuers, SSLEngine e) {
         out.print("TestKeyManager.chooseEngineClientAlias");
         out.print(" | keyTypes: ");
@@ -185,6 +192,7 @@ public final class TestKeyManager extends X509ExtendedKeyManager {
         return dumpAlias(keyManager.chooseEngineClientAlias(keyTypes, issuers, e));
     }
 
+    @Override
     public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine e) {
         out.print("TestKeyManager.chooseEngineServerAlias");
         out.print(" | keyType: ");

--- a/libcore-stub/src/main/java/libcore/javax/net/ssl/TestTrustManager.java
+++ b/libcore-stub/src/main/java/libcore/javax/net/ssl/TestTrustManager.java
@@ -68,6 +68,7 @@ public final class TestTrustManager extends X509ExtendedTrustManager {
         this.trustManager = trustManager;
     }
 
+    @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType)
             throws CertificateException {
         out.print("TestTrustManager.checkClientTrusted "
@@ -133,6 +134,7 @@ public final class TestTrustManager extends X509ExtendedTrustManager {
         }
     }
 
+    @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType)
             throws CertificateException {
         out.print("TestTrustManager.checkServerTrusted "
@@ -205,6 +207,7 @@ public final class TestTrustManager extends X509ExtendedTrustManager {
      * @return the list of certificate issuer authorities which are trusted for
      *         authentication of peers.
      */
+    @Override
     public X509Certificate[] getAcceptedIssuers() {
         X509Certificate[] result = trustManager.getAcceptedIssuers();
         out.print("TestTrustManager.getAcceptedIssuers result=" + result.length);

--- a/openjdk/src/test/java/org/conscrypt/ChainStrengthAnalyzerTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ChainStrengthAnalyzerTest.java
@@ -273,7 +273,7 @@ public class ChainStrengthAnalyzerTest extends TestCase {
 
     private static X509Certificate createCert(String pem) throws Exception {
         CertificateFactory cf = CertificateFactory.getInstance("X509");
-        InputStream pemInput = new ByteArrayInputStream(pem.getBytes());
+        InputStream pemInput = new ByteArrayInputStream(pem.getBytes("UTF-8"));
         return (X509Certificate) cf.generateCertificate(pemInput);
     }
 }

--- a/openjdk/src/test/java/org/conscrypt/DuckTypedPSKKeyManagerTest.java
+++ b/openjdk/src/test/java/org/conscrypt/DuckTypedPSKKeyManagerTest.java
@@ -139,7 +139,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         assertSame(identityHint, mockInvocationHandler.lastInvokedMethodArgs[0]);
         assertSame(mSSLEngine, mockInvocationHandler.lastInvokedMethodArgs[1]);
 
-        SecretKey key = new SecretKeySpec("arbitrary".getBytes(), "RAW");
+        SecretKey key = new SecretKeySpec("arbitrary".getBytes("UTF-8"), "RAW");
         mockInvocationHandler.returnValue = key;
         assertSame(key, pskKeyManager.getKey(identityHint, identity, mSSLSocket));
         assertEquals("getKey", mockInvocationHandler.lastInvokedMethod.getName());

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -325,7 +325,9 @@ public class NativeCryptoTest {
             NativeCrypto.SSL_CTX_set_session_id_context(c, new byte[32]);
             try {
                 NativeCrypto.SSL_CTX_set_session_id_context(c, new byte[33]);
+                fail("Expected IllegalArgumentException");
             } catch (IllegalArgumentException expected) {
+                // Expected.
             }
         } finally {
             NativeCrypto.SSL_CTX_free(c);
@@ -1867,7 +1869,7 @@ public class NativeCryptoTest {
             public void afterHandshake(long session, long ssl, long context, Socket socket,
                     FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
                 byte[] negotiated = NativeCrypto.SSL_get0_alpn_selected(ssl);
-                assertEquals("spdy/2", new String(negotiated));
+                assertEquals("spdy/2", new String(negotiated, "UTF-8"));
                 super.afterHandshake(session, ssl, context, socket, fd, callback);
             }
         };
@@ -1876,7 +1878,7 @@ public class NativeCryptoTest {
             public void afterHandshake(long session, long ssl, long c, Socket sock,
                     FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
                 byte[] negotiated = NativeCrypto.SSL_get0_alpn_selected(ssl);
-                assertEquals("spdy/2", new String(negotiated));
+                assertEquals("spdy/2", new String(negotiated, "UTF-8"));
                 super.afterHandshake(session, ssl, c, sock, fd, callback);
             }
         };
@@ -2811,7 +2813,7 @@ public class NativeCryptoTest {
 
     @Test
     public void test_create_BIO_InputStream() throws Exception {
-        byte[] actual = "Test".getBytes();
+        byte[] actual = "Test".getBytes("UTF-8");
         ByteArrayInputStream is = new ByteArrayInputStream(actual);
 
         @SuppressWarnings("resource")
@@ -2829,7 +2831,7 @@ public class NativeCryptoTest {
 
     @Test
     public void test_create_BIO_OutputStream() throws Exception {
-        byte[] actual = "Test".getBytes();
+        byte[] actual = "Test".getBytes("UTF-8");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
 
         long ctx = NativeCrypto.create_BIO_OutputStream(os);

--- a/openjdk/src/test/java/org/conscrypt/OpenSSLKeyTest.java
+++ b/openjdk/src/test/java/org/conscrypt/OpenSSLKeyTest.java
@@ -48,7 +48,7 @@ public class OpenSSLKeyTest extends TestCase {
         "e9e1326013a84467190dd94c5aabaf148ad5e3c452a2dd063e1d4c044d6994a1", 16);
 
     public void test_fromPublicKeyPemInputStream() throws Exception {
-        ByteArrayInputStream is = new ByteArrayInputStream(RSA_PUBLIC_KEY.getBytes());
+        ByteArrayInputStream is = new ByteArrayInputStream(RSA_PUBLIC_KEY.getBytes("UTF-8"));
         OpenSSLKey key = OpenSSLKey.fromPublicKeyPemInputStream(is);
         OpenSSLRSAPublicKey publicKey = (OpenSSLRSAPublicKey)key.getPublicKey();
         assertEquals(RSA_MODULUS, publicKey.getModulus());
@@ -56,7 +56,7 @@ public class OpenSSLKeyTest extends TestCase {
     }
 
     public void test_fromPrivateKeyPemInputStream() throws Exception {
-        ByteArrayInputStream is = new ByteArrayInputStream(RSA_PRIVATE_KEY.getBytes());
+        ByteArrayInputStream is = new ByteArrayInputStream(RSA_PRIVATE_KEY.getBytes("UTF-8"));
         OpenSSLKey key = OpenSSLKey.fromPrivateKeyPemInputStream(is);
         OpenSSLRSAPrivateKey privateKey = (OpenSSLRSAPrivateKey)key.getPrivateKey();
         assertEquals(RSA_MODULUS, privateKey.getModulus());

--- a/openjdk/src/test/java/org/conscrypt/OpenSSLServerSocketImplTest.java
+++ b/openjdk/src/test/java/org/conscrypt/OpenSSLServerSocketImplTest.java
@@ -52,6 +52,7 @@ public class OpenSSLServerSocketImplTest {
         DEFAULT(getConscryptServerSocketFactory(false)),
         ENGINE(getConscryptServerSocketFactory(true));
 
+        @SuppressWarnings("ImmutableEnumChecker")
         private final SSLServerSocketFactory serverSocketFactory;
 
         SocketType(SSLServerSocketFactory serverSocketFactory) {

--- a/openjdk/src/test/java/org/conscrypt/SSLUtilsTest.java
+++ b/openjdk/src/test/java/org/conscrypt/SSLUtilsTest.java
@@ -16,6 +16,7 @@
 
 package org.conscrypt;
 
+import static org.conscrypt.TestUtils.UTF_8;
 import static org.junit.Assert.assertArrayEquals;
 
 import org.junit.Test;
@@ -25,7 +26,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class SSLUtilsTest {
     private static final byte[] VALID_CHARACTERS =
-            "0123456789abcdefghijklmnopqrstuvwxyz".getBytes();
+            "0123456789abcdefghijklmnopqrstuvwxyz".getBytes(UTF_8);
 
     @Test
     public void noProtocolsShouldSucceed() {
@@ -41,7 +42,7 @@ public class SSLUtilsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void longProtocolShouldThrow() {
-        SSLUtils.toLengthPrefixedList(new String(newValidProtocol(256)));
+        SSLUtils.toLengthPrefixedList(new String(newValidProtocol(256), UTF_8));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -52,9 +53,9 @@ public class SSLUtilsTest {
     @Test
     public void validProtocolsShouldSucceed() {
         byte[][] protocols = new byte[][]{
-                "protocol-1".getBytes(),
-                "protocol-2".getBytes(),
-                "protocol-3".getBytes(),
+                "protocol-1".getBytes(UTF_8),
+                "protocol-2".getBytes(UTF_8),
+                "protocol-3".getBytes(UTF_8),
         };
         byte[] expected = getExpectedEncodedBytes(protocols);
         byte[] actual = SSLUtils.toLengthPrefixedList(toStrings(protocols));
@@ -65,7 +66,7 @@ public class SSLUtilsTest {
         int numProtocols = protocols.length;
         String[] out = new String[numProtocols];
         for(int i = 0; i < numProtocols; ++i) {
-            out[i] = new String(protocols[i]);
+            out[i] = new String(protocols[i], UTF_8);
         }
         return out;
     }

--- a/platform/src/main/java/org/conscrypt/CertBlacklist.java
+++ b/platform/src/main/java/org/conscrypt/CertBlacklist.java
@@ -34,6 +34,10 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * @hide
+ */
+@Internal
 public final class CertBlacklist {
     private static final Logger logger = Logger.getLogger(CertBlacklist.class.getName());
 

--- a/platform/src/main/java/org/conscrypt/CertPinManager.java
+++ b/platform/src/main/java/org/conscrypt/CertPinManager.java
@@ -22,7 +22,10 @@ import java.util.List;
 
 /**
  * Interface for classes that implement certificate pinning for use in {@link TrustManagerImpl}.
+ *
+ * @hide
  */
+@Internal
 public interface CertPinManager {
     /**
      * Given a {@code hostname} and a {@code chain} this verifies that the

--- a/platform/src/main/java/org/conscrypt/CertificatePriorityComparator.java
+++ b/platform/src/main/java/org/conscrypt/CertificatePriorityComparator.java
@@ -39,6 +39,7 @@ import java.util.Map;
  * </ol>
  * </p>
  */
+@Internal
 public final class CertificatePriorityComparator implements Comparator<X509Certificate> {
 
     /**

--- a/platform/src/main/java/org/conscrypt/Hex.java
+++ b/platform/src/main/java/org/conscrypt/Hex.java
@@ -24,6 +24,7 @@ package org.conscrypt;
  */
 @Internal
 // public for testing by TrustedCertificateStoreTest
+// TODO(nathanmittler): Move to InternalUtil?
 public final class Hex {
     private Hex() {}
 

--- a/platform/src/main/java/org/conscrypt/InternalUtil.java
+++ b/platform/src/main/java/org/conscrypt/InternalUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import java.io.InputStream;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+
+/**
+ * Helper to initialize the JNI libraries. This version runs when compiled
+ * as part of the platform.
+ *
+ * @hide
+ */
+@Internal
+public final class InternalUtil {
+    public static PublicKey logKeyToPublicKey(byte[] logKey) throws NoSuchAlgorithmException {
+        return new OpenSSLKey(NativeCrypto.d2i_PUBKEY(logKey)).getPublicKey();
+    }
+
+    public static PublicKey readPublicKeyPem(InputStream pem) throws InvalidKeyException, NoSuchAlgorithmException {
+        return OpenSSLKey.fromPublicKeyPemInputStream(pem).getPublicKey();
+    }
+
+    public static byte[] getOcspSingleExtension(
+            byte[] ocspResponse, String oid, long x509Ref, long issuerX509Ref) {
+        return NativeCrypto.get_ocsp_single_extension(ocspResponse, oid, x509Ref, issuerX509Ref);
+    }
+
+    private InternalUtil() {
+    }
+}

--- a/platform/src/main/java/org/conscrypt/JSSEProvider.java
+++ b/platform/src/main/java/org/conscrypt/JSSEProvider.java
@@ -36,7 +36,9 @@ import java.security.Provider;
  *     CertPathValidator    PKIX
  *     CertificateFactory    X509
  *
+ * @hide
  */
+@Internal
 public final class JSSEProvider extends Provider {
 
     private static final long serialVersionUID = 3075686092260669675L;

--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -54,7 +54,7 @@ import javax.net.ssl.X509TrustManager;
 import libcore.net.NetworkSecurityPolicy;
 import sun.security.x509.AlgorithmId;
 
-class Platform {
+final class Platform {
     private static class NoPreloadHolder {
         public static final Platform MAPPER = new Platform();
     }
@@ -75,11 +75,11 @@ class Platform {
     private Platform() {
     }
 
-    public static FileDescriptor getFileDescriptor(Socket s) {
+    static FileDescriptor getFileDescriptor(Socket s) {
         return s.getFileDescriptor$();
     }
 
-    public static FileDescriptor getFileDescriptorFromSSLSocket(OpenSSLSocketImpl openSSLSocketImpl) {
+    static FileDescriptor getFileDescriptorFromSSLSocket(OpenSSLSocketImpl openSSLSocketImpl) {
         try {
             Field f_impl = Socket.class.getDeclaredField("impl");
             f_impl.setAccessible(true);
@@ -92,15 +92,15 @@ class Platform {
         }
     }
 
-    public static String getCurveName(ECParameterSpec spec) {
+    static String getCurveName(ECParameterSpec spec) {
         return spec.getCurveName();
     }
 
-    public static void setCurveName(ECParameterSpec spec, String curveName) {
+    static void setCurveName(ECParameterSpec spec, String curveName) {
         spec.setCurveName(curveName);
     }
 
-    public static void setSocketWriteTimeout(Socket s, long timeoutMillis) throws SocketException {
+    static void setSocketWriteTimeout(Socket s, long timeoutMillis) throws SocketException {
         StructTimeval tv = StructTimeval.fromMillis(timeoutMillis);
         try {
             Os.setsockoptTimeval(s.getFileDescriptor$(), SOL_SOCKET, SO_SNDTIMEO, tv);
@@ -109,7 +109,7 @@ class Platform {
         }
     }
 
-    public static void setSSLParameters(SSLParameters params, SSLParametersImpl impl,
+    static void setSSLParameters(SSLParameters params, SSLParametersImpl impl,
             OpenSSLSocketImpl socket) {
         impl.setEndpointIdentificationAlgorithm(params.getEndpointIdentificationAlgorithm());
         impl.setUseCipherSuitesOrder(params.getUseCipherSuitesOrder());
@@ -124,7 +124,7 @@ class Platform {
         }
     }
 
-    public static void getSSLParameters(SSLParameters params, SSLParametersImpl impl,
+    static void getSSLParameters(SSLParameters params, SSLParametersImpl impl,
             OpenSSLSocketImpl socket) {
         params.setEndpointIdentificationAlgorithm(impl.getEndpointIdentificationAlgorithm());
         params.setUseCipherSuitesOrder(impl.getUseCipherSuitesOrder());
@@ -134,7 +134,7 @@ class Platform {
         }
     }
 
-    public static void setSSLParameters(
+    static void setSSLParameters(
             SSLParameters params, SSLParametersImpl impl, OpenSSLEngineImpl engine) {
         impl.setEndpointIdentificationAlgorithm(params.getEndpointIdentificationAlgorithm());
         impl.setUseCipherSuitesOrder(params.getUseCipherSuitesOrder());
@@ -149,7 +149,7 @@ class Platform {
         }
     }
 
-    public static void getSSLParameters(
+    static void getSSLParameters(
             SSLParameters params, SSLParametersImpl impl, OpenSSLEngineImpl engine) {
         params.setEndpointIdentificationAlgorithm(impl.getEndpointIdentificationAlgorithm());
         params.setUseCipherSuitesOrder(impl.getUseCipherSuitesOrder());
@@ -184,7 +184,7 @@ class Platform {
         return false;
     }
 
-    public static void checkClientTrusted(X509TrustManager tm, X509Certificate[] chain,
+    static void checkClientTrusted(X509TrustManager tm, X509Certificate[] chain,
             String authType, OpenSSLSocketImpl socket) throws CertificateException {
         if (tm instanceof X509ExtendedTrustManager) {
             X509ExtendedTrustManager x509etm = (X509ExtendedTrustManager) tm;
@@ -196,7 +196,7 @@ class Platform {
         }
     }
 
-    public static void checkServerTrusted(X509TrustManager tm, X509Certificate[] chain,
+    static void checkServerTrusted(X509TrustManager tm, X509Certificate[] chain,
             String authType, OpenSSLSocketImpl socket) throws CertificateException {
         if (tm instanceof X509ExtendedTrustManager) {
             X509ExtendedTrustManager x509etm = (X509ExtendedTrustManager) tm;
@@ -208,7 +208,7 @@ class Platform {
         }
     }
 
-    public static void checkClientTrusted(X509TrustManager tm, X509Certificate[] chain,
+    static void checkClientTrusted(X509TrustManager tm, X509Certificate[] chain,
             String authType, OpenSSLEngineImpl engine) throws CertificateException {
         if (tm instanceof X509ExtendedTrustManager) {
             X509ExtendedTrustManager x509etm = (X509ExtendedTrustManager) tm;
@@ -220,7 +220,7 @@ class Platform {
         }
     }
 
-    public static void checkServerTrusted(X509TrustManager tm, X509Certificate[] chain,
+    static void checkServerTrusted(X509TrustManager tm, X509Certificate[] chain,
             String authType, OpenSSLEngineImpl engine) throws CertificateException {
         if (tm instanceof X509ExtendedTrustManager) {
             X509ExtendedTrustManager x509etm = (X509ExtendedTrustManager) tm;
@@ -236,14 +236,14 @@ class Platform {
      * Wraps an old AndroidOpenSSL key instance. This is not needed on platform
      * builds since we didn't backport, so return null.
      */
-    public static OpenSSLKey wrapRsaKey(PrivateKey key) {
+    static OpenSSLKey wrapRsaKey(PrivateKey key) {
         return null;
     }
 
     /**
      * Logs to the system EventLog system.
      */
-    public static void logEvent(String message) {
+    static void logEvent(String message) {
         try {
             Class processClass = Class.forName("android.os.Process");
             Object processInstance = processClass.newInstance();
@@ -264,7 +264,7 @@ class Platform {
     /**
      * Returns true if the supplied hostname is an literal IP address.
      */
-    public static boolean isLiteralIpAddress(String hostname) {
+    static boolean isLiteralIpAddress(String hostname) {
         return InetAddress.isNumeric(hostname);
     }
 
@@ -272,14 +272,14 @@ class Platform {
      * Wrap the SocketFactory with the platform wrapper if needed for compatability.
      * For the platform-bundled library we never need to wrap.
      */
-    public static SSLSocketFactory wrapSocketFactoryIfNeeded(OpenSSLSocketFactoryImpl factory) {
+    static SSLSocketFactory wrapSocketFactoryIfNeeded(OpenSSLSocketFactoryImpl factory) {
         return factory;
     }
 
     /**
      * Convert from platform's GCMParameterSpec to our internal version.
      */
-    public static GCMParameters fromGCMParameterSpec(AlgorithmParameterSpec params) {
+    static GCMParameters fromGCMParameterSpec(AlgorithmParameterSpec params) {
         if (params instanceof GCMParameterSpec) {
             GCMParameterSpec gcmParams = (GCMParameterSpec) params;
             return new GCMParameters(gcmParams.getTLen(), gcmParams.getIV());
@@ -290,7 +290,7 @@ class Platform {
     /**
      * Creates a platform version of {@code GCMParameterSpec}.
      */
-    public static AlgorithmParameterSpec toGCMParameterSpec(int tagLenInBits, byte[] iv) {
+    static AlgorithmParameterSpec toGCMParameterSpec(int tagLenInBits, byte[] iv) {
         return new GCMParameterSpec(tagLenInBits, iv);
     }
 
@@ -298,21 +298,21 @@ class Platform {
      * CloseGuard functions.
      */
 
-    public static CloseGuard closeGuardGet() {
+    static CloseGuard closeGuardGet() {
         return CloseGuard.get();
     }
 
-    public static void closeGuardOpen(Object guardObj, String message) {
+    static void closeGuardOpen(Object guardObj, String message) {
         CloseGuard guard = (CloseGuard) guardObj;
         guard.open(message);
     }
 
-    public static void closeGuardClose(Object guardObj) {
+    static void closeGuardClose(Object guardObj) {
         CloseGuard guard = (CloseGuard) guardObj;
         guard.close();
     }
 
-    public static void closeGuardWarnIfOpen(Object guardObj) {
+    static void closeGuardWarnIfOpen(Object guardObj) {
         CloseGuard guard = (CloseGuard) guardObj;
         guard.warnIfOpen();
     }
@@ -321,14 +321,14 @@ class Platform {
      * BlockGuard functions.
      */
 
-    public static void blockGuardOnNetwork() {
+    static void blockGuardOnNetwork() {
         BlockGuard.getThreadPolicy().onNetwork();
     }
 
     /**
      * OID to Algorithm Name mapping.
      */
-    public static String oidToAlgorithmName(String oid) {
+    static String oidToAlgorithmName(String oid) {
         try {
             return AlgorithmId.get(oid).getName();
         } catch (NoSuchAlgorithmException e) {
@@ -340,11 +340,11 @@ class Platform {
      * Pre-Java 8 backward compatibility.
      */
 
-    public static SSLSession wrapSSLSession(AbstractOpenSSLSession sslSession) {
+    static SSLSession wrapSSLSession(AbstractOpenSSLSession sslSession) {
         return new OpenSSLExtendedSessionImpl(sslSession);
     }
 
-    public static SSLSession unwrapSSLSession(SSLSession sslSession) {
+    static SSLSession unwrapSSLSession(SSLSession sslSession) {
         if (sslSession instanceof OpenSSLExtendedSessionImpl) {
             return ((OpenSSLExtendedSessionImpl) sslSession).getDelegate();
         }
@@ -355,11 +355,11 @@ class Platform {
      * Pre-Java-7 backward compatibility.
      */
 
-    public static String getHostStringFromInetSocketAddress(InetSocketAddress addr) {
+    static String getHostStringFromInetSocketAddress(InetSocketAddress addr) {
         return addr.getHostString();
     }
 
-    public static boolean isCTVerificationRequired(String hostname) {
+    static boolean isCTVerificationRequired(String hostname) {
         return NetworkSecurityPolicy.getInstance()
                 .isCertificateTransparencyVerificationRequired(hostname);
     }

--- a/platform/src/main/java/org/conscrypt/TrustManagerFactoryImpl.java
+++ b/platform/src/main/java/org/conscrypt/TrustManagerFactoryImpl.java
@@ -49,7 +49,9 @@ import javax.net.ssl.TrustManagerFactorySpi;
  * TrustManagerFactory service provider interface implementation.
  *
  * @see javax.net.ssl.TrustManagerFactorySpi
+ * @hide
  */
+@Internal
 public class TrustManagerFactoryImpl extends TrustManagerFactorySpi {
 
     private KeyStore keyStore;

--- a/platform/src/main/java/org/conscrypt/TrustManagerImpl.java
+++ b/platform/src/main/java/org/conscrypt/TrustManagerImpl.java
@@ -84,7 +84,9 @@ import org.conscrypt.ct.CTVerifier;
  * be provided by some certification provider.
  *
  * @see javax.net.ssl.X509ExtendedTrustManager
+ * @hide
  */
+@Internal
 public final class TrustManagerImpl extends X509ExtendedTrustManager {
 
     /**

--- a/platform/src/main/java/org/conscrypt/TrustedCertificateIndex.java
+++ b/platform/src/main/java/org/conscrypt/TrustedCertificateIndex.java
@@ -33,7 +33,10 @@ import javax.security.auth.x500.X500Principal;
 /**
  * Indexes {@code TrustAnchor} instances so they can be found in O(1)
  * time instead of O(N).
+ *
+ * @hide
  */
+@Internal
 public final class TrustedCertificateIndex {
 
     private final Map<X500Principal, List<TrustAnchor>> subjectToTrustAnchors

--- a/platform/src/main/java/org/conscrypt/TrustedCertificateKeyStoreSpi.java
+++ b/platform/src/main/java/org/conscrypt/TrustedCertificateKeyStoreSpi.java
@@ -27,7 +27,10 @@ import java.util.Enumeration;
 
 /**
  * A KeyStoreSpi wrapper for the TrustedCertificateStore.
+ *
+ * @hide
  */
+@Internal
 public final class TrustedCertificateKeyStoreSpi extends KeyStoreSpi {
 
     private final TrustedCertificateStore store = new TrustedCertificateStore();

--- a/platform/src/main/java/org/conscrypt/TrustedCertificateStore.java
+++ b/platform/src/main/java/org/conscrypt/TrustedCertificateStore.java
@@ -79,7 +79,10 @@ import libcore.io.IoUtils;
  * ensures that its owner and group are the system uid and system
  * gid and that it is world readable but only writable by the system
  * user.
+ *
+ * @hide
  */
+@Internal
 public class TrustedCertificateStore {
 
     private static final String PREFIX_SYSTEM = "system:";

--- a/platform/src/main/java/org/conscrypt/ct/CTConstants.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTConstants.java
@@ -16,6 +16,12 @@
 
 package org.conscrypt.ct;
 
+import org.conscrypt.Internal;
+
+/**
+ * @hide
+ */
+@Internal
 public class CTConstants {
     public static final String X509_SCT_LIST_OID = "1.3.6.1.4.1.11129.2.4.2";
     public static final String OCSP_SCT_LIST_OID = "1.3.6.1.4.1.11129.2.4.5";

--- a/platform/src/main/java/org/conscrypt/ct/CTLogInfo.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTLogInfo.java
@@ -23,12 +23,16 @@ import java.security.PublicKey;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.util.Arrays;
+import org.conscrypt.Internal;
 
 /**
  * Properties about a Certificate Transparency Log.
  * This object stores information about a CT log, its public key, description and URL.
  * It allows verification of SCTs against the log's public key.
+ *
+ * @hide
  */
+@Internal
 public class CTLogInfo {
     private final byte[] logId;
     private final PublicKey publicKey;

--- a/platform/src/main/java/org/conscrypt/ct/CTLogStore.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTLogStore.java
@@ -16,6 +16,12 @@
 
 package org.conscrypt.ct;
 
+import org.conscrypt.Internal;
+
+/**
+ * @hide
+ */
+@Internal
 public interface CTLogStore {
     CTLogInfo getKnownLog(byte[] logId);
 }

--- a/platform/src/main/java/org/conscrypt/ct/CTLogStoreImpl.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTLogStoreImpl.java
@@ -31,8 +31,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Scanner;
 import java.util.Set;
-import org.conscrypt.NativeCrypto;
-import org.conscrypt.OpenSSLKey;
+import org.conscrypt.InternalUtil;
 
 public class CTLogStoreImpl implements CTLogStore {
     /**
@@ -144,8 +143,7 @@ public class CTLogStoreImpl implements CTLogStore {
         CTLogInfo[] logs = new CTLogInfo[KnownLogs.LOG_COUNT];
         for (int i = 0; i < KnownLogs.LOG_COUNT; i++) {
             try {
-                PublicKey key = new OpenSSLKey(NativeCrypto.d2i_PUBKEY(KnownLogs.LOG_KEYS[i]))
-                                .getPublicKey();
+                PublicKey key = InternalUtil.logKeyToPublicKey(KnownLogs.LOG_KEYS[i]);
 
                 logs[i] = new CTLogInfo(key,
                                         KnownLogs.LOG_DESCRIPTIONS[i],
@@ -220,10 +218,10 @@ public class CTLogStoreImpl implements CTLogStore {
 
         PublicKey pubkey;
         try {
-            pubkey = OpenSSLKey.fromPublicKeyPemInputStream(new StringBufferInputStream(
+            pubkey = InternalUtil.readPublicKeyPem(new StringBufferInputStream(
                         "-----BEGIN PUBLIC KEY-----\n" +
                         key + "\n" +
-                        "-----END PUBLIC KEY-----")).getPublicKey();
+                        "-----END PUBLIC KEY-----"));
         } catch (InvalidKeyException e) {
             throw new InvalidLogFileException(e);
         } catch (NoSuchAlgorithmException e) {

--- a/platform/src/main/java/org/conscrypt/ct/CTLogStoreImpl.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTLogStoreImpl.java
@@ -31,8 +31,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Scanner;
 import java.util.Set;
+import org.conscrypt.Internal;
 import org.conscrypt.InternalUtil;
 
+/**
+ * @hide
+ */
+@Internal
 public class CTLogStoreImpl implements CTLogStore {
     /**
      * Thrown when parsing of a log file fails.

--- a/platform/src/main/java/org/conscrypt/ct/CTPolicy.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTPolicy.java
@@ -17,7 +17,9 @@
 package org.conscrypt.ct;
 
 import java.security.cert.X509Certificate;
+import org.conscrypt.Internal;
 
+@Internal
 public interface CTPolicy {
     boolean doesResultConformToPolicy(CTVerificationResult result, String hostname,
             X509Certificate[] chain);

--- a/platform/src/main/java/org/conscrypt/ct/CTPolicyImpl.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTPolicyImpl.java
@@ -19,7 +19,12 @@ package org.conscrypt.ct;
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.Set;
+import org.conscrypt.Internal;
 
+/**
+ * @hide
+ */
+@Internal
 public class CTPolicyImpl implements CTPolicy {
     private final CTLogStore logStore;
     private final int minimumLogCount;

--- a/platform/src/main/java/org/conscrypt/ct/CTVerificationResult.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTVerificationResult.java
@@ -19,7 +19,12 @@ package org.conscrypt.ct;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.conscrypt.Internal;
 
+/**
+ * @hide
+ */
+@Internal
 public class CTVerificationResult {
     private final ArrayList<VerifiedSCT> validSCTs = new ArrayList<>();
     private final ArrayList<VerifiedSCT> invalidSCTs = new ArrayList<>();

--- a/platform/src/main/java/org/conscrypt/ct/CTVerifier.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTVerifier.java
@@ -22,7 +22,7 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.conscrypt.NativeCrypto;
+import org.conscrypt.InternalUtil;
 import org.conscrypt.OpenSSLX509Certificate;
 
 public class CTVerifier {
@@ -213,9 +213,8 @@ public class CTVerifier {
             return Collections.emptyList();
         }
 
-        byte[] extData = NativeCrypto.get_ocsp_single_extension(data, CTConstants.OCSP_SCT_LIST_OID,
-                                                                chain[0].getContext(),
-                                                                chain[1].getContext());
+        byte[] extData = InternalUtil.getOcspSingleExtension(data, CTConstants.OCSP_SCT_LIST_OID,
+                                                             chain[0].getContext(), chain[1].getContext());
         if (extData == null) {
             return Collections.emptyList();
         }

--- a/platform/src/main/java/org/conscrypt/ct/CTVerifier.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTVerifier.java
@@ -22,9 +22,14 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.conscrypt.Internal;
 import org.conscrypt.InternalUtil;
 import org.conscrypt.OpenSSLX509Certificate;
 
+/**
+ * @hide
+ */
+@Internal
 public class CTVerifier {
     private final CTLogStore store;
 

--- a/platform/src/main/java/org/conscrypt/ct/CertificateEntry.java
+++ b/platform/src/main/java/org/conscrypt/ct/CertificateEntry.java
@@ -22,6 +22,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import org.conscrypt.Internal;
 import org.conscrypt.OpenSSLX509Certificate;
 
 /**
@@ -38,7 +39,9 @@ import org.conscrypt.OpenSSLX509Certificate;
  *     } signed_entry;
  * } CertificateEntry;
  *
+ * @hide
  */
+@Internal
 public class CertificateEntry {
     public enum LogEntryType {
         X509_ENTRY,

--- a/platform/src/main/java/org/conscrypt/ct/DigitallySigned.java
+++ b/platform/src/main/java/org/conscrypt/ct/DigitallySigned.java
@@ -18,10 +18,14 @@ package org.conscrypt.ct;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import org.conscrypt.Internal;
 
 /**
  * DigitallySigned structure, as defined by RFC5246 Section 4.7.
+ *
+ * @hide
  */
+@Internal
 public class DigitallySigned {
     public enum HashAlgorithm {
         NONE,

--- a/platform/src/main/java/org/conscrypt/ct/KnownLogs.java
+++ b/platform/src/main/java/org/conscrypt/ct/KnownLogs.java
@@ -19,6 +19,12 @@
 
 package org.conscrypt.ct;
 
+import org.conscrypt.Internal;
+
+/**
+ * @hide
+ */
+@Internal
 public final class KnownLogs {
     public static final int LOG_COUNT = 8;
     public static final String[] LOG_DESCRIPTIONS = new String[] {

--- a/platform/src/main/java/org/conscrypt/ct/Serialization.java
+++ b/platform/src/main/java/org/conscrypt/ct/Serialization.java
@@ -21,7 +21,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import org.conscrypt.Internal;
 
+/**
+ * @hide
+ */
+@Internal
 public class Serialization {
     private Serialization() {}
 

--- a/platform/src/main/java/org/conscrypt/ct/SerializationException.java
+++ b/platform/src/main/java/org/conscrypt/ct/SerializationException.java
@@ -16,6 +16,12 @@
 
 package org.conscrypt.ct;
 
+import org.conscrypt.Internal;
+
+/**
+ * @hide
+ */
+@Internal
 public class SerializationException extends Exception {
     public SerializationException() {
     }

--- a/platform/src/main/java/org/conscrypt/ct/SignedCertificateTimestamp.java
+++ b/platform/src/main/java/org/conscrypt/ct/SignedCertificateTimestamp.java
@@ -20,10 +20,14 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.conscrypt.Internal;
 
 /**
  * SignedCertificateTimestamp structure, as defined by RFC6962 Section 3.2.
+ *
+ * @hide
  */
+@Internal
 public class SignedCertificateTimestamp {
     public enum Version {
         V1

--- a/platform/src/main/java/org/conscrypt/ct/VerifiedSCT.java
+++ b/platform/src/main/java/org/conscrypt/ct/VerifiedSCT.java
@@ -16,9 +16,14 @@
 
 package org.conscrypt.ct;
 
+import org.conscrypt.Internal;
+
 /**
  * Verification result for a single SCT.
+ *
+ * @hide
  */
+@Internal
 public final class VerifiedSCT {
     public enum Status {
         VALID,

--- a/platform/src/test/java/org/conscrypt/ct/CTLogStoreImplTest.java
+++ b/platform/src/test/java/org/conscrypt/ct/CTLogStoreImplTest.java
@@ -28,7 +28,7 @@ import java.io.PrintWriter;
 import java.io.StringBufferInputStream;
 import java.security.PublicKey;
 import junit.framework.TestCase;
-import org.conscrypt.OpenSSLKey;
+import org.conscrypt.InternalUtil;
 
 public class CTLogStoreImplTest extends TestCase {
     private static final String[] LOG_KEYS = new String[] {
@@ -64,10 +64,10 @@ public class CTLogStoreImplTest extends TestCase {
             LOGS = new CTLogInfo[logCount];
             LOGS_SERIALIZED = new String[logCount];
             for (int i = 0; i < logCount; i++) {
-                PublicKey key = OpenSSLKey.fromPublicKeyPemInputStream(new StringBufferInputStream(
+                PublicKey key = InternalUtil.readPublicKeyPem(new StringBufferInputStream(
                     "-----BEGIN PUBLIC KEY-----\n" +
                     LOG_KEYS[i] + "\n" +
-                    "-----END PUBLIC KEY-----\n")).getPublicKey();
+                    "-----END PUBLIC KEY-----\n"));
                 String description = String.format("Test Log %d", i);
                 String url = String.format("log%d.example.com", i);
                 LOGS[i] = new CTLogInfo(key, description, url);

--- a/platform/src/test/java/org/conscrypt/ct/CTVerifierTest.java
+++ b/platform/src/test/java/org/conscrypt/ct/CTVerifierTest.java
@@ -22,7 +22,7 @@ import static org.conscrypt.TestUtils.readTestFile;
 import java.security.PublicKey;
 import java.util.Arrays;
 import junit.framework.TestCase;
-import org.conscrypt.OpenSSLKey;
+import org.conscrypt.InternalUtil;
 import org.conscrypt.OpenSSLX509Certificate;
 
 public class CTVerifierTest extends TestCase {
@@ -39,8 +39,7 @@ public class CTVerifierTest extends TestCase {
         certEmbedded = OpenSSLX509Certificate.fromX509PemInputStream(
                 openTestFile("cert-ct-embedded.pem"));
 
-        PublicKey key = OpenSSLKey.fromPublicKeyPemInputStream(
-                openTestFile("ct-server-key-public.pem")).getPublicKey();
+        PublicKey key = InternalUtil.readPublicKeyPem(openTestFile("ct-server-key-public.pem"));
 
         final CTLogInfo log = new CTLogInfo(key, "Test Log", "foo");
         CTLogStore store = new CTLogStore() {

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -29,7 +29,6 @@ import java.nio.charset.Charset;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
-import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
@@ -43,20 +42,15 @@ import libcore.java.security.TestKeyStore;
  * Utility methods to support testing.
  */
 public final class TestUtils {
-    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private static final Provider JDK_PROVIDER = getDefaultTlsProvider();
     private static final Provider CONSCRYPT_PROVIDER = getConscryptProvider();
     private static final byte[] CHARS =
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".getBytes(UTF_8);
-    private static final Pattern KEY_PATTERN =
-            Pattern.compile("-+BEGIN\\s+.*PRIVATE\\s+KEY[^-]*-+(?:\\s|\\r|\\n)+" + // Header
-                            "([a-z0-9+/=\\r\\n]+)" + // Base64 text
-                            "-+END\\s+.*PRIVATE\\s+KEY[^-]*-+", // Footer
-                    Pattern.CASE_INSENSITIVE);
 
     public static final String PROTOCOL_TLS_V1_2 = "TLSv1.2";
-    public static final String PROVIDER_PROPERTY = "SSLContext.TLSv1.2";
+    private static final String PROVIDER_PROPERTY = "SSLContext.TLSv1.2";
     public static final String LOCALHOST = "localhost";
 
     private TestUtils() {}
@@ -76,37 +70,38 @@ public final class TestUtils {
     /**
      * Returns an array containing only {@link #PROTOCOL_TLS_V1_2}.
      */
-    public static String[] getProtocols() {
+    static String[] getProtocols() {
         return new String[] {PROTOCOL_TLS_V1_2};
     }
 
-    public static SSLSocketFactory getJdkSocketFactory() {
+    static SSLSocketFactory getJdkSocketFactory() {
         return getSocketFactory(JDK_PROVIDER);
     }
 
-    public static SSLServerSocketFactory getJdkServerSocketFactory() {
+    static SSLServerSocketFactory getJdkServerSocketFactory() {
         return getServerSocketFactory(JDK_PROVIDER);
     }
 
-    public static SSLSocketFactory getConscryptSocketFactory(boolean useEngineSocket) {
+    static SSLSocketFactory getConscryptSocketFactory(boolean useEngineSocket) {
         try {
-            Class<?> clazz = Class.forName("org.conscrypt.OpenSSLSocketFactoryImpl");
-            Method method = clazz.getMethod("setUseEngineSocket", boolean.class);
+            Class<?> clazz = Class.forName("org.conscrypt.Conscrypt$SocketFactories");
+            Method method = clazz.getMethod("setUseEngineSocket", SSLSocketFactory.class, boolean.class);
+
             SSLSocketFactory socketFactory = getSocketFactory(CONSCRYPT_PROVIDER);
-            method.invoke(socketFactory, useEngineSocket);
+            method.invoke(null, socketFactory, useEngineSocket);
             return socketFactory;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static SSLServerSocketFactory getConscryptServerSocketFactory(boolean useEngineSocket) {
+    static SSLServerSocketFactory getConscryptServerSocketFactory(boolean useEngineSocket) {
         try {
-            Class<?> clazz = Class.forName("org.conscrypt.OpenSSLServerSocketFactoryImpl");
-            Method method = clazz.getMethod("setUseEngineSocket", boolean.class);
+            Class<?> clazz = Class.forName("org.conscrypt.Conscrypt$ServerSocketFactories");
+            Method method = clazz.getMethod("setUseEngineSocket", SSLServerSocketFactory.class, boolean.class);
 
             SSLServerSocketFactory socketFactory = getServerSocketFactory(CONSCRYPT_PROVIDER);
-            method.invoke(socketFactory, useEngineSocket);
+            method.invoke(null, socketFactory, useEngineSocket);
             return socketFactory;
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -123,7 +118,7 @@ public final class TestUtils {
         return serverContext.getServerSocketFactory();
     }
 
-    public static SSLContext newContext(Provider provider) {
+    private static SSLContext newContext(Provider provider) {
         try {
             return SSLContext.getInstance("TLS", provider);
         } catch (NoSuchAlgorithmException e) {
@@ -137,7 +132,7 @@ public final class TestUtils {
      * returned port to create a new server socket when other threads/processes are concurrently
      * creating new sockets without a specific port.
      */
-    public static int pickUnusedPort() {
+    static int pickUnusedPort() {
         try {
             ServerSocket serverSocket = new ServerSocket(0);
             int port = serverSocket.getLocalPort();
@@ -151,7 +146,7 @@ public final class TestUtils {
     /**
      * Creates a text message of the given length.
      */
-    public static byte[] newTextMessage(int length) {
+    static byte[] newTextMessage(int length) {
         byte[] msg = new byte[length];
         for (int msgIndex = 0; msgIndex < length;) {
             int remaining = length - msgIndex;
@@ -165,7 +160,7 @@ public final class TestUtils {
     /**
      * Initializes the given engine with the cipher and client mode.
      */
-    public static SSLEngine initEngine(SSLEngine engine, String cipher, boolean client) {
+    static SSLEngine initEngine(SSLEngine engine, String cipher, boolean client) {
         engine.setEnabledProtocols(getProtocols());
         engine.setEnabledCipherSuites(new String[] {cipher});
         engine.setUseClientMode(client);
@@ -175,21 +170,21 @@ public final class TestUtils {
     /**
      * Initializes the given client-side {@code context} with a default cert.
      */
-    public static SSLContext initClientSslContext(SSLContext context) {
+    private static SSLContext initClientSslContext(SSLContext context) {
         return initSslContext(context, TestKeyStore.getClient());
     }
 
     /**
      * Initializes the given server-side {@code context} with the given cert chain and private key.
      */
-    public static SSLContext initServerSslContext(SSLContext context) {
+    private static SSLContext initServerSslContext(SSLContext context) {
         return initSslContext(context, TestKeyStore.getServer());
     }
 
     /**
      * Initializes the given {@code context} from the {@code keyStore}.
      */
-    public static SSLContext initSslContext(SSLContext context, TestKeyStore keyStore) {
+    static SSLContext initSslContext(SSLContext context, TestKeyStore keyStore) {
         try {
             context.init(keyStore.keyManagers, keyStore.trustManagers, null);
             return context;
@@ -201,7 +196,7 @@ public final class TestUtils {
     /**
      * Performs the intial TLS handshake between the two {@link SSLEngine} instances.
      */
-    public static void doEngineHandshake(SSLEngine clientEngine, SSLEngine serverEngine)
+    static void doEngineHandshake(SSLEngine clientEngine, SSLEngine serverEngine)
             throws SSLException {
         ByteBuffer cTOs = ByteBuffer.allocate(clientEngine.getSession().getPacketBufferSize());
         ByteBuffer sTOc = ByteBuffer.allocate(serverEngine.getSession().getPacketBufferSize());


### PR DESCRIPTION
Tried to be as aggressive as I could, so this probably deserves a fairly thorough review.  I left most of OpenSSLSocketImpl public, because I think it's needed by a few external projects.

I also did some cleanup work to get rid of a bunch of compiler warnings that we seem to have accumulated.

Fixes #142