### PR TITLE
Encode certs in verify callback

### DIFF
--- a/benchmark-base/src/main/java/org/conscrypt/EngineHandshakeBenchmark.java
+++ b/benchmark-base/src/main/java/org/conscrypt/EngineHandshakeBenchmark.java
@@ -101,12 +101,12 @@ public final class EngineHandshakeBenchmark {
         EngineHandshakeBenchmark bm = new EngineHandshakeBenchmark(new Config() {
             @Override
             public BufferType bufferType() {
-                return BufferType.HEAP;
+                return BufferType.DIRECT;
             }
 
             @Override
             public EngineType engineType() {
-                return EngineType.NETTY;
+                return EngineType.CONSCRYPT_UNPOOLED;
             }
 
             @Override

--- a/common/src/jni/main/cpp/NativeCrypto.cpp
+++ b/common/src/jni/main/cpp/NativeCrypto.cpp
@@ -5767,6 +5767,59 @@ static int cert_verify_callback(X509_STORE_CTX* x509_store_ctx, void* arg) {
     return result;
 }
 
+static int encoded_cert_verify_callback(X509_STORE_CTX *x509_store_ctx, void *arg) {
+    /* Get the correct index to the SSLobject stored into X509_STORE_CTX. */
+    SSL* ssl = reinterpret_cast<SSL*>(X509_STORE_CTX_get_ex_data(x509_store_ctx,
+            SSL_get_ex_data_X509_STORE_CTX_idx()));
+    JNI_TRACE("ssl=%p encoded_cert_verify_callback x509_store_ctx=%p arg=%p", ssl,
+            x509_store_ctx, arg);
+
+    AppData* appData = toAppData(ssl);
+    JNIEnv* env = appData->env;
+    if (env == nullptr) {
+        ALOGE("AppData->env missing in encoded_cert_verify_callback");
+        JNI_TRACE("ssl=%p encoded_cert_verify_callback => 0", ssl);
+        return 0;
+    }
+    // Get a stack of all certs in the chain
+    STACK_OF(CRYPTO_BUFFER)* buffers = SSL_get0_peer_certificates(ssl);
+
+    int numBuffers = sk_CRYPTO_BUFFER_num(buffers);
+
+    // Create the byte[][] array that holds all the certs
+    ScopedLocalRef<jobjectArray> array(env,
+        env->NewObjectArray(numBuffers, JniConstants::byteArrayClass, nullptr));
+
+    for(unsigned i = 0; i < numBuffers; ++i) {
+        CRYPTO_BUFFER* buffer = sk_CRYPTO_BUFFER_value(buffers, i);
+        int length = CRYPTO_BUFFER_len(buffer);
+        ScopedLocalRef<jbyteArray> bArray(env, env->NewByteArray(length));
+        env->SetByteArrayRegion(bArray.get(), 0, length, (jbyte*) CRYPTO_BUFFER_data(buffer));
+        env->SetObjectArrayElement(array.get(), i, bArray.get());
+    }
+
+    jobject sslHandshakeCallbacks = appData->sslHandshakeCallbacks;
+    jclass cls = env->GetObjectClass(sslHandshakeCallbacks);
+    jmethodID methodID = env->GetMethodID(cls, "verifyEncodedCertificateChain",
+                                          "([[BLjava/lang/String;)V");
+
+    const SSL_CIPHER *cipher = SSL_get_pending_cipher(ssl);
+    const char *authMethod = SSL_CIPHER_get_kx_name(cipher);
+
+    JNI_TRACE("ssl=%p encoded_cert_verify_callback calling verifyCertificateChain2 authMethod=%s",
+              ssl, authMethod);
+    jstring authMethodString = env->NewStringUTF(authMethod);
+    env->CallVoidMethod(sslHandshakeCallbacks, methodID, array.get(), authMethodString);
+
+    // We need to delete the local references so we not leak memory as this method is called
+    // via callback.
+    env->DeleteLocalRef(authMethodString);
+
+    int result = (env->ExceptionCheck()) ? 0 : 1;
+    JNI_TRACE("ssl=%p encoded_cert_verify_callback => %d", ssl, result);
+    return result;
+}
+
 /**
  * Call back to watch for handshake to be completed. This is necessary for
  * False Start support, since SSL_do_handshake returns before the handshake is
@@ -6182,7 +6235,7 @@ static jlong NativeCrypto_SSL_CTX_new(JNIEnv* env, jclass) {
 
     SSL_CTX_set_mode(sslCtx.get(), mode);
 
-    SSL_CTX_set_cert_verify_callback(sslCtx.get(), cert_verify_callback, nullptr);
+    SSL_CTX_set_cert_verify_callback(sslCtx.get(), encoded_cert_verify_callback, nullptr);
     SSL_CTX_set_info_callback(sslCtx.get(), info_callback);
     SSL_CTX_set_cert_cb(sslCtx.get(), cert_cb, nullptr);
     if (Trace::kWithJniTraceKeys) {

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1561,29 +1561,14 @@ final class ConscryptEngine extends SSLEngine implements NativeCrypto.SSLHandsha
     }
 
     @Override
-    public void verifyCertificateChain(long[] certRefs, String authMethod)
-            throws CertificateException {
-        if (certRefs == null || certRefs.length == 0) {
-            throw new CertificateException("Peer sent no certificate");
-        }
-        OpenSSLX509Certificate[] peerCertChain = OpenSSLX509Certificate.createCertChain(certRefs);
-
-        verifyPeerCertificateChain(peerCertChain, authMethod);
-    }
-
-    @Override
-    public void verifyEncodedCertificateChain(byte[][] certChain, String authMethod)
-            throws CertificateException {
-        if (certChain == null || certChain.length == 0) {
-            throw new CertificateException("Peer sent no certificate");
-        }
-        X509Certificate[] peerCertChain = SSLUtils.decodeX509CertificateChain(certChain);
-        verifyPeerCertificateChain(peerCertChain, authMethod);
-    }
-
-    private void verifyPeerCertificateChain(X509Certificate[] peerCertChain, String authMethod)
+    public void verifyCertificateChain(byte[][] certChain, String authMethod)
             throws CertificateException {
         try {
+            if (certChain == null || certChain.length == 0) {
+                throw new CertificateException("Peer sent no certificate");
+            }
+            X509Certificate[] peerCertChain = SSLUtils.decodeX509CertificateChain(certChain);
+
             X509TrustManager x509tm = sslParameters.getX509TrustManager();
             if (x509tm == null) {
                 throw new CertificateException("No X.509 TrustManager");

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -74,6 +74,7 @@ import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.ECKey;
 import java.security.spec.ECParameterSpec;
 import javax.crypto.SecretKey;
@@ -1562,16 +1563,31 @@ final class ConscryptEngine extends SSLEngine implements NativeCrypto.SSLHandsha
     @Override
     public void verifyCertificateChain(long[] certRefs, String authMethod)
             throws CertificateException {
+        if (certRefs == null || certRefs.length == 0) {
+            throw new CertificateException("Peer sent no certificate");
+        }
+        OpenSSLX509Certificate[] peerCertChain = OpenSSLX509Certificate.createCertChain(certRefs);
+
+        verifyPeerCertificateChain(peerCertChain, authMethod);
+    }
+
+    @Override
+    public void verifyEncodedCertificateChain(byte[][] certChain, String authMethod)
+            throws CertificateException {
+        if (certChain == null || certChain.length == 0) {
+            throw new CertificateException("Peer sent no certificate");
+        }
+        X509Certificate[] peerCertChain = SSLUtils.decodeX509CertificateChain(certChain);
+        verifyPeerCertificateChain(peerCertChain, authMethod);
+    }
+
+    private void verifyPeerCertificateChain(X509Certificate[] peerCertChain, String authMethod)
+            throws CertificateException {
         try {
             X509TrustManager x509tm = sslParameters.getX509TrustManager();
             if (x509tm == null) {
                 throw new CertificateException("No X.509 TrustManager");
             }
-            if (certRefs == null || certRefs.length == 0) {
-                throw new SSLException("Peer sent no certificate");
-            }
-            OpenSSLX509Certificate[] peerCertChain =
-                    OpenSSLX509Certificate.createCertChain(certRefs);
 
             // Update the peer information on the session.
             sslSession.onPeerCertificatesReceived(getPeerHost(), getPeerPort(), peerCertChain);

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -378,31 +378,15 @@ final class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
         return 0;
     }
 
-    @SuppressWarnings("unused") // used by NativeCrypto.SSLHandshakeCallbacks
     @Override
-    public void verifyCertificateChain(long[] certRefs, String authMethod)
-            throws CertificateException {
-        if (certRefs == null || certRefs.length == 0) {
-            throw new CertificateException("Peer sent no certificate");
-        }
-        OpenSSLX509Certificate[] peerCertChain = OpenSSLX509Certificate.createCertChain(certRefs);
-
-        verifyPeerCertificateChain(peerCertChain, authMethod);
-    }
-
-    @Override
-    public void verifyEncodedCertificateChain(byte[][] certChain, String authMethod)
-            throws CertificateException {
-        if (certChain == null || certChain.length == 0) {
-            throw new CertificateException("Peer sent no certificate");
-        }
-        X509Certificate[] peerCertChain = SSLUtils.decodeX509CertificateChain(certChain);
-        verifyPeerCertificateChain(peerCertChain, authMethod);
-    }
-
-    private void verifyPeerCertificateChain(X509Certificate[] peerCertChain, String authMethod)
+    public void verifyCertificateChain(byte[][] certChain, String authMethod)
             throws CertificateException {
         try {
+            if (certChain == null || certChain.length == 0) {
+                throw new CertificateException("Peer sent no certificate");
+            }
+            X509Certificate[] peerCertChain = SSLUtils.decodeX509CertificateChain(certChain);
+
             X509TrustManager x509tm = sslParameters.getX509TrustManager();
             if (x509tm == null) {
                 throw new CertificateException("No X.509 TrustManager");

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1113,6 +1113,19 @@ public final class NativeCrypto {
                 throws CertificateException;
 
         /**
+         * Verify that we trust the certificate chain is trusted. This is an alternative
+         * to {@link #verifyCertificateChain(long[], String)}, which is given the fully encoded
+         * certificates.
+         *
+         * @param certificateChain chain of X.509 certificates in their encoded form
+         * @param authMethod auth algorithm name
+         *
+         * @throws CertificateException if the certificate is untrusted
+         */
+        void verifyEncodedCertificateChain(byte[][] certificateChain, String authMethod)
+                throws CertificateException;
+
+        /**
          * Called on an SSL client when the server requests (or
          * requires a certificate). The client can respond by using
          * SSL_use_certificate and SSL_use_PrivateKey to set a

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1101,28 +1101,15 @@ public final class NativeCrypto {
      */
     interface SSLHandshakeCallbacks {
         /**
-         * Verify that we trust the certificate chain is trusted.
-         *
-         * @param certificateChainRefs chain of X.509 certificate references
-         * @param authMethod auth algorithm name
-         *
-         * @throws CertificateException if the certificate is untrusted
-         */
-        @SuppressWarnings("unused")
-        void verifyCertificateChain(long[] certificateChainRefs, String authMethod)
-                throws CertificateException;
-
-        /**
-         * Verify that we trust the certificate chain is trusted. This is an alternative
-         * to {@link #verifyCertificateChain(long[], String)}, which is given the fully encoded
-         * certificates.
+         * Verify that the certificate chain is trusted.
          *
          * @param certificateChain chain of X.509 certificates in their encoded form
          * @param authMethod auth algorithm name
          *
          * @throws CertificateException if the certificate is untrusted
          */
-        void verifyEncodedCertificateChain(byte[][] certificateChain, String authMethod)
+        @SuppressWarnings("unused")
+        void verifyCertificateChain(byte[][] certificateChain, String authMethod)
                 throws CertificateException;
 
         /**

--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -175,11 +175,13 @@ final class SSLUtils {
 
     static X509Certificate[] decodeX509CertificateChain(byte[][] certChain)
             throws java.security.cert.CertificateException {
-        X509Certificate[] peerCertChain = new X509Certificate[certChain.length];
-        for (int i = 0; i < peerCertChain.length; i++) {
-            peerCertChain[i] = decodeX509Certificate(certChain[i]);
+        CertificateFactory certificateFactory = getCertificateFactory();
+        int numCerts = certChain.length;
+        X509Certificate[] decodedCerts = new X509Certificate[numCerts];
+        for (int i = 0; i < numCerts; i++) {
+            decodedCerts[i] = decodeX509Certificate(certificateFactory, certChain[i]);
         }
-        return peerCertChain;
+        return decodedCerts;
     }
 
     private static CertificateFactory getCertificateFactory() {
@@ -190,12 +192,11 @@ final class SSLUtils {
         }
     }
 
-    private static X509Certificate decodeX509Certificate(byte[] bytes)
-            throws java.security.cert.CertificateException {
-        CertificateFactory certificateFactory = getCertificateFactory();
+    private static X509Certificate decodeX509Certificate(CertificateFactory certificateFactory,
+            byte[] bytes) throws java.security.cert.CertificateException {
         if (certificateFactory != null) {
             return (X509Certificate) certificateFactory.generateCertificate(
-                new ByteArrayInputStream(bytes));
+                    new ByteArrayInputStream(bytes));
         }
         return OpenSSLX509Certificate.fromX509Der(bytes);
     }

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -748,6 +748,22 @@ public class NativeCryptoTest {
             this.verifyCertificateChainCalled = true;
         }
 
+        @Override
+        public void verifyEncodedCertificateChain(byte[][] certs, String authMethod)
+            throws CertificateException {
+            certificateChainRefs = new long[certs.length];
+            for (int i = 0; i < certs.length; ++i) {
+                byte[] cert = certs[i];
+                try {
+                    certificateChainRefs[i] = NativeCrypto.d2i_X509(cert);
+                } catch (ParsingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            this.authMethod = authMethod;
+            this.verifyCertificateChainCalled = true;
+        }
+
         private byte[] keyTypes;
         private byte[][] asn1DerEncodedX500Principals;
         private boolean clientCertificateRequestedCalled;

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -735,21 +735,7 @@ public class NativeCryptoTest {
         private boolean verifyCertificateChainCalled;
 
         @Override
-        public void verifyCertificateChain(long[] certChainRefs, String authMethod)
-                throws CertificateException {
-            if (DEBUG) {
-                System.out.println("ssl=0x" + Long.toString(sslNativePointer, 16)
-                        + " verifyCertificateChain"
-                        + " asn1DerEncodedCertificateChain=" + Arrays.toString(certChainRefs)
-                        + " authMethod=" + authMethod);
-            }
-            this.certificateChainRefs = certChainRefs;
-            this.authMethod = authMethod;
-            this.verifyCertificateChainCalled = true;
-        }
-
-        @Override
-        public void verifyEncodedCertificateChain(byte[][] certs, String authMethod)
+        public void verifyCertificateChain(byte[][] certs, String authMethod)
             throws CertificateException {
             certificateChainRefs = new long[certs.length];
             for (int i = 0; i < certs.length; ++i) {


### PR DESCRIPTION
This code was copied from Netty/netty-tcnative and seems to
significantly increases performance of the verify callback. Before
we call back to Java, we first encode all of the certs and then
decode them in Java into X509Certificate instances. Previous code
was calling into JNI for each method in the certificate.

This helps in addressing #247.

Before this change, the Conscrypt handshake was hovering around 750 ops/s.
New results:

```
Benchmark                                                  (a_cipher)  (b_buffer)          (c_engine)   Mode  Cnt     Score     Error  Units
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256        HEAP                 JDK  thrpt   10   168.576 ±   2.897  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256        HEAP  CONSCRYPT_UNPOOLED  thrpt   10  1025.581 ± 148.268  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256        HEAP    CONSCRYPT_POOLED  thrpt   10  1045.715 ± 121.240  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256        HEAP               NETTY  thrpt   10  1182.696 ± 113.352  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256        HEAP       NETTY_REF_CNT  thrpt   10  1231.431 ±  17.584  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256      DIRECT                 JDK  thrpt   10   162.221 ±   9.756  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256      DIRECT  CONSCRYPT_UNPOOLED  thrpt   10  1072.158 ± 141.050  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256      DIRECT    CONSCRYPT_POOLED  thrpt   10  1060.003 ± 189.386  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256      DIRECT               NETTY  thrpt   10  1250.313 ±  10.711  ops/s
JmhEngineHandshakeBenchmark.hs  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256      DIRECT       NETTY_REF_CNT  thrpt   10  1248.498 ±   9.888  ops/s
```