### PR TITLE
Properly update state on ConscryptEngine.closeOutbound

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -442,7 +442,9 @@ final class ConscryptEngine extends SSLEngine implements NativeCrypto.SSLHandsha
                 return;
             }
             if (isHandshakeStarted()) {
+                state = STATE_CLOSED;
                 shutdownAndFreeSslNative();
+                return;
             }
             if (state == STATE_CLOSED_INBOUND) {
                 state = STATE_CLOSED;


### PR DESCRIPTION
When isHandshakeStarted is true, state is not correctly set to
CLOSED.

The error I'm seeing:

```
ERROR InternalHttpAsyncClient I/O dispatch worker terminated abnormally
 org.apache.hc.core5.reactor.IOReactorException: I/O dispatch worker terminated abnormally
	at org.apache.hc.core5.reactor.AbstractMultiworkerIOReactor.doExecute(AbstractMultiworkerIOReactor.java:293)
	at org.apache.hc.core5.reactor.AbstractMultiworkerIOReactor.execute(AbstractMultiworkerIOReactor.java:240)
	at org.apache.hc.client5.http.impl.async.AbstractHttpAsyncClientBase$2.run(AbstractHttpAsyncClientBase.java:86)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.NullPointerException: ssl == null
	at org.conscrypt.NativeCrypto.SSL_get_shutdown(Native Method)
	at org.conscrypt.SslWrapper.wasShutdownReceived(SslWrapper.java:473)
	at org.conscrypt.ConscryptEngine.isInboundDone(ConscryptEngine.java:591)
	at org.apache.hc.core5.reactor.ssl.SSLIOSession.isInboundDone(SSLIOSession.java:558)
	at org.apache.hc.core5.reactor.InternalIOSession.onTimeout(InternalIOSession.java:196)
	at org.apache.hc.core5.reactor.IOReactorImpl.timeoutCheck(IOReactorImpl.java:310)
	at org.apache.hc.core5.reactor.IOReactorImpl.validateActiveChannels(IOReactorImpl.java:220)
	at org.apache.hc.core5.reactor.IOReactorImpl.doExecute(IOReactorImpl.java:168)
	at org.apache.hc.core5.reactor.IOReactorImpl.execute(IOReactorImpl.java:134)
	at org.apache.hc.core5.reactor.AbstractMultiworkerIOReactor$IODispatchWorker.run(AbstractMultiworkerIOReactor.java:495)
	... 1 more
```

Where state is set to 7 (STATE_CLOSED_OUTBOUND) rather than 8 (STATE_CLOSED).