### PR TITLE
Cleaning up JNI exceptions

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -168,7 +168,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
     }
 
     void doCryptoInit(AlgorithmParameterSpec spec)
-            throws InvalidAlgorithmParameterException {}
+        throws InvalidAlgorithmParameterException, InvalidKeyException {}
 
     void engineInitInternal(int opmode, Key key, AlgorithmParameterSpec spec)
             throws InvalidKeyException, InvalidAlgorithmParameterException {
@@ -503,7 +503,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
 
         @Override
         void doCryptoInit(AlgorithmParameterSpec spec)
-                throws InvalidAlgorithmParameterException {
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
             pkeyCtx = new NativeRef.EVP_PKEY_CTX(encrypting
                             ? NativeCrypto.EVP_PKEY_encrypt_init(key.getNativeRef())
                             : NativeCrypto.EVP_PKEY_decrypt_init(key.getNativeRef()));

--- a/common/src/main/java/org/conscrypt/OpenSSLECPrivateKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECPrivateKey.java
@@ -30,6 +30,7 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
+import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * An implementation of a {@link PrivateKey} for EC keys based on BoringSSL.
@@ -231,7 +232,11 @@ final class OpenSSLECPrivateKey implements ECPrivateKey, OpenSSLKeyHolder {
 
         byte[] encoded = (byte[]) stream.readObject();
 
-        key = new OpenSSLKey(NativeCrypto.EVP_parse_private_key(encoded));
+        try {
+            key = new OpenSSLKey(NativeCrypto.EVP_parse_private_key(encoded));
+        } catch (ParsingException e) {
+            throw new IOException(e);
+        }
         group = new OpenSSLECGroupContext(new NativeRef.EC_GROUP(
                 NativeCrypto.EC_KEY_get1_group(key.getNativeRef())));
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLECPublicKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECPublicKey.java
@@ -26,6 +26,7 @@ import java.security.spec.ECPoint;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
+import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * An implementation of a {@link java.security.PublicKey} for EC keys based on BoringSSL.
@@ -156,7 +157,11 @@ final class OpenSSLECPublicKey implements ECPublicKey, OpenSSLKeyHolder {
 
         byte[] encoded = (byte[]) stream.readObject();
 
-        key = new OpenSSLKey(NativeCrypto.EVP_parse_public_key(encoded));
+        try {
+            key = new OpenSSLKey(NativeCrypto.EVP_parse_public_key(encoded));
+        } catch (ParsingException e) {
+            throw new IOException(e);
+        }
         group = new OpenSSLECGroupContext(new NativeRef.EC_GROUP(
                 NativeCrypto.EC_KEY_get1_group(key.getNativeRef())));
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLKey.java
@@ -27,6 +27,7 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * Represents a BoringSSL {@code EVP_PKEY}.
@@ -73,7 +74,11 @@ final class OpenSSLKey {
             throw new InvalidKeyException("Key encoding is null");
         }
 
-        return new OpenSSLKey(NativeCrypto.EVP_parse_private_key(key.getEncoded()));
+        try {
+            return new OpenSSLKey(NativeCrypto.EVP_parse_private_key(key.getEncoded()));
+        } catch (ParsingException e) {
+            throw new InvalidKeyException(e);
+        }
     }
 
     /**
@@ -169,7 +174,7 @@ final class OpenSSLKey {
      * @return instance or {@code null} if the {@code key} does not export its key material in a
      *         suitable format.
      */
-    private static OpenSSLKey fromKeyMaterial(PrivateKey key) {
+    private static OpenSSLKey fromKeyMaterial(PrivateKey key) throws InvalidKeyException {
         if (!"PKCS#8".equals(key.getFormat())) {
             return null;
         }
@@ -177,7 +182,11 @@ final class OpenSSLKey {
         if (encoded == null) {
             return null;
         }
-        return new OpenSSLKey(NativeCrypto.EVP_parse_private_key(encoded));
+        try {
+            return new OpenSSLKey(NativeCrypto.EVP_parse_private_key(encoded));
+        } catch (ParsingException e) {
+            throw new InvalidKeyException(e);
+        }
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/SslWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslWrapper.java
@@ -16,8 +16,14 @@
 
 package org.conscrypt;
 
+import static org.conscrypt.NativeConstants.SSL_MODE_CBC_RECORD_SPLITTING;
+import static org.conscrypt.NativeConstants.SSL_OP_CIPHER_SERVER_PREFERENCE;
+import static org.conscrypt.NativeConstants.SSL_OP_NO_TICKET;
 import static org.conscrypt.NativeConstants.SSL_RECEIVED_SHUTDOWN;
 import static org.conscrypt.NativeConstants.SSL_SENT_SHUTDOWN;
+import static org.conscrypt.NativeConstants.SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+import static org.conscrypt.NativeConstants.SSL_VERIFY_NONE;
+import static org.conscrypt.NativeConstants.SSL_VERIFY_PEER;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
@@ -337,7 +343,7 @@ final class SslWrapper {
                 }
             }
 
-            NativeCrypto.SSL_set_options(ssl, NativeConstants.SSL_OP_CIPHER_SERVER_PREFERENCE);
+            NativeCrypto.SSL_set_options(ssl, SSL_OP_CIPHER_SERVER_PREFERENCE);
 
             if (parameters.sctExtension != null) {
                 NativeCrypto.SSL_set_signed_cert_timestamp_list(ssl, parameters.sctExtension);
@@ -351,10 +357,10 @@ final class SslWrapper {
         enablePSKKeyManagerIfRequested();
 
         if (parameters.useSessionTickets) {
-            NativeCrypto.SSL_clear_options(ssl, NativeConstants.SSL_OP_NO_TICKET);
+            NativeCrypto.SSL_clear_options(ssl, SSL_OP_NO_TICKET);
         } else {
             NativeCrypto.SSL_set_options(
-                    ssl, NativeCrypto.SSL_get_options(ssl) | NativeConstants.SSL_OP_NO_TICKET);
+                    ssl, NativeCrypto.SSL_get_options(ssl) | SSL_OP_NO_TICKET);
         }
 
         if (parameters.getUseSni() && AddressUtils.isValidSniHostname(hostname)) {
@@ -363,7 +369,7 @@ final class SslWrapper {
 
         // BEAST attack mitigation (1/n-1 record splitting for CBC cipher suites
         // with TLSv1 and SSLv3).
-        NativeCrypto.SSL_set_mode(ssl, NativeConstants.SSL_MODE_CBC_RECORD_SPLITTING);
+        NativeCrypto.SSL_set_mode(ssl, SSL_MODE_CBC_RECORD_SPLITTING);
 
         setCertificateValidation(ssl);
         setTlsChannelId(channelIdPrivateKey);
@@ -438,16 +444,16 @@ final class SslWrapper {
             // needing client auth takes priority...
             boolean certRequested;
             if (parameters.getNeedClientAuth()) {
-                NativeCrypto.SSL_set_verify(sslNativePointer, NativeCrypto.SSL_VERIFY_PEER
-                                | NativeCrypto.SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
+                NativeCrypto.SSL_set_verify(sslNativePointer, SSL_VERIFY_PEER
+                                | SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
                 certRequested = true;
                 // ... over just wanting it...
             } else if (parameters.getWantClientAuth()) {
-                NativeCrypto.SSL_set_verify(sslNativePointer, NativeCrypto.SSL_VERIFY_PEER);
+                NativeCrypto.SSL_set_verify(sslNativePointer, SSL_VERIFY_PEER);
                 certRequested = true;
                 // ... and we must disable verification if we don't want client auth.
             } else {
-                NativeCrypto.SSL_set_verify(sslNativePointer, NativeCrypto.SSL_VERIFY_NONE);
+                NativeCrypto.SSL_set_verify(sslNativePointer, SSL_VERIFY_NONE);
                 certRequested = false;
             }
 

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -18,6 +18,13 @@ package org.conscrypt;
 
 import static org.conscrypt.NativeConstants.SSL_MODE_CBC_RECORD_SPLITTING;
 import static org.conscrypt.NativeConstants.SSL_MODE_ENABLE_FALSE_START;
+import static org.conscrypt.NativeConstants.SSL_OP_NO_SSLv3;
+import static org.conscrypt.NativeConstants.SSL_OP_NO_TLSv1;
+import static org.conscrypt.NativeConstants.SSL_OP_NO_TLSv1_1;
+import static org.conscrypt.NativeConstants.SSL_OP_NO_TLSv1_2;
+import static org.conscrypt.NativeConstants.SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+import static org.conscrypt.NativeConstants.SSL_VERIFY_NONE;
+import static org.conscrypt.NativeConstants.SSL_VERIFY_PEER;
 import static org.conscrypt.TestUtils.openTestFile;
 import static org.conscrypt.TestUtils.readTestFile;
 import static org.junit.Assert.assertEquals;
@@ -204,7 +211,8 @@ public class NativeCryptoTest {
         CHANNEL_ID = new BigInteger(
                 "702b07871fd7955c320b26f15e244e47eed60272124c92b9ebecf0b42f90069b"
                         + "ab53592ebfeb4f167dbf3ce61513afb0e354c479b1c1b69874fa471293494f77",
-                16).toByteArray();
+                16)
+                             .toByteArray();
     }
 
     private static RSAPrivateCrtKey generateRsaKey() throws Exception {
@@ -346,10 +354,10 @@ public class NativeCryptoTest {
         long s = NativeCrypto.SSL_new(c);
 
         assertTrue(s != NULL);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_SSLv3) == 0);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_TLSv1) == 0);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_TLSv1_1) == 0);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_TLSv1_2) == 0);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_SSLv3) == 0);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_TLSv1) == 0);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_TLSv1_1) == 0);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_TLSv1_2) == 0);
 
         long s2 = NativeCrypto.SSL_new(c);
         assertTrue(s != s2);
