### PR TITLE
Use buffer allocator in engine

### DIFF
--- a/benchmark-base/src/main/java/org/conscrypt/ClientEndpoint.java
+++ b/benchmark-base/src/main/java/org/conscrypt/ClientEndpoint.java
@@ -32,9 +32,9 @@ final class ClientEndpoint {
     private InputStream input;
     private OutputStream output;
 
-    ClientEndpoint(SSLSocketFactory socketFactory, WrappedSocketType wrappedSocketType, int port,
+    ClientEndpoint(SSLSocketFactory socketFactory, ChannelType channelType, int port,
             String[] protocols, String[] ciphers) throws IOException {
-        socket = wrappedSocketType.newClientSocket(
+        socket = channelType.newClientSocket(
                 socketFactory, InetAddress.getLoopbackAddress(), port);
         socket.setEnabledProtocols(protocols);
         socket.setEnabledCipherSuites(ciphers);

--- a/benchmark-base/src/main/java/org/conscrypt/ClientSocketBenchmark.java
+++ b/benchmark-base/src/main/java/org/conscrypt/ClientSocketBenchmark.java
@@ -38,7 +38,7 @@ public final class ClientSocketBenchmark {
         SocketType socketType();
         int messageSize();
         String cipher();
-        WrappedSocketType wrappedSocketType();
+        ChannelType channelType();
     }
 
     private ClientEndpoint client;
@@ -58,7 +58,7 @@ public final class ClientSocketBenchmark {
 
         // Always use the same server for consistency across the benchmarks.
         server = SocketType.CONSCRYPT_ENGINE.newServer(
-                WrappedSocketType.CHANNEL, config.messageSize(), getProtocols(), ciphers(config));
+                ChannelType.CHANNEL, config.messageSize(), getProtocols(), ciphers(config));
 
         server.setMessageProcessor(new ServerEndpoint.MessageProcessor() {
             @Override
@@ -72,7 +72,7 @@ public final class ClientSocketBenchmark {
         Future<?> connectedFuture = server.start();
 
         client = config.socketType().newClient(
-            config.wrappedSocketType(), server.port(), getProtocols(), ciphers(config));
+            config.channelType(), server.port(), getProtocols(), ciphers(config));
         client.start();
 
         // Wait for the initial connection to complete.
@@ -142,8 +142,8 @@ public final class ClientSocketBenchmark {
             }
 
             @Override
-            public WrappedSocketType wrappedSocketType() {
-                return WrappedSocketType.CHANNEL;
+            public ChannelType channelType() {
+                return ChannelType.CHANNEL;
             }
         });
 

--- a/benchmark-base/src/main/java/org/conscrypt/ServerEndpoint.java
+++ b/benchmark-base/src/main/java/org/conscrypt/ServerEndpoint.java
@@ -55,7 +55,7 @@ final class ServerEndpoint {
     }
 
     private final ServerSocket serverSocket;
-    private final WrappedSocketType wrappedSocketType;
+    private final ChannelType channelType;
     private final SSLSocketFactory socketFactory;
     private final int messageSize;
     private final String[] protocols;
@@ -69,11 +69,11 @@ final class ServerEndpoint {
     private volatile MessageProcessor messageProcessor = new EchoProcessor();
 
     ServerEndpoint(SSLSocketFactory socketFactory, SSLServerSocketFactory serverSocketFactory,
-            WrappedSocketType wrappedSocketType, int messageSize, String[] protocols,
+            ChannelType channelType, int messageSize, String[] protocols,
             String[] cipherSuites) throws IOException {
-        this.serverSocket = wrappedSocketType.newServerSocket(serverSocketFactory);
+        this.serverSocket = channelType.newServerSocket(serverSocketFactory);
         this.socketFactory = socketFactory;
-        this.wrappedSocketType = wrappedSocketType;
+        this.channelType = channelType;
         this.messageSize = messageSize;
         this.protocols = protocols;
         this.cipherSuites = cipherSuites;
@@ -120,7 +120,7 @@ final class ServerEndpoint {
                 if (stopping) {
                     return;
                 }
-                socket = wrappedSocketType.accept(serverSocket, socketFactory);
+                socket = channelType.accept(serverSocket, socketFactory);
                 socket.setEnabledProtocols(protocols);
                 socket.setEnabledCipherSuites(cipherSuites);
 

--- a/benchmark-base/src/main/java/org/conscrypt/ServerSocketBenchmark.java
+++ b/benchmark-base/src/main/java/org/conscrypt/ServerSocketBenchmark.java
@@ -41,7 +41,7 @@ public final class ServerSocketBenchmark {
         SocketType socketType();
         int messageSize();
         String cipher();
-        WrappedSocketType wrappedSocketType();
+        ChannelType channelType();
     }
 
     private ClientEndpoint client;
@@ -57,10 +57,10 @@ public final class ServerSocketBenchmark {
 
         byte[] message = newTextMessage(config.messageSize());
 
-        final WrappedSocketType wrappedSocketType = config.wrappedSocketType();
+        final ChannelType channelType = config.channelType();
 
         server = config.socketType().newServer(
-                wrappedSocketType, config.messageSize(), getProtocols(), ciphers(config));
+            channelType, config.messageSize(), getProtocols(), ciphers(config));
         server.setMessageProcessor(new MessageProcessor() {
             @Override
             public void processMessage(byte[] inMessage, int numBytes, OutputStream os) {
@@ -78,7 +78,7 @@ public final class ServerSocketBenchmark {
 
         // Always use the same client for consistency across the benchmarks.
         client = SocketType.CONSCRYPT_ENGINE.newClient(
-                WrappedSocketType.CHANNEL, server.port(), getProtocols(), ciphers(config));
+                ChannelType.CHANNEL, server.port(), getProtocols(), ciphers(config));
         client.start();
 
         // Wait for the initial connection to complete.
@@ -156,8 +156,8 @@ public final class ServerSocketBenchmark {
             }
 
             @Override
-            public WrappedSocketType wrappedSocketType() {
-                return WrappedSocketType.CHANNEL;
+            public ChannelType channelType() {
+                return ChannelType.CHANNEL;
             }
         });
 

--- a/benchmark-base/src/main/java/org/conscrypt/SocketType.java
+++ b/benchmark-base/src/main/java/org/conscrypt/SocketType.java
@@ -21,16 +21,16 @@ public enum SocketType {
         this.factories = factories;
     }
 
-    ClientEndpoint newClient(WrappedSocketType wrappedSocketType, int port, String[] protocols,
+    ClientEndpoint newClient(ChannelType channelType, int port, String[] protocols,
             String[] ciphers) throws IOException {
         return new ClientEndpoint(
-                factories.clientFactory, wrappedSocketType, port, protocols, ciphers);
+                factories.clientFactory, channelType, port, protocols, ciphers);
     }
 
-    ServerEndpoint newServer(WrappedSocketType wrappedSocketType, int messageSize,
+    ServerEndpoint newServer(ChannelType channelType, int messageSize,
             String[] protocols, String[] ciphers) throws IOException {
         return new ServerEndpoint(factories.serverFactory, factories.serverSocketFactory,
-                wrappedSocketType, messageSize, protocols, ciphers);
+            channelType, messageSize, protocols, ciphers);
     }
 
     private static final class Factories {

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhClientSocketBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhClientSocketBenchmark.java
@@ -56,7 +56,8 @@ public class JmhClientSocketBenchmark {
 
     private final JmhConfig config = new JmhConfig();
 
-    @Param public SocketType socketType;
+    @Param
+    public SocketType socketType;
 
     @Param({"64", "512", "4096"})
     public int messageSize;
@@ -64,7 +65,8 @@ public class JmhClientSocketBenchmark {
     @Param({TestUtils.TEST_CIPHER})
     public String cipher;
 
-    @Param public WrappedSocketType wrapped;
+    @Param
+    public ChannelType channelType;
 
     private ClientSocketBenchmark benchmark;
 
@@ -101,8 +103,8 @@ public class JmhClientSocketBenchmark {
         }
 
         @Override
-        public WrappedSocketType wrappedSocketType() {
-            return wrapped;
+        public ChannelType channelType() {
+            return channelType;
         }
     }
 }

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhEngineBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhEngineBenchmark.java
@@ -33,7 +33,6 @@
 package org.conscrypt;
 
 import javax.net.ssl.SSLException;
-import org.conscrypt.EngineBenchmark.BufferType;
 import org.conscrypt.EngineBenchmark.Config;
 import org.conscrypt.EngineBenchmark.SslProvider;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -55,9 +54,6 @@ public class JmhEngineBenchmark {
 
     @Param
     public SslProvider sslProvider;
-
-    @Param
-    public BufferType bufferType;
 
     @Param({"64", "512", "4096"})
     public int messageSize;
@@ -86,11 +82,6 @@ public class JmhEngineBenchmark {
         @Override
         public SslProvider sslProvider() {
             return sslProvider;
-        }
-
-        @Override
-        public BufferType bufferType() {
-            return bufferType;
         }
 
         @Override

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhServerSocketBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhServerSocketBenchmark.java
@@ -56,13 +56,17 @@ public class JmhServerSocketBenchmark {
 
     private final JmhConfig config = new JmhConfig();
 
-    @Param public SocketType socketType;
+    @Param
+    public SocketType socketType;
 
-    @Param public WrappedSocketType wrapped;
+    @Param
+    public ChannelType channelType;
 
-    @Param({"64", "1024"}) public int messageSize;
+    @Param({"64", "512", "4096"})
+    public int messageSize;
 
-    @Param({"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}) public String cipher;
+    @Param({"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"})
+    public String cipher;
 
     private ServerSocketBenchmark benchmark;
 
@@ -99,8 +103,8 @@ public class JmhServerSocketBenchmark {
         }
 
         @Override
-        public WrappedSocketType wrappedSocketType() {
-            return wrapped;
+        public ChannelType channelType() {
+            return channelType;
         }
     }
 }

--- a/common/src/main/java/org/conscrypt/AllocatedBuffer.java
+++ b/common/src/main/java/org/conscrypt/AllocatedBuffer.java
@@ -13,182 +13,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package org.conscrypt;
 
 import static org.conscrypt.Preconditions.checkNotNull;
-import static org.conscrypt.Preconditions.checkPositionIndexes;
 
 import java.nio.ByteBuffer;
 
 /**
- * A buffer that was allocated by a {@link BufferAllocator}. For every buffer, it is guaranteed that
- * at least one of {@link #hasArray()} or {@link #hasNioBuffer()} will be {@code true}.
+ * A buffer that was allocated by a {@link BufferAllocator}.
  */
 @ExperimentalApi
 abstract class AllocatedBuffer {
     /**
-     * Indicates whether this buffer contains a backing {@link ByteBuffer} (i.e. it is safe to call
-     * {@link #nioBuffer()}).
-     */
-    public abstract boolean hasNioBuffer();
-
-    /**
-     * Indicates whether this buffer contains a backing array (i.e. it is safe to call {@link
-     * #array()}).
-     */
-    public abstract boolean hasArray();
-
-    /**
-     * Returns the {@link ByteBuffer} that backs this buffer <i>(optional operation)</i>.
-     *
-     * <p>Call {@link #hasNioBuffer()} before invoking this method in order to ensure that this
-     * buffer has a backing {@link ByteBuffer}.
-     *
-     * @return The {@link ByteBuffer} that backs this buffer
-     * @throws UnsupportedOperationException If this buffer is not backed by a {@link ByteBuffer}.
+     * Returns the {@link ByteBuffer} that backs this buffer.
      */
     public abstract ByteBuffer nioBuffer();
 
     /**
-     * Returns the byte array that backs this buffer <i>(optional operation)</i>.
-     *
-     * <p>Call {@link #hasArray()} before invoking this method in order to ensure that this buffer
-     * has an accessible backing array.
-     *
-     * @return The array that backs this buffer
-     * @throws java.nio.ReadOnlyBufferException If this buffer is backed by an array but is
-     * read-only
-     * @throws UnsupportedOperationException If this buffer is not backed by an accessible array
+     * Increases the reference count by {@code 1}.
      */
-    public abstract byte[] array();
+    public abstract AllocatedBuffer retain();
 
     /**
-     * Returns the offset within this buffer's backing array of the first element of the buffer
-     * <i>(optional operation)</i>.
+     * Decreases the reference count by {@code 1} and deallocates this object if the reference count
+     * reaches at {@code 0}.
      *
-     * <p>If this buffer is backed by an array then {@link #position()} corresponds to the array
-     * index
-     * {@link #position()} {@code +} {@link #arrayOffset()}.
-     *
-     * <p>Invoke the {@link #hasArray hasArray} method before invoking this method in order to
-     * ensure that this buffer has an accessible backing array.
-     *
-     * @return The offset within this buffer's array of the first element of the buffer
-     * @throws java.nio.ReadOnlyBufferException If this buffer is backed by an array but is
-     * read-only
-     * @throws UnsupportedOperationException If this buffer is not backed by an accessible array
+     * @return {@code true} if and only if the reference count became {@code 0} and this object has
+     * been deallocated
      */
-    public abstract int arrayOffset();
+    public abstract AllocatedBuffer release();
 
     /**
-     * Returns this buffer's position.
-     *
-     * @return The position of this buffer
-     */
-    public abstract int position();
-
-    /**
-     * Sets this buffer's position.
-     *
-     * @param position The new position value; must be non-negative and no larger than the current
-     *     limit
-     * @return This buffer
-     * @throws IllegalArgumentException If the preconditions on {@code position} do not hold
-     */
-    public abstract AllocatedBuffer position(int position);
-
-    /**
-     * Returns this buffer's limit.
-     *
-     * @return The limit of this buffer
-     */
-    public abstract int limit();
-
-    /**
-     * Returns the number of elements between the current {@link #position()} and the {@link
-     * #limit()}
-     * .
-     *
-     * @return The number of elements remaining in this buffer
-     */
-    public abstract int remaining();
-
-    /**
-     * Creates a new {@link AllocatedBuffer} that is backed by the given array. The returned buffer
-     * will have {@link #hasArray} == {@code true}, {@link #arrayOffset()} == {@code 0}, {@link
-     * #position()} == {@code 0} and {@link #limit()} equal to the length of {@code bytes}.
-     */
-    public static AllocatedBuffer wrap(byte[] bytes) {
-        return wrap(bytes, 0, bytes.length);
-    }
-
-    /**
-     * Creates a new {@link AllocatedBuffer} that is backed by the given array. The returned buffer
-     * will have {@link #hasArray} == {@code true}, {@link #arrayOffset()} == {@code offset}, {@link
-     * #position()} == {@code 0} and {@link #limit()} == {@code length}.
-     */
-    public static AllocatedBuffer wrap(final byte[] bytes, final int offset, final int length) {
-        checkNotNull(bytes, "bytes");
-        checkPositionIndexes(offset, offset + length, bytes.length);
-        return new AllocatedBuffer() {
-            // Relative to offset.
-            private int position;
-
-            @Override
-            public boolean hasNioBuffer() {
-                return false;
-            }
-
-            @Override
-            public ByteBuffer nioBuffer() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean hasArray() {
-                return true;
-            }
-
-            @Override
-            public byte[] array() {
-                return bytes;
-            }
-
-            @Override
-            public int arrayOffset() {
-                return offset;
-            }
-
-            @Override
-            public int position() {
-                return position;
-            }
-
-            @Override
-            public AllocatedBuffer position(int position) {
-                if (position < 0 || position > length) {
-                    throw new IllegalArgumentException("Invalid position: " + position);
-                }
-                this.position = position;
-                return this;
-            }
-
-            @Override
-            public int limit() {
-                // Relative to offset.
-                return length;
-            }
-
-            @Override
-            public int remaining() {
-                return length - position;
-            }
-        };
-    }
-
-    /**
-     * Creates a new {@link AllocatedBuffer} that is backed by the given {@link ByteBuffer}. The
-     * returned buffer will have {@link #hasNioBuffer} == {@code true}.
+     * Creates a new {@link AllocatedBuffer} that is backed by the given {@link ByteBuffer}.
      */
     public static AllocatedBuffer wrap(final ByteBuffer buffer) {
         checkNotNull(buffer, "buffer");
@@ -196,49 +68,20 @@ abstract class AllocatedBuffer {
         return new AllocatedBuffer() {
 
             @Override
-            public boolean hasNioBuffer() {
-                return true;
-            }
-
-            @Override
             public ByteBuffer nioBuffer() {
                 return buffer;
             }
 
             @Override
-            public boolean hasArray() {
-                return buffer.hasArray();
-            }
-
-            @Override
-            public byte[] array() {
-                return buffer.array();
-            }
-
-            @Override
-            public int arrayOffset() {
-                return buffer.arrayOffset();
-            }
-
-            @Override
-            public int position() {
-                return buffer.position();
-            }
-
-            @Override
-            public AllocatedBuffer position(int position) {
-                buffer.position(position);
+            public AllocatedBuffer retain() {
+                // Do nothing.
                 return this;
             }
 
             @Override
-            public int limit() {
-                return buffer.limit();
-            }
-
-            @Override
-            public int remaining() {
-                return buffer.remaining();
+            public AllocatedBuffer release() {
+                // Do nothing.
+                return this;
             }
         };
     }

--- a/common/src/main/java/org/conscrypt/BufferAllocator.java
+++ b/common/src/main/java/org/conscrypt/BufferAllocator.java
@@ -25,11 +25,6 @@ import java.nio.ByteBuffer;
 abstract class BufferAllocator {
     private static BufferAllocator UNPOOLED = new BufferAllocator() {
         @Override
-        public AllocatedBuffer allocateHeapBuffer(int capacity) {
-            return AllocatedBuffer.wrap(new byte[capacity]);
-        }
-
-        @Override
         public AllocatedBuffer allocateDirectBuffer(int capacity) {
             return AllocatedBuffer.wrap(ByteBuffer.allocateDirect(capacity));
         }
@@ -41,11 +36,6 @@ abstract class BufferAllocator {
     public static BufferAllocator unpooled() {
         return UNPOOLED;
     }
-
-    /**
-     * Allocates a buffer with the given capacity that is backed by an array on the heap.
-     */
-    public abstract AllocatedBuffer allocateHeapBuffer(int capacity);
 
     /**
      * Allocates a direct (i.e. non-heap) buffer with the given capacity.

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -370,6 +370,15 @@ public final class Conscrypt {
         }
 
         /**
+         * Provides the given engine with the provided bufferAllocator.
+         * @param engine
+         * @param bufferAllocator
+         */
+        static void setBufferAllocator(SSLEngine engine, BufferAllocator bufferAllocator) {
+            toConscrypt(engine).setBufferAllocator(bufferAllocator);
+        }
+
+        /**
          * This method enables Server Name Indication (SNI) and overrides the hostname supplied
          * during engine creation.
          *

--- a/testing/src/main/java/org/conscrypt/ChannelType.java
+++ b/testing/src/main/java/org/conscrypt/ChannelType.java
@@ -35,7 +35,7 @@ import javax.net.ssl.SSLSocketFactory;
  * The type of socket to be wrapped by the Conscrypt socket.
  */
 @SuppressWarnings("unused")
-public enum WrappedSocketType {
+public enum ChannelType {
     NONE {
         @Override
         SSLSocket newClientSocket(SSLSocketFactory factory, InetAddress address, int port)


### PR DESCRIPTION
Also modifying the engine so that when running with no allocator
(i.e. default), that it lazy-creates a direct buffer for JNI operations.
This is a trade-off of performance for memory. It requires the
allocation of a single direct buffer (~16k) that it uses to copy
from/to heap buffers provided by the application.

Fixes #226

Benchmarks show a huge improvement. The engine socket now blows away
old file-based socket. Also the engine, itself, is performing on par with Netty.

Client Socket:
```
Benchmark                                (channelType)  (messageSize)      (socketType)           Score           Error  Units
JmhClientSocketBenchmark:bytesPerSecond           NONE             64               JDK    20670510.287 ±   2819961.400  ops/s
JmhClientSocketBenchmark:bytesPerSecond           NONE             64         CONSCRYPT    33848197.816 ±   4989350.539  ops/s
JmhClientSocketBenchmark:bytesPerSecond           NONE             64  CONSCRYPT_ENGINE    44749583.683 ±   6134292.637  ops/s
JmhClientSocketBenchmark:bytesPerSecond           NONE            512               JDK    48204433.541 ±   2810531.888  ops/s
JmhClientSocketBenchmark:bytesPerSecond           NONE            512         CONSCRYPT   232416415.148 ±  29684894.680  ops/s
JmhClientSocketBenchmark:bytesPerSecond           NONE            512  CONSCRYPT_ENGINE   310801215.727 ±  24371818.265  ops/s
JmhClientSocketBenchmark:bytesPerSecond           NONE           4096               JDK    58643513.808 ±   1658108.450  ops/s
JmhClientSocketBenchmark:bytesPerSecond           NONE           4096         CONSCRYPT  1042715167.769 ±  33554034.996  ops/s
JmhClientSocketBenchmark:bytesPerSecond           NONE           4096  CONSCRYPT_ENGINE   998985902.510 ± 173250355.584  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL             64               JDK    21669189.718 ±   2106385.961  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL             64         CONSCRYPT    37385156.054 ±   4532906.286  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL             64  CONSCRYPT_ENGINE    52886375.324 ±   6790212.250  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL            512               JDK    47883220.892 ±   3333321.741  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL            512         CONSCRYPT   224271272.001 ±  31693272.362  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL            512  CONSCRYPT_ENGINE   307433134.710 ±  30458931.236  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL           4096               JDK    59366754.581 ±    989937.143  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL           4096         CONSCRYPT   997387329.864 ±  88179847.161  ops/s
JmhClientSocketBenchmark:bytesPerSecond     NO_CHANNEL           4096  CONSCRYPT_ENGINE   949163467.244 ± 162903541.551  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL             64               JDK    18853147.149 ±   2567512.388  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL             64         CONSCRYPT    38973102.125 ±   5288147.227  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL             64  CONSCRYPT_ENGINE    49037557.290 ±   3449771.391  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL            512               JDK    46940578.297 ±   3187957.601  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL            512         CONSCRYPT   242148384.926 ±  26908183.865  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL            512  CONSCRYPT_ENGINE   285255663.928 ±  29806352.951  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL           4096               JDK    58530903.691 ±   1673847.911  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL           4096         CONSCRYPT   935549616.895 ± 174971552.322  ops/s
JmhClientSocketBenchmark:bytesPerSecond        CHANNEL           4096  CONSCRYPT_ENGINE   885196452.941 ± 149034647.632  ops/s
```

Server socket:
```
Benchmark                                (channelType)  (messageSize)      (socketType)           Score           Error  Units
JmhServerSocketBenchmark:bytesPerSecond           NONE             64               JDK    20471863.122 ±   2750083.890  ops/s
JmhServerSocketBenchmark:bytesPerSecond           NONE             64         CONSCRYPT    35067182.137 ±   4321558.305  ops/s
JmhServerSocketBenchmark:bytesPerSecond           NONE             64  CONSCRYPT_ENGINE    51865841.557 ±   6210881.683  ops/s
JmhServerSocketBenchmark:bytesPerSecond           NONE            512               JDK    48226041.924 ±   2652378.529  ops/s
JmhServerSocketBenchmark:bytesPerSecond           NONE            512         CONSCRYPT   256960370.646 ±  15978194.656  ops/s
JmhServerSocketBenchmark:bytesPerSecond           NONE            512  CONSCRYPT_ENGINE   305922585.432 ±  11603169.168  ops/s
JmhServerSocketBenchmark:bytesPerSecond           NONE           4096               JDK    57540407.205 ±   1494303.451  ops/s
JmhServerSocketBenchmark:bytesPerSecond           NONE           4096         CONSCRYPT   834949391.557 ± 131468107.844  ops/s
JmhServerSocketBenchmark:bytesPerSecond           NONE           4096  CONSCRYPT_ENGINE   894561064.594 ± 186485784.506  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL             64               JDK    21414715.924 ±   2525202.959  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL             64         CONSCRYPT    36320793.361 ±   2506987.539  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL             64  CONSCRYPT_ENGINE    51698559.566 ±   4280412.657  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL            512               JDK    47550444.360 ±   2791912.476  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL            512         CONSCRYPT   226298704.876 ±  32094643.264  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL            512  CONSCRYPT_ENGINE   302745204.149 ±  32629696.557  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL           4096               JDK    59568364.160 ±    662744.026  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL           4096         CONSCRYPT   892983849.077 ± 185771381.513  ops/s
JmhServerSocketBenchmark:bytesPerSecond     NO_CHANNEL           4096  CONSCRYPT_ENGINE  1027094139.211 ± 142838635.652  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL             64               JDK    19017307.062 ±   3202589.193  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL             64         CONSCRYPT    36145718.739 ±   7424407.014  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL             64  CONSCRYPT_ENGINE    43706545.753 ±   8133454.663  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL            512               JDK    48295259.871 ±   2751536.354  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL            512         CONSCRYPT   260689915.496 ±  11958497.389  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL            512  CONSCRYPT_ENGINE   300341704.678 ±  29489214.700  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL           4096               JDK    57961362.687 ±   1450364.082  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL           4096         CONSCRYPT   999803862.933 ± 113516770.944  ops/s
JmhServerSocketBenchmark:bytesPerSecond        CHANNEL           4096  CONSCRYPT_ENGINE  1031217300.014 ± 124844374.416  ops/s
```

Engine:
```
Benchmark                                                      (cipher)  (messageSize)            (sslProvider)           Score           Error  Units
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64                 JDK_HEAP      465332.382 ±     23279.209  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64               JDK_DIRECT      454529.557 ±     27897.327  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64  CONSCRYPT_HEAP_UNPOOLED     1744207.896 ±     17819.397  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64    CONSCRYPT_HEAP_POOLED     1465451.813 ±     14176.452  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64         CONSCRYPT_DIRECT     2016813.524 ±     27654.790  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64               NETTY_HEAP     1434943.223 ±     75951.521  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64             NETTY_DIRECT     2213406.254 ±    176332.371  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512                 JDK_HEAP      106853.524 ±      4317.313  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512               JDK_DIRECT      103353.246 ±      8433.983  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512  CONSCRYPT_HEAP_UNPOOLED     1496206.948 ±     21583.193  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512    CONSCRYPT_HEAP_POOLED     1057553.091 ±    130857.752  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512         CONSCRYPT_DIRECT     1597479.155 ±     20888.559  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512               NETTY_HEAP     1169042.447 ±     77704.222  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512             NETTY_DIRECT     1663056.393 ±     26704.186  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096                 JDK_HEAP       15108.921 ±       160.300  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096               JDK_DIRECT       14246.365 ±       981.619  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096  CONSCRYPT_HEAP_UNPOOLED      497098.353 ±      4970.274  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096    CONSCRYPT_HEAP_POOLED      417374.589 ±      4997.278  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096         CONSCRYPT_DIRECT      527155.170 ±     33216.737  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096               NETTY_HEAP      392839.884 ±     23065.132  ops/s
JmhEngineBenchmark.wrap           TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096             NETTY_DIRECT      507145.953 ±     29442.768  ops/s


JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64                 JDK_HEAP      221410.435 ±     15308.092  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64               JDK_DIRECT      219072.340 ±     16675.432  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64  CONSCRYPT_HEAP_UNPOOLED      866077.951 ±     42527.270  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64    CONSCRYPT_HEAP_POOLED      597154.296 ±      8613.868  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64         CONSCRYPT_DIRECT      926671.460 ±     15021.389  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64               NETTY_HEAP      704027.048 ±     25672.112  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256             64             NETTY_DIRECT     1051056.529 ±     15020.345  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512                 JDK_HEAP       50648.382 ±      4929.690  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512               JDK_DIRECT       51725.315 ±      2160.470  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512  CONSCRYPT_HEAP_UNPOOLED      648229.046 ±     20470.238  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512    CONSCRYPT_HEAP_POOLED      493919.908 ±     43992.976  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512         CONSCRYPT_DIRECT      718664.342 ±      8480.030  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512               NETTY_HEAP      554893.692 ±     18063.672  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256            512             NETTY_DIRECT      777181.573 ±      9124.882  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096                 JDK_HEAP        7456.319 ±        86.302  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096               JDK_DIRECT        7106.374 ±       397.573  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096  CONSCRYPT_HEAP_UNPOOLED      223205.783 ±     11577.505  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096    CONSCRYPT_HEAP_POOLED      190202.214 ±      9213.396  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096         CONSCRYPT_DIRECT      253628.773 ±      2695.321  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096               NETTY_HEAP      186621.213 ±     10636.644  ops/s
JmhEngineBenchmark.wrapAndUnwrap  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256           4096             NETTY_DIRECT      234275.366 ±     14115.279  ops/s
```
