### PR TITLE
Move closer to the old test version

### DIFF
--- a/openjdk-integ-tests/src/test/java/libcore/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/libcore/javax/net/ssl/SSLSocketTest.java
@@ -1700,7 +1700,6 @@ public class SSLSocketTest extends AbstractSSLTest {
         // Schedule the socket to be closes in 1 second.
         Future<Void> future = runAsync(() -> {
             Thread.sleep(1000);
-            toClose.shutdownInput();
             toClose.close();
             return null;
         });
@@ -1708,17 +1707,10 @@ public class SSLSocketTest extends AbstractSSLTest {
         // Read from the socket.
         try {
             toRead.setSoTimeout(readingTimeoutMillis);
-            final InputStream inputStream = toRead.getInputStream();
-            int value = inputStream.read();
-            if (isConscryptSocket(clientWrapping)) {
-                // TODO(nmittler): Conscrypt socket read may return -1 instead of SocketException.
-                assertEquals(-1, value);
-            } else {
-                // For any other socket type, we should expect SocketException.
-                fail();
-            }
-        } catch (SocketException e) {
-            // Otherwise, ignore the exception since it's expected.
+            toRead.getInputStream().read();
+            fail();
+        } catch (SocketException expected) {
+            // Expected
         }
 
         future.get();
@@ -1748,18 +1740,10 @@ public class SSLSocketTest extends AbstractSSLTest {
             wrapping.startHandshake();
             try {
                 wrapping.setSoTimeout(readingTimeoutMillis);
-                int ret = wrapping.getInputStream().read();
-                // Android returns -1 rather than throwing.
-                if (isConscryptSocket(wrapping)) {
-                    // TODO(nmittler): Conscrypt socket read may return -1 instead of
-                    // SocketException.
-                    assertEquals(-1, ret);
-                } else {
-                    // For any other socket type, we should expect SocketException.
-                    fail();
-                }
-            } catch (SocketException e) {
-                // Otherwise, ignore the exception since it's expected.
+                wrapping.getInputStream().read();
+                fail();
+            } catch (SocketException expected) {
+                // Expected
             }
             return null;
         });


### PR DESCRIPTION
The original test never called shutdownInput() since the Javadoc
indicates it will make the socket behave in a different manner than
expected in this test.

Also assert that we're not using the type of socket that we expect to
return -1 if we get a SocketException. This will indicate when this
difference is fixed and the test can be changed to reflect the
expectation.