### PR TITLE
Remove conscrypt-openjdk from benchmark-base

### DIFF
--- a/benchmark-base/build.gradle
+++ b/benchmark-base/build.gradle
@@ -1,8 +1,7 @@
 description = 'Conscrypt: Base library for benchmarks'
 
 dependencies {
-    compile project(':conscrypt-openjdk'),
-            project(':conscrypt-testing'),
+    compile project(':conscrypt-testing'),
             libraries.junit
 }
 


### PR DESCRIPTION
The Android benchmarks can't transitively depend on the openjdk build,
so each benchmark project has to depend on its own build and the base
benchmark project has to stand alone.