### PR TITLE
Call free() if a new socket is immediately closed.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -918,6 +918,7 @@ final class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
                 // The handshake hasn't been started yet, so there's no OpenSSL related
                 // state to clean up. We still need to close the underlying socket if
                 // we're wrapping it and were asked to autoClose.
+                free();
                 closeUnderlyingSocket();
 
                 stateLock.notifyAll();


### PR DESCRIPTION
Even though we haven't created any OpenSSL state, we've allocated
some resources, including most importantly file descriptors in
AppData, that need to be freed.