### PR TITLE
Add IvParameters and ECParameters to Conscrypt.

### DIFF
--- a/common/src/main/java/org/conscrypt/ECParameters.java
+++ b/common/src/main/java/org/conscrypt/ECParameters.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import java.io.IOException;
+import java.security.AlgorithmParametersSpi;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+
+/**
+ * AlgorithmParameters implementation for elliptic curves.  The only supported encoding format is
+ * ASN.1, as specified in RFC 3279, section 2.3.5.  However, only named curves are supported.
+ *
+ * @hide
+ */
+@Internal
+public class ECParameters extends AlgorithmParametersSpi {
+
+    private OpenSSLECGroupContext curve;
+
+    @Override
+    protected void engineInit(AlgorithmParameterSpec algorithmParameterSpec)
+            throws InvalidParameterSpecException {
+        if (algorithmParameterSpec instanceof ECGenParameterSpec) {
+            String newCurveName = ((ECGenParameterSpec) algorithmParameterSpec).getName();
+            OpenSSLECGroupContext newCurve = OpenSSLECGroupContext.getCurveByName(newCurveName);
+            if (newCurve == null) {
+                throw new InvalidParameterSpecException("Unknown EC curve name: " + newCurveName);
+            }
+            this.curve = newCurve;
+        } else if (algorithmParameterSpec instanceof ECParameterSpec) {
+            ECParameterSpec ecParamSpec = (ECParameterSpec) algorithmParameterSpec;
+            try {
+                OpenSSLECGroupContext newCurve = OpenSSLECGroupContext.getInstance(ecParamSpec);
+                if (newCurve == null) {
+                    throw new InvalidParameterSpecException("Unknown EC curve: " + ecParamSpec);
+                }
+                this.curve = newCurve;
+            } catch (InvalidAlgorithmParameterException e) {
+                throw new InvalidParameterSpecException(e.getMessage());
+            }
+        } else {
+            throw new InvalidParameterSpecException(
+                    "Only ECParameterSpec and ECGenParameterSpec are supported");
+        }
+    }
+
+    @Override
+    protected void engineInit(byte[] bytes) throws IOException {
+        long ref = NativeCrypto.EC_KEY_parse_curve_name(bytes);
+        if (ref == 0) {
+            throw new IOException("Error reading ASN.1 encoding");
+        }
+        this.curve = new OpenSSLECGroupContext(new NativeRef.EC_GROUP(ref));
+    }
+
+    @Override
+    protected void engineInit(byte[] bytes, String format) throws IOException {
+        if ((format == null) || format.equals("ASN.1")) {
+            engineInit(bytes);
+        } else {
+            throw new IOException("Unsupported format: " + format);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> aClass)
+            throws InvalidParameterSpecException {
+        if (aClass == ECParameterSpec.class) {
+            return (T) curve.getECParameterSpec();
+        } else if (aClass == ECGenParameterSpec.class) {
+            return (T) new ECGenParameterSpec(Platform.getCurveName(curve.getECParameterSpec()));
+        } else {
+            throw new InvalidParameterSpecException("Unsupported class: " + aClass);
+        }
+    }
+
+    @Override
+    protected byte[] engineGetEncoded() throws IOException {
+        return NativeCrypto.EC_KEY_marshal_curve_name(curve.getNativeRef());
+    }
+
+    @Override
+    protected byte[] engineGetEncoded(String format) throws IOException {
+        if ((format == null) || format.equals("ASN.1")) {
+            return engineGetEncoded();
+        }
+        throw new IOException("Unsupported format: " + format);
+    }
+
+    @Override
+    protected String engineToString() {
+        return "Conscrypt EC AlgorithmParameters";
+    }
+}

--- a/common/src/main/java/org/conscrypt/ECParameters.java
+++ b/common/src/main/java/org/conscrypt/ECParameters.java
@@ -73,7 +73,7 @@ public class ECParameters extends AlgorithmParametersSpi {
 
     @Override
     protected void engineInit(byte[] bytes, String format) throws IOException {
-        if ((format == null) || format.equals("ASN.1")) {
+        if (format == null || format.equals("ASN.1")) {
             engineInit(bytes);
         } else {
             throw new IOException("Unsupported format: " + format);
@@ -100,7 +100,7 @@ public class ECParameters extends AlgorithmParametersSpi {
 
     @Override
     protected byte[] engineGetEncoded(String format) throws IOException {
-        if ((format == null) || format.equals("ASN.1")) {
+        if (format == null || format.equals("ASN.1")) {
             return engineGetEncoded();
         }
         throw new IOException("Unsupported format: " + format);

--- a/common/src/main/java/org/conscrypt/IvParameters.java
+++ b/common/src/main/java/org/conscrypt/IvParameters.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import java.io.IOException;
+import java.security.AlgorithmParametersSpi;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+import javax.crypto.spec.IvParameterSpec;
+
+/**
+ * An implementation of {@link java.security.AlgorithmParameters} that contains only an IV.  The
+ * supported encoding formats are ASN.1 (primary) and RAW.
+ *
+ * @hide
+ */
+@Internal
+public class IvParameters extends AlgorithmParametersSpi {
+    private byte[] iv;
+
+    @Override
+    protected void engineInit(AlgorithmParameterSpec algorithmParameterSpec)
+            throws InvalidParameterSpecException {
+        if (!(algorithmParameterSpec instanceof IvParameterSpec)) {
+            throw new InvalidParameterSpecException("Only IvParameterSpec is supported");
+        }
+        iv = ((IvParameterSpec) algorithmParameterSpec).getIV().clone();
+    }
+
+    @Override
+    protected void engineInit(byte[] bytes) throws IOException {
+        long readRef = 0;
+        try {
+            readRef = NativeCrypto.asn1_read_init(bytes);
+            byte[] newIv = NativeCrypto.asn1_read_octetstring(readRef);
+            if (!NativeCrypto.asn1_read_is_empty(readRef)) {
+                throw new IOException("Error reading ASN.1 encoding");
+            }
+            this.iv = newIv;
+        } finally {
+            NativeCrypto.asn1_read_free(readRef);
+        }
+    }
+
+    @Override
+    protected void engineInit(byte[] bytes, String format) throws IOException {
+        if ((format == null) || format.equals("ASN.1")) {
+            engineInit(bytes);
+        } else if (format.equals("RAW")) {
+            iv = bytes.clone();
+        } else {
+            throw new IOException("Unsupported format: " + format);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> aClass)
+            throws InvalidParameterSpecException {
+        if (aClass != IvParameterSpec.class) {
+            throw new InvalidParameterSpecException(
+                    "Incompatible AlgorithmParametersSpec class: " + aClass);
+        }
+        return (T) new IvParameterSpec(iv);
+    }
+
+    @Override
+    protected byte[] engineGetEncoded() throws IOException {
+        long cbbRef = 0;
+        try {
+            cbbRef = NativeCrypto.asn1_write_init();
+            NativeCrypto.asn1_write_octetstring(cbbRef, this.iv);
+            return NativeCrypto.asn1_write_finish(cbbRef);
+        } catch (IOException e) {
+            NativeCrypto.asn1_write_cleanup(cbbRef);
+            throw e;
+        } finally {
+            NativeCrypto.asn1_write_free(cbbRef);
+        }
+    }
+
+    @Override
+    protected byte[] engineGetEncoded(String format) throws IOException {
+        if ((format == null) || format.equals("ASN.1")) {
+            return engineGetEncoded();
+        } else if (format.equals("RAW")) {
+            return iv.clone();
+        } else {
+            throw new IOException("Unsupported format: " + format);
+        }
+    }
+
+    @Override
+    protected String engineToString() {
+        return "Conscrypt IV AlgorithmParameters";
+    }
+
+    public static class AES extends IvParameters {}
+    public static class DESEDE extends IvParameters {}
+}

--- a/common/src/main/java/org/conscrypt/IvParameters.java
+++ b/common/src/main/java/org/conscrypt/IvParameters.java
@@ -58,7 +58,7 @@ public class IvParameters extends AlgorithmParametersSpi {
 
     @Override
     protected void engineInit(byte[] bytes, String format) throws IOException {
-        if ((format == null) || format.equals("ASN.1")) {
+        if (format == null || format.equals("ASN.1")) {
             engineInit(bytes);
         } else if (format.equals("RAW")) {
             iv = bytes.clone();
@@ -95,7 +95,7 @@ public class IvParameters extends AlgorithmParametersSpi {
 
     @Override
     protected byte[] engineGetEncoded(String format) throws IOException {
-        if ((format == null) || format.equals("ASN.1")) {
+        if (format == null || format.equals("ASN.1")) {
             return engineGetEncoded();
         } else if (format.equals("RAW")) {
             return iv.clone();

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -161,6 +161,10 @@ public final class NativeCrypto {
 
     static native long EC_KEY_get_public_key(NativeRef.EVP_PKEY keyRef);
 
+    static native byte[] EC_KEY_marshal_curve_name(NativeRef.EC_GROUP groupRef) throws IOException;
+
+    static native long EC_KEY_parse_curve_name(byte[] encoded) throws IOException;
+
     static native int ECDH_compute_key(byte[] out, int outOffset, NativeRef.EVP_PKEY publicKeyRef,
             NativeRef.EVP_PKEY privateKeyRef) throws InvalidKeyException;
 

--- a/common/src/main/java/org/conscrypt/OpenSSLCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipher.java
@@ -245,11 +245,11 @@ public abstract class OpenSSLCipher extends CipherSpi {
         if (iv != null && iv.length > 0) {
             try {
                 AlgorithmParameters params = AlgorithmParameters.getInstance(getBaseCipherName());
-                params.init(iv);
+                params.init(new IvParameterSpec(iv));
                 return params;
             } catch (NoSuchAlgorithmException e) {
                 return null;
-            } catch (IOException e) {
+            } catch (InvalidParameterSpecException e) {
                 return null;
             }
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipher.java
@@ -16,7 +16,6 @@
 
 package org.conscrypt;
 
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.security.AlgorithmParameters;

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -73,11 +73,21 @@ public final class OpenSSLProvider extends Provider {
         put("SSLContext.Default", PREFIX + "DefaultSSLContextImpl");
 
         /* === AlgorithmParameters === */
+        put("AlgorithmParameters.AES", PREFIX + "IvParameters$AES");
+        put("Alg.Alias.AlgorithmParameters.2.16.840.1.101.3.4.1.2", "AES");
+        put("Alg.Alias.AlgorithmParameters.2.16.840.1.101.3.4.1.22", "AES");
+        put("Alg.Alias.AlgorithmParameters.2.16.840.1.101.3.4.1.42", "AES");
+
+        put("AlgorithmParameters.DESEDE", PREFIX + "IvParameters$DESEDE");
+        put("Alg.Alias.AlgorithmParameters.TDEA", "DESEDE");
+        put("Alg.Alias.AlgorithmParameters.1.2.840.113549.3.7", "DESEDE");
+
         put("AlgorithmParameters.GCM", PREFIX + "GCMParameters");
         put("Alg.Alias.AlgorithmParameters.2.16.840.1.101.3.4.1.6", "GCM");
         put("Alg.Alias.AlgorithmParameters.2.16.840.1.101.3.4.1.26", "GCM");
         put("Alg.Alias.AlgorithmParameters.2.16.840.1.101.3.4.1.46", "GCM");
         put("AlgorithmParameters.OAEP", PREFIX + "OAEPParameters");
+        put("AlgorithmParameters.EC", PREFIX + "ECParameters");
 
         /* === Message Digests === */
         put("MessageDigest.SHA-1", PREFIX + "OpenSSLMessageDigestJDK$SHA1");


### PR DESCRIPTION
IvParameters is used as the AlgorithmParameters implementation for AES
and DESEDE.  ECParameters only supports named curves, since BoringSSL
provides functions for marshalling curve names but not arbitrary curves
and generally discourages the use of arbitrary curves (eg, ec.h says
"Avoid using arbitrary curves and use EC_GROUP_new_by_curve_name
instead.")