### PR TITLE
Remove LOCAL_CLANG

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -250,7 +250,6 @@ endif
 
 # Conscrypt native library for host
 include $(CLEAR_VARS)
-LOCAL_CLANG := true
 LOCAL_SRC_FILES := $(call all-cpp-files-under,common/src/jni/main/cpp)
 LOCAL_C_INCLUDES += \
         external/openssl/include \


### PR DESCRIPTION
clang is the default compiler since Android nougat

Change-Id: I24c0f3e587a44972956afc1b54d430c5cd0ca7c5
Signed-off-by: Lennart Wieboldt <lennart.1997@gmx.de>