### PR TITLE
Allow beginHandshake() when a handshake is in process.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -364,10 +364,11 @@ final class ConscryptEngine extends SSLEngine implements NativeCrypto.SSLHandsha
     private void beginHandshakeInternal() throws SSLException {
         switch (state) {
             case STATE_MODE_SET:
-                // This is the only allowed state.
+                // We know what mode to handshake in but have not started the handshake, proceed
                 break;
             case STATE_HANDSHAKE_STARTED:
-                throw new IllegalStateException("Handshake has already been started");
+                // We've already started the handshake, just return
+                return;
             case STATE_CLOSED_INBOUND:
             case STATE_CLOSED_OUTBOUND:
             case STATE_CLOSED:

--- a/openjdk-integ-tests/src/test/java/libcore/javax/net/ssl/SSLEngineTest.java
+++ b/openjdk-integ-tests/src/test/java/libcore/javax/net/ssl/SSLEngineTest.java
@@ -497,6 +497,17 @@ public class SSLEngineTest extends AbstractSSLTest {
         TestSSLEnginePair.close(engines);
     }
 
+    // http://b/37078438
+    @Test
+    public void test_SSLEngine_beginHandshake_redundantCalls() throws Exception {
+        TestSSLContext c = TestSSLContext.create();
+        SSLEngine client = c.clientContext.createSSLEngine(c.host.getHostName(), c.port);
+        client.setUseClientMode(true);
+        client.beginHandshake();
+        client.beginHandshake();  // This call should be ignored
+        c.close();
+    }
+
     @Test
     public void test_SSLEngine_getUseClientMode() throws Exception {
         TestSSLContext c = TestSSLContext.create();


### PR DESCRIPTION
The documentation for beginHandshake() says that IllegalStateException is
thrown if the client/server mode hasn't been set, and it's reported that
the OpenJDK implementation and previous Android releases both allowed
calling beginHandshake() when a handshake is in progress.  Since
beginHandshake() is documented as being non-blocking, this should be safe.

This fixes https://issuetracker.google.com/37078438.