@@ -595,9 +603,9 @@ public class NativeCryptoTest {
     public void test_SSL_set_options() throws Exception {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_SSLv3) == 0);
-        NativeCrypto.SSL_set_options(s, NativeConstants.SSL_OP_NO_SSLv3);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_SSLv3) != 0);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_SSLv3) == 0);
+        NativeCrypto.SSL_set_options(s, SSL_OP_NO_SSLv3);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_SSLv3) != 0);
         NativeCrypto.SSL_free(s);
         NativeCrypto.SSL_CTX_free(c);
     }
@@ -611,11 +619,11 @@ public class NativeCryptoTest {
     public void test_SSL_clear_options() throws Exception {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_SSLv3) == 0);
-        NativeCrypto.SSL_set_options(s, NativeConstants.SSL_OP_NO_SSLv3);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_SSLv3) != 0);
-        NativeCrypto.SSL_clear_options(s, NativeConstants.SSL_OP_NO_SSLv3);
-        assertTrue((NativeCrypto.SSL_get_options(s) & NativeConstants.SSL_OP_NO_SSLv3) == 0);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_SSLv3) == 0);
+        NativeCrypto.SSL_set_options(s, SSL_OP_NO_SSLv3);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_SSLv3) != 0);
+        NativeCrypto.SSL_clear_options(s, SSL_OP_NO_SSLv3);
+        assertTrue((NativeCrypto.SSL_get_options(s) & SSL_OP_NO_SSLv3) == 0);
         NativeCrypto.SSL_free(s);
         NativeCrypto.SSL_CTX_free(c);
     }
