### PR TITLE
Change so pointer is logged instead of long.

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -5728,8 +5728,10 @@ static SSL_SESSION* server_session_requested_callback(SSL* ssl, uint8_t* id, int
         JNI_TRACE("ssl=%p server_session_requested_callback exception cleared", ssl);
         env->ExceptionClear();
     }
-    JNI_TRACE("ssl=%p server_session_requested_callback completed => %d", ssl, ssl_session_address);
-    return reinterpret_cast<SSL_SESSION*>(static_cast<uintptr_t>(ssl_session_address));
+    SSL_SESSION* ssl_session_ptr = reinterpret_cast<SSL_SESSION*>(
+            static_cast<uintptr_t>(ssl_session_address));
+    JNI_TRACE("ssl=%p server_session_requested_callback completed => %p", ssl, ssl_session_ptr);
+    return ssl_session_ptr;
 }
 
 static jint NativeCrypto_EVP_has_aes_hardware(JNIEnv*, jclass) {


### PR DESCRIPTION
The underlying type of jlong differs by platform, and that causes the
necessary format specifier to differ between %d and %ld.  Instead, log
the pointer it's holding, which has a consistent format specifier.