### PR TITLE
Fix inconsistency with engine socket

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -545,7 +545,7 @@ final class ConscryptEngine extends SSLEngine implements NativeCrypto.SSLHandsha
      */
     SSLSession handshakeSession() {
         synchronized (stateLock) {
-            return state >= STATE_HANDSHAKE_STARTED && state < STATE_READY ? sslSession : null;
+            return state == STATE_HANDSHAKE_STARTED ? sslSession : null;
         }
     }
 

--- a/openjdk-integ-tests/build.gradle
+++ b/openjdk-integ-tests/build.gradle
@@ -24,6 +24,18 @@ dependencies {
                 project(':conscrypt-testing')
 }
 
+// Add a second round of tests using the engine-based socket.
+task testEngineSocket(type: Test) {
+    dependsOn testClasses
+    // Use the engine socket by default.
+    jvmArgs "-Dorg.conscrypt.useEngineSocketByDefault=true"
+    testClassesDir = test.testClassesDir
+    doFirst {
+        classpath = test.classpath
+    }
+}
+test.dependsOn testEngineSocket
+
 // Don't include this artifact in the distribution.
 tasks.install.enabled = false
 tasks.uploadArchives.enabled = false;


### PR DESCRIPTION
The SSLSocketTest (an android integ test) fails with the
engine socket due to a minor inconsistency in the behavior
of the handshakeSession method.