### PR TITLE
Fetch the peer certificates if necessary when handshake completes.

### DIFF
--- a/common/src/main/java/org/conscrypt/ActiveSession.java
+++ b/common/src/main/java/org/conscrypt/ActiveSession.java
@@ -324,8 +324,9 @@ final class ActiveSession implements SSLSession {
         this.localCertificates = ssl.getLocalCertificates();
         if (this.peerCertificates == null) {
             // When resuming a session, the cert_verify_callback (which calls
-            // onPeerCertificatesReceived) isn't called by BoringSSL during the handshake, leaving
-            // us without the peer certificates.  If that happens, fetch them explicitly.
+            // onPeerCertificatesReceived) isn't called by BoringSSL during the handshake because
+            // it presumes the certs were verified in the previous connection on that session,
+            // leaving us without the peer certificates.  If that happens, fetch them explicitly.
             configurePeer(peerHost, peerPort, ssl.getPeerCertificates());
         }
     }

--- a/common/src/main/java/org/conscrypt/ActiveSession.java
+++ b/common/src/main/java/org/conscrypt/ActiveSession.java
@@ -323,7 +323,7 @@ final class ActiveSession implements SSLSession {
         id = null;
         this.localCertificates = ssl.getLocalCertificates();
         if (this.peerCertificates == null) {
-            // Under some as-yet-undetermined circumstances, the cert_verify_callback (which calls
+            // When resuming a session, the cert_verify_callback (which calls
             // onPeerCertificatesReceived) isn't called by BoringSSL during the handshake, leaving
             // us without the peer certificates.  If that happens, fetch them explicitly.
             configurePeer(peerHost, peerPort, ssl.getPeerCertificates());

--- a/common/src/main/java/org/conscrypt/ActiveSession.java
+++ b/common/src/main/java/org/conscrypt/ActiveSession.java
@@ -304,6 +304,11 @@ final class ActiveSession implements SSLSession {
      */
     void onPeerCertificatesReceived(
             String peerHost, int peerPort, X509Certificate[] peerCertificates) {
+        configurePeer(peerHost, peerPort, peerCertificates);
+    }
+
+    private void configurePeer(
+            String peerHost, int peerPort, X509Certificate[] peerCertificates) {
         this.peerHost = peerHost;
         this.peerPort = peerPort;
         this.peerCertificates = peerCertificates;
@@ -316,9 +321,13 @@ final class ActiveSession implements SSLSession {
      */
     void onHandshakeCompleted(String peerHost, int peerPort) {
         id = null;
-        this.peerHost = peerHost;
-        this.peerPort = peerPort;
         this.localCertificates = ssl.getLocalCertificates();
+        if (this.peerCertificates == null) {
+            // Under some as-yet-undetermined circumstances, the cert_verify_callback (which calls
+            // onPeerCertificatesReceived) isn't called by BoringSSL during the handshake, leaving
+            // us without the peer certificates.  If that happens, fetch them explicitly.
+            configurePeer(peerHost, peerPort, ssl.getPeerCertificates());
+        }
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/SslWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslWrapper.java
@@ -112,6 +112,10 @@ final class SslWrapper {
         return NativeCrypto.cipherSuiteToJava(NativeCrypto.SSL_get_current_cipher(ssl));
     }
 
+    X509Certificate[] getPeerCertificates() {
+        return OpenSSLX509Certificate.createCertChain(NativeCrypto.SSL_get_peer_cert_chain(ssl));
+    }
+
     X509Certificate[] getLocalCertificates() {
         return localCertificates;
     }


### PR DESCRIPTION
I'm not sure why, but under some circumstances the first connection on
a session can not have the cert_verify_callback called, which leaves us
without the peer certificates, causing hostname verification to fail in
apps (since they don't have a certificate to verify the hostname with).
This fixes the problem for the short term.