### PR TITLE
Remove Java <-> OpenSSL name mapping.

### DIFF
--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -6979,7 +6979,7 @@ static jstring NativeCrypto_SSL_get_current_cipher(JNIEnv* env, jclass, jlong ss
         return nullptr;
     }
     const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl);
-    const char* name = SSL_CIPHER_get_name(cipher);
+    const char* name = SSL_CIPHER_standard_name(cipher);
     JNI_TRACE("ssl=%p NativeCrypto_SSL_get_current_cipher => %s", ssl, name);
     return env->NewStringUTF(name);
 }
@@ -7944,7 +7944,7 @@ static jstring NativeCrypto_SSL_SESSION_cipher(JNIEnv* env, jclass, jlong ssl_se
         return nullptr;
     }
     const SSL_CIPHER* cipher = ssl_session->cipher;
-    const char* name = SSL_CIPHER_get_name(cipher);
+    const char* name = SSL_CIPHER_standard_name(cipher);
     JNI_TRACE("ssl_session=%p NativeCrypto_SSL_SESSION_cipher => %s", ssl_session, name);
     return env->NewStringUTF(name);
 }
@@ -8048,18 +8048,27 @@ static jobjectArray NativeCrypto_get_cipher_names(JNIEnv *env, jclass, jstring s
 
     size_t size = sk_SSL_CIPHER_num(ciphers);
     ScopedLocalRef<jobjectArray> cipherNamesArray(
-            env, env->NewObjectArray(static_cast<jsize>(size), JniConstants::stringClass, nullptr));
+            env,
+            env->NewObjectArray(static_cast<jsize>(2 * size), JniConstants::stringClass, nullptr));
     if (cipherNamesArray.get() == nullptr) {
         return nullptr;
     }
 
+    // Return an array of standard and OpenSSL name pairs.
     for (size_t i = 0; i < size; i++) {
-        const char *name = SSL_CIPHER_get_name(sk_SSL_CIPHER_value(ciphers, i));
-        ScopedLocalRef<jstring> cipherName(env, env->NewStringUTF(name));
-        env->SetObjectArrayElement(cipherNamesArray.get(), static_cast<jsize>(i), cipherName.get());
+        const SSL_CIPHER* cipher = sk_SSL_CIPHER_value(ciphers, i);
+        ScopedLocalRef<jstring> cipherName(env,
+                                           env->NewStringUTF(SSL_CIPHER_standard_name(cipher)));
+        env->SetObjectArrayElement(cipherNamesArray.get(), static_cast<jsize>(2 * i),
+                                   cipherName.get());
+
+        ScopedLocalRef<jstring> opensslName(env, env->NewStringUTF(SSL_CIPHER_get_name(cipher)));
+        env->SetObjectArrayElement(cipherNamesArray.get(), static_cast<jsize>(2 * i + 1),
+                                   opensslName.get());
     }
 
-    JNI_TRACE("NativeCrypto_get_cipher_names(%s) => success (%zd entries)", selector.c_str(), size);
+    JNI_TRACE("NativeCrypto_get_cipher_names(%s) => success (%zd entries)", selector.c_str(),
+              2 * size);
     return cipherNamesArray.release();
 }
 

--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -261,14 +261,6 @@ final class SSLUtils {
         return principalBytes;
     }
 
-    static String getCipherSuiteFromName(String name) {
-        String cipherSuite = name;
-        if (name != null) {
-            cipherSuite = NativeCrypto.OPENSSL_TO_STANDARD_CIPHER_SUITES.get(name);
-        }
-        return cipherSuite != null ? cipherSuite : SSLNullSession.INVALID_CIPHER;
-    }
-
     /**
      * Converts the peer certificates into a cert chain.
      */

--- a/common/src/main/java/org/conscrypt/SslSessionWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslSessionWrapper.java
@@ -229,8 +229,8 @@ abstract class SslSessionWrapper {
             this.peerOcspStapledResponse = peerOcspStapledResponse;
             this.peerSignedCertificateTimestamp = peerSignedCertificateTimestamp;
             this.protocol = NativeCrypto.SSL_SESSION_get_version(ref.context);
-            this.cipherSuite = SSLUtils.getCipherSuiteFromName(
-                    NativeCrypto.SSL_SESSION_cipher(ref.context));
+            this.cipherSuite =
+                    NativeCrypto.cipherSuiteToJava(NativeCrypto.SSL_SESSION_cipher(ref.context));
             this.ref = ref;
         }
 

--- a/common/src/main/java/org/conscrypt/SslWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslWrapper.java
@@ -102,8 +102,7 @@ final class SslWrapper {
     }
 
     String getCipherSuite() {
-        String name = NativeCrypto.SSL_get_current_cipher(ssl);
-        return SSLUtils.getCipherSuiteFromName(name);
+        return NativeCrypto.cipherSuiteToJava(NativeCrypto.SSL_get_current_cipher(ssl));
     }
 
     OpenSSLX509Certificate[] getLocalCertificates() {

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -694,8 +694,7 @@ public class NativeCryptoTest {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c);
 
-        List<String> ciphers =
-                new ArrayList<>(NativeCrypto.OPENSSL_TO_STANDARD_CIPHER_SUITES.keySet());
+        List<String> ciphers = new ArrayList<>(NativeCrypto.SUPPORTED_CIPHER_SUITES_SET);
         NativeCrypto.SSL_set_cipher_lists(s, ciphers.toArray(new String[ciphers.size()]));
 
         NativeCrypto.SSL_free(s);
@@ -2603,8 +2602,11 @@ public class NativeCryptoTest {
             @Override
             public void afterHandshake(long session, long s, long c, Socket sock, FileDescriptor fd,
                     SSLHandshakeCallbacks callback) throws Exception {
-                String a = NativeCrypto.SSL_SESSION_cipher(session);
-                assertTrue(NativeCrypto.OPENSSL_TO_STANDARD_CIPHER_SUITES.containsKey(a));
+                String nativeCipher = NativeCrypto.SSL_SESSION_cipher(session);
+                String javaCipher = NativeCrypto.cipherSuiteFromJava(nativeCipher);
+                assertTrue(NativeCrypto.SUPPORTED_CIPHER_SUITES_SET.contains(javaCipher));
+                // SSL_SESSION_cipher should return a standard name rather than an OpenSSL name.
+                assertTrue(nativeCipher.startsWith("TLS_"));
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
         };


### PR DESCRIPTION
~~**Note: This shouldn't be merged until all Conscrypt consumers have updated their BoringSSLs.** I'd probably wait a week or two? Meanwhile, here's a PR to review early.~~

As of https://github.com/google/boringssl/commit/6fff386492d9f316f5f780ff9d0ddaf1700f98a9, BoringSSL supports the standard cipher suite names. The Java names are the same, with the exception of TLS_RSA_WITH_3DES_EDE_CBC_SHA/SSL_RSA_WITH_3DES_EDE_CBC_SHA for historical reasons. Add code to map between that exception but otherwise rely on the native support.