### PR TITLE
Properly handle socket close in socket benchmarks

### DIFF
--- a/benchmark-base/src/main/java/org/conscrypt/ServerSocketBenchmark.java
+++ b/benchmark-base/src/main/java/org/conscrypt/ServerSocketBenchmark.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.SocketException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -72,6 +73,8 @@ public final class ServerSocketBenchmark {
                     } finally {
                         os.flush();
                     }
+                } catch (SocketException e) {
+                    // Just ignore.
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -100,6 +103,9 @@ public final class ServerSocketBenchmark {
                 byte[] buffer = new byte[config.messageSize()];
                 while (!stopping && !thread.isInterrupted()) {
                     int numBytes = client.readMessage(buffer);
+                    if (numBytes < 0) {
+                        return;
+                    }
                     assertEquals(config.messageSize(), numBytes);
 
                     // Increment the message counter if we're recording.

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -713,17 +713,21 @@ final class ConscryptEngineSocket extends OpenSSLSocketImpl {
         }
 
         private int readFromSocket() throws IOException {
-            if (socketChannel != null) {
-                return socketChannel.read(fromSocket);
-            }
-            // Read directly to the underlying array and increment the buffer position if
-            // appropriate.
-            int read = socketInputStream.read(
+            try {
+                if (socketChannel != null) {
+                    return socketChannel.read(fromSocket);
+                }
+                // Read directly to the underlying array and increment the buffer position if
+                // appropriate.
+                int read = socketInputStream.read(
                     fromSocket.array(), fromSocket.position(), fromSocket.remaining());
-            if (read > 0) {
-                fromSocket.position(fromSocket.position() + read);
+                if (read > 0) {
+                    fromSocket.position(fromSocket.position() + read);
+                }
+                return read;
+            } catch (EOFException e) {
+                return -1;
             }
-            return read;
         }
     }
 }


### PR DESCRIPTION
The socket bechmarks were not correctly handling exceptions resulting from
the socket being closed asynchronously during a read. This lead to
spurious exceptions when shutting down in the benchmarks.