### PR TITLE
Fixing disposed module error in IntelliJ

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -100,7 +100,12 @@ if (androidSdkInstalled) {
         compile fileTree(dir: 'libs', include: ['*.jar'])
         publicApiDocs project(':conscrypt-api-doclet')
         androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-            exclude group: 'com.android.support', module: 'support-annotations'
+            exclude module: 'support-annotations'
+            exclude module: 'support-v4'
+            exclude module: 'support-v13'
+            exclude module: 'recyclerview-v7'
+            exclude module: 'appcompat-v7'
+            exclude module: 'design'
         })
         provided project(':conscrypt-android-stub')
 

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -92,7 +92,12 @@ if (androidSdkInstalled) {
         compile project(path: ':conscrypt-openjdk', configuration: 'platform')
         publicApiDocs project(':conscrypt-api-doclet')
         androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-            exclude group: 'com.android.support', module: 'support-annotations'
+            exclude module: 'support-annotations'
+            exclude module: 'support-v4'
+            exclude module: 'support-v13'
+            exclude module: 'recyclerview-v7'
+            exclude module: 'appcompat-v7'
+            exclude module: 'design'
         })
         testCompile project(':conscrypt-testing'),
                     libraries.junit


### PR DESCRIPTION
I was seeing disposed module errors when trying to sync the gradle project in IntelliJ.  It was complaining about espresso and junit, but it seems the former was the actual culprit.