### PR TITLE
Don't fill in RSA_METHOD.encrypt when not needed.

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -568,6 +568,10 @@ size_t RsaMethodSize(const RSA *rsa) {
   return ex_data->cached_size;
 }
 
+// TODO(davidben): Remove this once
+// https://boringssl-review.googlesource.com/c/15864/ is in all Conscrypt
+// consumers.
+#if BORINGSSL_API_VERSION < 4
 int RsaMethodEncrypt(RSA* /* rsa */,
                      size_t* /* out_len */,
                      uint8_t* /* out */,
@@ -578,6 +582,7 @@ int RsaMethodEncrypt(RSA* /* rsa */,
   OPENSSL_PUT_ERROR(RSA, RSA_R_UNKNOWN_ALGORITHM_TYPE);
   return 0;
 }
+#endif
 
 int RsaMethodSignRaw(RSA* rsa,
                      size_t* out_len,
@@ -750,8 +755,12 @@ void init_engine_globals() {
 
     g_rsa_method.common.is_static = 1;
     g_rsa_method.size = RsaMethodSize;
-    // TODO(davidben): Update BoringSSL to ignore this hook and remove this.
+    // TODO(davidben): Remove this once
+    // https://boringssl-review.googlesource.com/c/15864/ is in all Conscrypt
+    // consumers.
+#if BORINGSSL_API_VERSION < 4
     g_rsa_method.encrypt = RsaMethodEncrypt;
+#endif
     g_rsa_method.sign_raw = RsaMethodSignRaw;
     g_rsa_method.decrypt = RsaMethodDecrypt;
     g_rsa_method.flags = RSA_FLAG_OPAQUE;


### PR DESCRIPTION
This resolves a TODO, at the cost of adding two more. Newer BoringSSL
revisions ignore the hook as of
https://boringssl-review.googlesource.com/c/15864/.

It's probably unnecessary in older revisions too, but since Conscrypt
does not fill in rsa->n or rsa->e, it's plausible that, prior to that
BoringSSL change, someone might have passed Conscrypt's custom RSA
objects into a codepath that ultimately used RSA_encrypt. Tracing
through Java cryptography goo is probably not worth the trouble, so I've
left it as an #ifdef which can be removed in a couple weeks.