### PR TITLE
Adding bechmark for ALPN

### DIFF
--- a/benchmark-base/src/main/java/org/conscrypt/EngineHandshakeBenchmark.java
+++ b/benchmark-base/src/main/java/org/conscrypt/EngineHandshakeBenchmark.java
@@ -49,10 +49,12 @@ public final class EngineHandshakeBenchmark {
         BufferType bufferType();
         EngineType engineType();
         String cipher();
+        boolean useAlpn();
     }
 
     private final EngineType engineType;
     private final String cipher;
+    private final boolean useAlpn;
 
     private final ByteBuffer clientApplicationBuffer;
     private final ByteBuffer clientPacketBuffer;
@@ -62,10 +64,11 @@ public final class EngineHandshakeBenchmark {
     EngineHandshakeBenchmark(Config config) throws Exception {
         engineType = config.engineType();
         cipher = config.cipher();
+        useAlpn = config.useAlpn();
         BufferType bufferType = config.bufferType();
 
-        SSLEngine clientEngine = engineType.newClientEngine(cipher);
-        SSLEngine serverEngine = engineType.newServerEngine(cipher);
+        SSLEngine clientEngine = engineType.newClientEngine(cipher, useAlpn);
+        SSLEngine serverEngine = engineType.newServerEngine(cipher, useAlpn);
 
         // Create the application and packet buffers for both endpoints.
         clientApplicationBuffer = bufferType.newApplicationBuffer(clientEngine);
@@ -78,8 +81,8 @@ public final class EngineHandshakeBenchmark {
     }
 
     void handshake() throws SSLException {
-        SSLEngine client = engineType.newClientEngine(cipher);
-        SSLEngine server = engineType.newServerEngine(cipher);
+        SSLEngine client = engineType.newClientEngine(cipher, useAlpn);
+        SSLEngine server = engineType.newServerEngine(cipher, useAlpn);
         clientApplicationBuffer.clear();
         clientPacketBuffer.clear();
         serverApplicationBuffer.clear();
@@ -109,6 +112,11 @@ public final class EngineHandshakeBenchmark {
             @Override
             public String cipher() {
                 return TestUtils.TEST_CIPHER;
+            }
+
+            @Override
+            public boolean useAlpn() {
+                return false;
             }
         });
 

--- a/benchmark-base/src/main/java/org/conscrypt/EngineWrapBenchmark.java
+++ b/benchmark-base/src/main/java/org/conscrypt/EngineWrapBenchmark.java
@@ -72,8 +72,8 @@ public final class EngineWrapBenchmark {
         cipher = config.cipher();
         BufferType bufferType = config.bufferType();
 
-        clientEngine = engineType.newClientEngine(cipher);
-        serverEngine = engineType.newServerEngine(cipher);
+        clientEngine = engineType.newClientEngine(cipher, false);
+        serverEngine = engineType.newServerEngine(cipher, false);
 
         // Create the application and packet buffers for both endpoints.
         clientApplicationBuffer = bufferType.newApplicationBuffer(clientEngine);

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhAlpnBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhAlpnBenchmark.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import javax.net.ssl.SSLException;
+import org.conscrypt.EngineHandshakeBenchmark.Config;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+/**
+ * Benchmark comparing ALPN performance between Conscrypt and Netty.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Threads(1)
+public class JmhAlpnBenchmark {
+  private final JmhConfig config = new JmhConfig();
+
+  @Param({TestUtils.TEST_CIPHER})
+  public String a_cipher;
+
+  @Param
+  public BufferType b_buffer;
+
+  // JDK does not support ALPN, so exclude it from the benchmarks.
+  @Param({"CONSCRYPT_UNPOOLED", "CONSCRYPT_POOLED", "NETTY", "NETTY_REF_CNT"})
+  public EngineType c_engine;
+
+  private EngineHandshakeBenchmark benchmark;
+
+  @Setup(Level.Iteration)
+  public void setup() throws Exception {
+    benchmark = new EngineHandshakeBenchmark(config);
+  }
+
+  @Benchmark
+  public void hs() throws SSLException {
+    benchmark.handshake();
+  }
+
+  private final class JmhConfig implements Config {
+
+    @Override
+    public BufferType bufferType() {
+      return b_buffer;
+    }
+
+    @Override
+    public EngineType engineType() {
+      return c_engine;
+    }
+
+    @Override
+    public String cipher() {
+      return a_cipher;
+    }
+
+    @Override
+    public boolean useAlpn() {
+      return true;
+    }
+  }
+}
+

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhEngineHandshakeBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhEngineHandshakeBenchmark.java
@@ -44,7 +44,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 
 /**
- * Benchmark comparing performance of various engine implementations to conscrypt.
+ * Benchmark comparing handshake performance of various engine implementations.
  */
 @State(Scope.Benchmark)
 @Fork(1)
@@ -88,6 +88,11 @@ public class JmhEngineHandshakeBenchmark {
         @Override
         public String cipher() {
             return a_cipher;
+        }
+
+        @Override
+        public boolean useAlpn() {
+            return false;
         }
     }
 }

--- a/common/src/main/java/org/conscrypt/SslWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslWrapper.java
@@ -311,9 +311,12 @@ final class SslWrapper {
                     + NativeCrypto.OBSOLETE_PROTOCOL_SSLV3
                     + " is no longer supported and was filtered from the list");
         }
-        NativeCrypto.SSL_configure_alpn(ssl, isClient(), parameters.alpnProtocols);
         NativeCrypto.setEnabledProtocols(ssl, parameters.enabledProtocols);
         NativeCrypto.setEnabledCipherSuites(ssl, parameters.enabledCipherSuites);
+
+        if (parameters.alpnProtocols != null) {
+            NativeCrypto.SSL_configure_alpn(ssl, isClient(), parameters.alpnProtocols);
+        }
 
         // setup server certificates and private keys.
         // clients will receive a call back to request certificates.


### PR DESCRIPTION
Fixes #156

The performance seems to be little different than that of a non-ALPN
handshake.

```
Benchmark            (b_buffer)          (c_engine)     Score     Error  Units
JmhAlpnBenchmark.hs        HEAP  CONSCRYPT_UNPOOLED   768.916 ± 168.074  ops/s
JmhAlpnBenchmark.hs        HEAP    CONSCRYPT_POOLED   774.796 ±  78.671  ops/s
JmhAlpnBenchmark.hs        HEAP               NETTY  1212.837 ±  66.354  ops/s
JmhAlpnBenchmark.hs        HEAP       NETTY_REF_CNT  1199.947 ±  72.580  ops/s
JmhAlpnBenchmark.hs      DIRECT  CONSCRYPT_UNPOOLED   748.874 ± 156.781  ops/s
JmhAlpnBenchmark.hs      DIRECT    CONSCRYPT_POOLED   787.118 ±  74.509  ops/s
JmhAlpnBenchmark.hs      DIRECT               NETTY  1199.316 ±  80.031  ops/s
JmhAlpnBenchmark.hs      DIRECT       NETTY_REF_CNT  1238.442 ±  40.716  ops/s
```