### PR TITLE
Remember local certs

### DIFF
--- a/common/src/main/java/org/conscrypt/ActiveSession.java
+++ b/common/src/main/java/org/conscrypt/ActiveSession.java
@@ -303,21 +303,7 @@ final class ActiveSession implements SSLSession {
      * Configures the peer information once it has been received by the handshake.
      */
     void onPeerCertificatesReceived(
-            String peerHost, int peerPort, OpenSSLX509Certificate[] peerCertificates) {
-        configurePeer(peerHost, peerPort, peerCertificates);
-    }
-
-    /**
-     * Configures the peer and local state from a newly created BoringSSL session.
-     */
-    void onSessionEstablished(String peerHost, int peerPort) {
-        id = null;
-        this.localCertificates = ssl.getLocalCertificates();
-        configurePeer(peerHost, peerPort, ssl.getPeerCertificates());
-    }
-
-    private void configurePeer(
-            String peerHost, int peerPort, OpenSSLX509Certificate[] peerCertificates) {
+            String peerHost, int peerPort, X509Certificate[] peerCertificates) {
         this.peerHost = peerHost;
         this.peerPort = peerPort;
         this.peerCertificates = peerCertificates;
@@ -325,11 +311,14 @@ final class ActiveSession implements SSLSession {
         this.peerTlsSctData = ssl.getPeerTlsSctData();
     }
 
-    private X509Certificate[] getX509PeerCertificates() throws SSLPeerUnverifiedException {
-        if (peerCertificates == null || peerCertificates.length == 0) {
-            throw new SSLPeerUnverifiedException("No peer certificates");
-        }
-        return peerCertificates;
+    /**
+     * Updates the session after the handshake has completed.
+     */
+    void onHandshakeCompleted(String peerHost, int peerPort) {
+        id = null;
+        this.peerHost = peerHost;
+        this.peerPort = peerPort;
+        this.localCertificates = ssl.getLocalCertificates();
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -947,7 +947,7 @@ final class ConscryptEngine extends SSLEngine implements NativeCrypto.SSLHandsha
             // The handshake has completed successfully...
 
             // Update the session from the current state of the SSL object.
-            sslSession.onSessionEstablished(getPeerHost(), getPeerPort());
+            sslSession.onHandshakeCompleted(getPeerHost(), getPeerPort());
 
             finishHandshake();
             return FINISHED;

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -326,7 +326,7 @@ final class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
         // The handshake has completed successfully ...
 
         // Update the session from the current state of the SSL object.
-        sslSession.onSessionEstablished(getHostnameOrIP(), getPort());
+        sslSession.onHandshakeCompleted(getHostnameOrIP(), getPort());
 
         // First, update the state.
         synchronized (stateLock) {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1037,11 +1037,6 @@ public final class NativeCrypto {
     public static native String SSL_get_version(long sslNativePointer);
 
     /**
-     * Returns the local X509 certificate references. Must X509_free when done.
-     */
-    static native long[] SSL_get_certificate(long sslNativePointer);
-
-    /**
      * Returns the peer X509 certificate references. Must X509_free when done.
      */
     static native long[] SSL_get_peer_cert_chain(long sslNativePointer);

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -2049,37 +2049,6 @@ public class NativeCryptoTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void SSL_get_certificate_withNullShouldThrow() throws Exception {
-        NativeCrypto.SSL_get_certificate(NULL);
-    }
-
-    @Test
-    public void test_SSL_get_certificate() throws Exception {
-        final ServerSocket listener = newServerSocket();
-        Hooks cHooks = new Hooks() {
-            @Override
-            public void afterHandshake(long session, long s, long c, Socket sock, FileDescriptor fd,
-                    SSLHandshakeCallbacks callback) throws Exception {
-                assertNull(NativeCrypto.SSL_get_certificate(s));
-                super.afterHandshake(session, s, c, sock, fd, callback);
-            }
-        };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getServerCertificates()) {
-            @Override
-            public void afterHandshake(long session, long s, long c, Socket sock, FileDescriptor fd,
-                    SSLHandshakeCallbacks callback) throws Exception {
-                assertEqualCertificateChains(
-                        getServerCertificates(), NativeCrypto.SSL_get_certificate(s));
-                super.afterHandshake(session, s, c, sock, fd, callback);
-            }
-        };
-        Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null);
-        Future<TestSSLHandshakeCallbacks> server = handshake(listener, 0, false, sHooks, null);
-        client.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    }
-
-    @Test(expected = NullPointerException.class)
     public void SSL_get_peer_cert_chain_withNullShouldThrow() throws Exception {
         NativeCrypto.SSL_get_peer_cert_chain(NULL);
     }


### PR DESCRIPTION
We were needlessly querying the SSL for the local certificates
during the handshake. Avoiding this shows a minor bump in
handshake performance

See #247