### PR TITLE
Convert HandshakeListener into abstract class

### DIFF
--- a/common/src/main/java/org/conscrypt/HandshakeListener.java
+++ b/common/src/main/java/org/conscrypt/HandshakeListener.java
@@ -22,10 +22,10 @@ import javax.net.ssl.SSLException;
  * Similar in concept to {@link javax.net.ssl.HandshakeCompletedListener}, but used for listening directly
  * to the engine. Allows the caller to be notified immediately upon completion of the TLS handshake.
  */
-public interface HandshakeListener {
+public abstract class HandshakeListener {
 
     /**
      * Called by the engine when the TLS handshake has completed.
      */
-    void onHandshakeFinished() throws SSLException;
+    public abstract void onHandshakeFinished() throws SSLException;
 }


### PR DESCRIPTION
This should help to stabilize the API going forward if we ever decide to expand the interface.