### PR TITLE
Fixing socket benchmarks.

### DIFF
--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -14,8 +14,7 @@ dependencies {
 
     compile project(':conscrypt-libcore-stub'),
             libraries.bouncycastle_apis,
-            libraries.bouncycastle_provider,
-            libraries.netty_handler
+            libraries.bouncycastle_provider
 }
 
 // Don't include this artifact in the distribution.


### PR DESCRIPTION
Not quite sure how these ever worked TBH. The last message sent would
very likely get chunked, resulting in the receiving end receiving EOF
before reading the entire message.