### PR TITLE
Make the BufferAllocator public.

### DIFF
--- a/common/src/main/java/org/conscrypt/AllocatedBuffer.java
+++ b/common/src/main/java/org/conscrypt/AllocatedBuffer.java
@@ -39,7 +39,7 @@ import java.nio.ByteBuffer;
  * A buffer that was allocated by a {@link BufferAllocator}.
  */
 @ExperimentalApi
-abstract class AllocatedBuffer {
+public abstract class AllocatedBuffer {
     /**
      * Returns the {@link ByteBuffer} that backs this buffer.
      */

--- a/common/src/main/java/org/conscrypt/BufferAllocator.java
+++ b/common/src/main/java/org/conscrypt/BufferAllocator.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
  * pooling within an application.
  */
 @ExperimentalApi
-abstract class BufferAllocator {
+public abstract class BufferAllocator {
     private static BufferAllocator UNPOOLED = new BufferAllocator() {
         @Override
         public AllocatedBuffer allocateDirectBuffer(int capacity) {

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -374,7 +374,7 @@ public final class Conscrypt {
          * @param engine
          * @param bufferAllocator
          */
-        static void setBufferAllocator(SSLEngine engine, BufferAllocator bufferAllocator) {
+        public static void setBufferAllocator(SSLEngine engine, BufferAllocator bufferAllocator) {
             toConscrypt(engine).setBufferAllocator(bufferAllocator);
         }
 


### PR DESCRIPTION
This will allow it to be used by other projects such as Netty
and gRPC.