### PR TITLE
Make checkNotNull a non-varargs function

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEngineImpl.java
@@ -1532,9 +1532,16 @@ final class OpenSSLEngineImpl extends SSLEngine implements NativeCrypto.SSLHands
         }
     }
 
-    private static <T> T checkNotNull(T obj, String fmt, Object... args) {
+    private static <T> T checkNotNull(T obj, String msg) {
         if (obj == null) {
-            throw new IllegalArgumentException(String.format(fmt, args));
+            throw new IllegalArgumentException(msg);
+        }
+        return obj;
+    }
+
+    private static <T> T checkNotNull(T obj, String fmt, Object arg1) {
+        if (obj == null) {
+            throw new IllegalArgumentException(String.format(fmt, arg1));
         }
         return obj;
     }


### PR DESCRIPTION
checkNotNull is called multiple times in both wrap and unwrap. The fact that it is a varargs method means that each call allocates an Object[]. None of the callers to checkNotNull really need the varargs behavior, so remove it to save the allocations.