### PR TITLE
build generate_constants.cpp with WIN32_LEAN_AND_MEAN

### DIFF
--- a/constants/build.gradle
+++ b/constants/build.gradle
@@ -40,6 +40,12 @@ model {
                     }
                 }
             }
+
+            binaries.all {
+                if (toolChain in VisualCpp) {
+                    cppCompiler.define "WIN32_LEAN_AND_MEAN"
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This fixes a broken build due to BoringSSL types conflicting with Windows. Using this define so that fewer windows includes are brought in.