### PR TITLE
Add additional aliases.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -101,16 +101,22 @@ public final class OpenSSLProvider extends Provider {
         /* == KeyPairGenerators == */
         put("KeyPairGenerator.RSA", PREFIX + "OpenSSLRSAKeyPairGenerator");
         put("Alg.Alias.KeyPairGenerator.1.2.840.113549.1.1.1", "RSA");
+        put("Alg.Alias.KeyPairGenerator.1.2.840.113549.1.1.7", "RSA");
+        put("Alg.Alias.KeyPairGenerator.2.5.8.1.1", "RSA");
 
         put("KeyPairGenerator.EC", PREFIX + "OpenSSLECKeyPairGenerator");
         put("Alg.Alias.KeyPairGenerator.1.2.840.10045.2.1", "EC");
+        put("Alg.Alias.KeyPairGenerator.1.3.133.16.840.63.0.2", "EC");
 
         /* == KeyFactory == */
         put("KeyFactory.RSA", PREFIX + "OpenSSLRSAKeyFactory");
         put("Alg.Alias.KeyFactory.1.2.840.113549.1.1.1", "RSA");
+        put("Alg.Alias.KeyFactory.1.2.840.113549.1.1.7", "RSA");
+        put("Alg.Alias.KeyFactory.2.5.8.1.1", "RSA");
 
         put("KeyFactory.EC", PREFIX + "OpenSSLECKeyFactory");
         put("Alg.Alias.KeyFactory.1.2.840.10045.2.1", "EC");
+        put("Alg.Alias.KeyFactory.1.3.133.16.840.63.0.2", "EC");
 
         /* == KeyAgreement == */
         putECDHKeyAgreementImplClass("OpenSSLECDHKeyAgreement");
@@ -120,6 +126,7 @@ public final class OpenSSLProvider extends Provider {
         put("Alg.Alias.Signature.MD5WithRSAEncryption", "MD5WithRSA");
         put("Alg.Alias.Signature.MD5/RSA", "MD5WithRSA");
         put("Alg.Alias.Signature.1.2.840.113549.1.1.4", "MD5WithRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.4", "MD5WithRSA");
         put("Alg.Alias.Signature.1.2.840.113549.2.5with1.2.840.113549.1.1.1", "MD5WithRSA");
 
         putSignatureImplClass("SHA1WithRSA", "OpenSSLSignature$SHA1RSA");
@@ -127,13 +134,17 @@ public final class OpenSSLProvider extends Provider {
         put("Alg.Alias.Signature.SHA1/RSA", "SHA1WithRSA");
         put("Alg.Alias.Signature.SHA-1/RSA", "SHA1WithRSA");
         put("Alg.Alias.Signature.1.2.840.113549.1.1.5", "SHA1WithRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.5", "SHA1WithRSA");
         put("Alg.Alias.Signature.1.3.14.3.2.26with1.2.840.113549.1.1.1", "SHA1WithRSA");
         put("Alg.Alias.Signature.1.3.14.3.2.26with1.2.840.113549.1.1.5", "SHA1WithRSA");
         put("Alg.Alias.Signature.1.3.14.3.2.29", "SHA1WithRSA");
+        put("Alg.Alias.Signature.OID.1.3.14.3.2.29", "SHA1WithRSA");
 
         putSignatureImplClass("SHA224WithRSA", "OpenSSLSignature$SHA224RSA");
         put("Alg.Alias.Signature.SHA224WithRSAEncryption", "SHA224WithRSA");
+        put("Alg.Alias.Signature.SHA224/RSA", "SHA224WithRSA");
         put("Alg.Alias.Signature.1.2.840.113549.1.1.14", "SHA224WithRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.14", "SHA224WithRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.4with1.2.840.113549.1.1.1",
                 "SHA224WithRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.4with1.2.840.113549.1.1.14",
@@ -141,7 +152,9 @@ public final class OpenSSLProvider extends Provider {
 
         putSignatureImplClass("SHA256WithRSA", "OpenSSLSignature$SHA256RSA");
         put("Alg.Alias.Signature.SHA256WithRSAEncryption", "SHA256WithRSA");
+        put("Alg.Alias.Signature.SHA256/RSA", "SHA256WithRSA");
         put("Alg.Alias.Signature.1.2.840.113549.1.1.11", "SHA256WithRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.11", "SHA256WithRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.1with1.2.840.113549.1.1.1",
                 "SHA256WithRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.1with1.2.840.113549.1.1.11",
@@ -149,13 +162,17 @@ public final class OpenSSLProvider extends Provider {
 
         putSignatureImplClass("SHA384WithRSA", "OpenSSLSignature$SHA384RSA");
         put("Alg.Alias.Signature.SHA384WithRSAEncryption", "SHA384WithRSA");
+        put("Alg.Alias.Signature.SHA384/RSA", "SHA384WithRSA");
         put("Alg.Alias.Signature.1.2.840.113549.1.1.12", "SHA384WithRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.12", "SHA384WithRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.2with1.2.840.113549.1.1.1",
                 "SHA384WithRSA");
 
         putSignatureImplClass("SHA512WithRSA", "OpenSSLSignature$SHA512RSA");
         put("Alg.Alias.Signature.SHA512WithRSAEncryption", "SHA512WithRSA");
+        put("Alg.Alias.Signature.SHA512/RSA", "SHA512WithRSA");
         put("Alg.Alias.Signature.1.2.840.113549.1.1.13", "SHA512WithRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.13", "SHA512WithRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.3with1.2.840.113549.1.1.1",
                 "SHA512WithRSA");
 
@@ -170,24 +187,32 @@ public final class OpenSSLProvider extends Provider {
 
         // iso(1) member-body(2) us(840) ansi-x962(10045) signatures(4) ecdsa-with-SHA2(3)
         putSignatureImplClass("SHA224withECDSA", "OpenSSLSignature$SHA224ECDSA");
+        put("Alg.Alias.Signature.SHA224/ECDSA", "SHA224withECDSA");
         // ecdsa-with-SHA224(1)
         put("Alg.Alias.Signature.1.2.840.10045.4.3.1", "SHA224withECDSA");
+        put("Alg.Alias.Signature.OID.1.2.840.10045.4.3.1", "SHA224withECDSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.4with1.2.840.10045.2.1", "SHA224withECDSA");
 
         // iso(1) member-body(2) us(840) ansi-x962(10045) signatures(4) ecdsa-with-SHA2(3)
         putSignatureImplClass("SHA256withECDSA", "OpenSSLSignature$SHA256ECDSA");
+        put("Alg.Alias.Signature.SHA256/ECDSA", "SHA256withECDSA");
         // ecdsa-with-SHA256(2)
         put("Alg.Alias.Signature.1.2.840.10045.4.3.2", "SHA256withECDSA");
+        put("Alg.Alias.Signature.OID.1.2.840.10045.4.3.2", "SHA256withECDSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.1with1.2.840.10045.2.1", "SHA256withECDSA");
 
         putSignatureImplClass("SHA384withECDSA", "OpenSSLSignature$SHA384ECDSA");
+        put("Alg.Alias.Signature.SHA384/ECDSA", "SHA384withECDSA");
         // ecdsa-with-SHA384(3)
         put("Alg.Alias.Signature.1.2.840.10045.4.3.3", "SHA384withECDSA");
+        put("Alg.Alias.Signature.OID.1.2.840.10045.4.3.3", "SHA384withECDSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.2with1.2.840.10045.2.1", "SHA384withECDSA");
 
         putSignatureImplClass("SHA512withECDSA", "OpenSSLSignature$SHA512ECDSA");
+        put("Alg.Alias.Signature.SHA512/ECDSA", "SHA512withECDSA");
         // ecdsa-with-SHA512(4)
         put("Alg.Alias.Signature.1.2.840.10045.4.3.4", "SHA512withECDSA");
+        put("Alg.Alias.Signature.OID.1.2.840.10045.4.3.4", "SHA512withECDSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.3with1.2.840.10045.2.1", "SHA512withECDSA");
 
         putSignatureImplClass("SHA1withRSA/PSS", "OpenSSLSignature$SHA1RSAPSS");
@@ -308,10 +333,17 @@ public final class OpenSSLProvider extends Provider {
         put("Alg.Alias.Cipher.DESEDE/CBC/PKCS7Padding", "DESEDE/CBC/PKCS5Padding");
 
         putSymmetricCipherImplClass("ARC4", "OpenSSLCipher$EVP_CIPHER$ARC4");
+        put("Alg.Alias.Cipher.ARCFOUR", "ARC4");
+        put("Alg.Alias.Cipher.RC4", "ARC4");
+        put("Alg.Alias.Cipher.1.2.840.113549.3.4", "ARC4");
+        put("Alg.Alias.Cipher.OID.1.2.840.113549.3.4", "ARC4");
 
         if (NativeConstants.HAS_EVP_AEAD) {
             putSymmetricCipherImplClass("AES/GCM/NoPadding", "OpenSSLCipher$EVP_AEAD$AES$GCM");
             put("Alg.Alias.Cipher.GCM", "AES/GCM/NoPadding");
+            put("Alg.Alias.Cipher.2.16.840.1.101.3.4.1.6", "AES/GCM/NoPadding");
+            put("Alg.Alias.Cipher.2.16.840.1.101.3.4.1.26", "AES/GCM/NoPadding");
+            put("Alg.Alias.Cipher.2.16.840.1.101.3.4.1.46", "AES/GCM/NoPadding");
             putSymmetricCipherImplClass(
                     "AES_128/GCM/NoPadding", "OpenSSLCipher$EVP_AEAD$AES$GCM$AES_128");
             putSymmetricCipherImplClass(
@@ -321,6 +353,9 @@ public final class OpenSSLProvider extends Provider {
         /* === Mac === */
 
         putMacImplClass("HmacMD5", "OpenSSLMac$HmacMD5");
+        put("Alg.Alias.Mac.1.3.6.1.5.5.8.1.1", "HmacMD5");
+        put("Alg.Alias.Mac.HMAC-MD5", "HmacMD5");
+        put("Alg.Alias.Mac.HMAC/MD5", "HmacMD5");
 
         // PKCS#2 - iso(1) member-body(2) US(840) rsadsi(113549) digestAlgorithm(2)
         // http://www.oid-info.com/get/1.2.840.113549.2
@@ -328,6 +363,7 @@ public final class OpenSSLProvider extends Provider {
         // HMAC-SHA-1 PRF (7)
         putMacImplClass("HmacSHA1", "OpenSSLMac$HmacSHA1");
         put("Alg.Alias.Mac.1.2.840.113549.2.7", "HmacSHA1");
+        put("Alg.Alias.Mac.1.3.6.1.5.5.8.1.2", "HmacSHA1");
         put("Alg.Alias.Mac.HMAC-SHA1", "HmacSHA1");
         put("Alg.Alias.Mac.HMAC/SHA1", "HmacSHA1");
 
@@ -336,24 +372,29 @@ public final class OpenSSLProvider extends Provider {
         put("Alg.Alias.Mac.1.2.840.113549.2.8", "HmacSHA224");
         put("Alg.Alias.Mac.HMAC-SHA224", "HmacSHA224");
         put("Alg.Alias.Mac.HMAC/SHA224", "HmacSHA224");
+        put("Alg.Alias.Mac.PBEWITHHMACSHA224", "HmacSHA224");
 
         // id-hmacWithSHA256 (9)
         putMacImplClass("HmacSHA256", "OpenSSLMac$HmacSHA256");
         put("Alg.Alias.Mac.1.2.840.113549.2.9", "HmacSHA256");
+        put("Alg.Alias.Mac.2.16.840.1.101.3.4.2.1", "HmacSHA256");
         put("Alg.Alias.Mac.HMAC-SHA256", "HmacSHA256");
         put("Alg.Alias.Mac.HMAC/SHA256", "HmacSHA256");
+        put("Alg.Alias.Mac.PBEWITHHMACSHA256", "HmacSHA256");
 
         // id-hmacWithSHA384 (10)
         putMacImplClass("HmacSHA384", "OpenSSLMac$HmacSHA384");
         put("Alg.Alias.Mac.1.2.840.113549.2.10", "HmacSHA384");
         put("Alg.Alias.Mac.HMAC-SHA384", "HmacSHA384");
         put("Alg.Alias.Mac.HMAC/SHA384", "HmacSHA384");
+        put("Alg.Alias.Mac.PBEWITHHMACSHA384", "HmacSHA384");
 
         // id-hmacWithSHA384 (11)
         putMacImplClass("HmacSHA512", "OpenSSLMac$HmacSHA512");
         put("Alg.Alias.Mac.1.2.840.113549.2.11", "HmacSHA512");
         put("Alg.Alias.Mac.HMAC-SHA512", "HmacSHA512");
         put("Alg.Alias.Mac.HMAC/SHA512", "HmacSHA512");
+        put("Alg.Alias.Mac.PBEWITHHMACSHA512", "HmacSHA512");
 
         /* === Certificate === */
 


### PR DESCRIPTION
These aliases are provided by Bouncy Castle for these algorithms, so we're
adding them as well so that anyone using them can get the Conscrypt
versions without having to change their code.