@@ -709,11 +717,10 @@ public class NativeCryptoTest {
     public void test_SSL_set_verify() throws Exception {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c);
-        NativeCrypto.SSL_set_verify(s, NativeCrypto.SSL_VERIFY_NONE);
-        NativeCrypto.SSL_set_verify(s, NativeCrypto.SSL_VERIFY_PEER);
-        NativeCrypto.SSL_set_verify(s, NativeCrypto.SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
-        NativeCrypto.SSL_set_verify(
-                s, (NativeCrypto.SSL_VERIFY_PEER | NativeCrypto.SSL_VERIFY_FAIL_IF_NO_PEER_CERT));
+        NativeCrypto.SSL_set_verify(s, SSL_VERIFY_NONE);
+        NativeCrypto.SSL_set_verify(s, SSL_VERIFY_PEER);
+        NativeCrypto.SSL_set_verify(s, SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
+        NativeCrypto.SSL_set_verify(s, (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT));
         NativeCrypto.SSL_free(s);
         NativeCrypto.SSL_CTX_free(c);
     }
@@ -723,9 +730,9 @@ public class NativeCryptoTest {
     public static class Hooks {
         String negotiatedCipherSuite;
         private OpenSSLKey channelIdPrivateKey;
-         boolean pskEnabled;
-         byte[] pskKey;
-         List<String> enabledCipherSuites;
+        boolean pskEnabled;
+        byte[] pskKey;
+        List<String> enabledCipherSuites;
 
         /**
          * @throws SSLException if an error occurs creating the context.
@@ -758,7 +765,8 @@ public class NativeCryptoTest {
         }
         public void configureCallbacks(
                 @SuppressWarnings("unused") TestSSLHandshakeCallbacks callbacks) {}
-        public void clientCertificateRequested(@SuppressWarnings("unused") long s) {}
+        public void clientCertificateRequested(@SuppressWarnings("unused") long s)
+                throws CertificateEncodingException, SSLException {}
         public void afterHandshake(long session, long ssl, long context, Socket socket,
                 FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
             if (session != NULL) {
@@ -817,7 +825,8 @@ public class NativeCryptoTest {
 
         @Override
         public void clientCertificateRequested(
-                byte[] keyTypes, byte[][] asn1DerEncodedX500Principals) {
+                byte[] keyTypes, byte[][] asn1DerEncodedX500Principals)
+                throws CertificateEncodingException, SSLException {
             if (DEBUG) {
                 System.out.println("ssl=0x" + Long.toString(sslNativePointer, 16)
                         + " clientCertificateRequested"
@@ -991,7 +1000,7 @@ public class NativeCryptoTest {
                 NativeCrypto.set_SSL_psk_server_callback_enabled(s, true);
                 NativeCrypto.SSL_use_psk_identity_hint(s, pskIdentityHint);
             }
-            NativeCrypto.SSL_set_verify(s, NativeCrypto.SSL_VERIFY_NONE);
+            NativeCrypto.SSL_set_verify(s, SSL_VERIFY_NONE);
             return s;
         }
 
@@ -1035,14 +1044,14 @@ public class NativeCryptoTest {
                             @SuppressWarnings("resource")
                             // Socket needs to remain open after the handshake
                             Socket socket = (client ? new Socket(listener.getInetAddress(),
-                                    listener.getLocalPort())
-                                    : listener.accept());
+                                                              listener.getLocalPort())
+                                                    : listener.accept());
                             if (timeout == -1) {
                                 return new TestSSLHandshakeCallbacks(socket, 0, null);
                             }
                             FileDescriptor fd =
-                                    (FileDescriptor) m_Platform_getFileDescriptor
-                                            .invoke(null, socket);
+                                    (FileDescriptor) m_Platform_getFileDescriptor.invoke(
+                                            null, socket);
                             long c = hooks.getContext();
                             long s = hooks.beforeHandshake(c);
                             TestSSLHandshakeCallbacks callback =
@@ -1051,8 +1060,8 @@ public class NativeCryptoTest {
                             if (DEBUG) {
                                 System.out.println("ssl=0x" + Long.toString(s, 16) + " handshake"
                                         + " context=0x" + Long.toString(c, 16) + " socket=" + socket
-                                        + " fd=" + fd + " timeout=" + timeout + " client="
-                                        + client);
+                                        + " fd=" + fd + " timeout=" + timeout
+                                        + " client=" + client);
                             }
                             long session = NULL;
                             try {
@@ -1065,9 +1074,9 @@ public class NativeCryptoTest {
                                 NativeCrypto.SSL_do_handshake(s, fd, callback, timeout);
                                 session = NativeCrypto.SSL_get1_session(s);
                                 if (DEBUG) {
-                                    System.out
-                                            .println("ssl=0x" + Long.toString(s, 16) + " handshake"
-                                                    + " session=0x" + Long.toString(session, 16));
+                                    System.out.println("ssl=0x" + Long.toString(s, 16)
+                                            + " handshake"
+                                            + " session=0x" + Long.toString(session, 16));
                                 }
                             } finally {
                                 // Ensure afterHandshake is called to free resources
@@ -1146,13 +1155,12 @@ public class NativeCryptoTest {
         // normal client and server case
         final ServerSocket listener = newServerSocket();
 
-        Future<TestSSLHandshakeCallbacks> client1 =
-                handshake(listener, 0, true, new ClientHooks() {
-                    @Override
-                    public void configureCallbacks(TestSSLHandshakeCallbacks callbacks) {
-                        callbacks.onNewSessionEstablishedSaveSession = true;
-                    }
-                }, null);
+        Future<TestSSLHandshakeCallbacks> client1 = handshake(listener, 0, true, new ClientHooks() {
+            @Override
+            public void configureCallbacks(TestSSLHandshakeCallbacks callbacks) {
+                callbacks.onNewSessionEstablishedSaveSession = true;
+            }
+        }, null);
         Future<TestSSLHandshakeCallbacks> server1 = handshake(listener, 0,
                 false, new ServerHooks(getServerPrivateKey(), getServerCertificates()) {
                     @Override
@@ -1182,15 +1190,14 @@ public class NativeCryptoTest {
         final long serverSessionContext =
                 serverCallback1.onNewSessionEstablishedSessionNativePointer;
 
-        Future<TestSSLHandshakeCallbacks> client2 =
-                handshake(listener, 0, true, new ClientHooks() {
-                    @Override
-                    public long beforeHandshake(long c) throws SSLException {
-                        long sslNativePtr = super.beforeHandshake(c);
-                        NativeCrypto.SSL_set_session(sslNativePtr, clientSessionContext);
-                        return sslNativePtr;
-                    }
-                }, null);
+        Future<TestSSLHandshakeCallbacks> client2 = handshake(listener, 0, true, new ClientHooks() {
+            @Override
+            public long beforeHandshake(long c) throws SSLException {
+                long sslNativePtr = super.beforeHandshake(c);
+                NativeCrypto.SSL_set_session(sslNativePtr, clientSessionContext);
+                return sslNativePtr;
+            }
+        }, null);
         Future<TestSSLHandshakeCallbacks> server2 = handshake(listener, 0,
                 false, new ServerHooks(getServerPrivateKey(), getServerCertificates()) {
                     @Override
@@ -1228,7 +1235,8 @@ public class NativeCryptoTest {
 
         Hooks cHooks = new Hooks() {
             @Override
-            public void clientCertificateRequested(long s) {
+            public void clientCertificateRequested(long s)
+                    throws CertificateEncodingException, SSLException {
                 super.clientCertificateRequested(s);
                 NativeCrypto.SSL_use_PrivateKey(s, getClientPrivateKey().getNativeRef());
                 NativeCrypto.SSL_use_certificate(s, getClientCertificates());
@@ -1239,7 +1247,7 @@ public class NativeCryptoTest {
             public long beforeHandshake(long c) throws SSLException {
                 long s = super.beforeHandshake(c);
                 NativeCrypto.SSL_set_client_CA_list(s, getCaPrincipals());
-                NativeCrypto.SSL_set_verify(s, NativeCrypto.SSL_VERIFY_PEER);
+                NativeCrypto.SSL_set_verify(s, SSL_VERIFY_PEER);
                 return s;
             }
         };
@@ -1282,8 +1290,8 @@ public class NativeCryptoTest {
                 public long beforeHandshake(long c) throws SSLException {
                     long s = super.beforeHandshake(c);
                     NativeCrypto.SSL_set_client_CA_list(s, getCaPrincipals());
-                    NativeCrypto.SSL_set_verify(s, NativeCrypto.SSL_VERIFY_PEER
-                                    | NativeCrypto.SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
+                    NativeCrypto.SSL_set_verify(
+                            s, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
                     return s;
                 }
             };
@@ -1997,11 +2005,43 @@ public class NativeCryptoTest {
     @Test
     public void test_SSL_AlpnNegotiateSuccess() throws Exception {
         final byte[] clientAlpnProtocols = new byte[] {
-                8, 'h', 't', 't', 'p', '/', '1', '.', '1', 3, 'f', 'o', 'o', 6, 's', 'p', 'd', 'y',
-                '/', '2',
+                8,
+                'h',
+                't',
+                't',
+                'p',
+                '/',
+                '1',
+                '.',
+                '1',
+                3,
+                'f',
+                'o',
+                'o',
+                6,
+                's',
+                'p',
+                'd',
+                'y',
+                '/',
+                '2',
         };
         final byte[] serverAlpnProtocols = new byte[] {
-                6, 's', 'p', 'd', 'y', '/', '2', 3, 'f', 'o', 'o', 3, 'b', 'a', 'r',
+                6,
+                's',
+                'p',
+                'd',
+                'y',
+                '/',
+                '2',
+                3,
+                'f',
+                'o',
+                'o',
+                3,
+                'b',
+                'a',
+                'r',
         };
 
         Hooks cHooks = new Hooks() {
@@ -2305,7 +2345,8 @@ public class NativeCryptoTest {
                             // Expected.
                         }
                     }
-                }.start();
+                }
+                        .start();
                 assertEquals(-1, NativeCrypto.SSL_read(s, fd, callback, new byte[1], 0, 1, 0));
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
@@ -2698,9 +2739,22 @@ public class NativeCryptoTest {
      * openssl rand -hex 16
      */
     private static final byte[] AES_128_KEY = new byte[] {
-            (byte) 0x3d, (byte) 0x4f, (byte) 0x89, (byte) 0x70, (byte) 0xb1, (byte) 0xf2,
-            (byte) 0x75, (byte) 0x37, (byte) 0xf4, (byte) 0x0a, (byte) 0x39, (byte) 0x29,
-            (byte) 0x8a, (byte) 0x41, (byte) 0x55, (byte) 0x5f,
+            (byte) 0x3d,
+            (byte) 0x4f,
+            (byte) 0x89,
+            (byte) 0x70,
+            (byte) 0xb1,
+            (byte) 0xf2,
+            (byte) 0x75,
+            (byte) 0x37,
+            (byte) 0xf4,
+            (byte) 0x0a,
+            (byte) 0x39,
+            (byte) 0x29,
+            (byte) 0x8a,
+            (byte) 0x41,
+            (byte) 0x55,
+            (byte) 0x5f,
     };
 
     @Test

--- a/platform/src/main/java/org/conscrypt/InternalUtil.java
+++ b/platform/src/main/java/org/conscrypt/InternalUtil.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * Helper to initialize the JNI libraries. This version runs when compiled
@@ -29,8 +30,13 @@ import java.security.PublicKey;
  */
 @Internal
 public final class InternalUtil {
-    public static PublicKey logKeyToPublicKey(byte[] logKey) throws NoSuchAlgorithmException {
-        return new OpenSSLKey(NativeCrypto.EVP_parse_public_key(logKey)).getPublicKey();
+    public static PublicKey logKeyToPublicKey(byte[] logKey)
+            throws NoSuchAlgorithmException {
+        try {
+            return new OpenSSLKey(NativeCrypto.EVP_parse_public_key(logKey)).getPublicKey();
+        } catch (ParsingException e) {
+            throw new NoSuchAlgorithmException(e);
+        }
     }
 
     public static PublicKey readPublicKeyPem(InputStream pem) throws InvalidKeyException, NoSuchAlgorithmException {


### PR DESCRIPTION
There were a bunch of exceptions that are being thrown from JNI methods that aren't currently declared.

Also removed a few unused JNI methods and duplicate constants, preferring those from NativeConstants.