### PR TITLE
Use Java logging consistently

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,10 @@ subprojects {
                 showExceptions true
                 showCauses true
                 showStackTraces true
+                showStandardStreams = true
             }
+            // Enable logging for all conscrypt classes while running tests.
+            systemProperty 'java.util.logging.config.file', "${rootDir}/test_logging.properties"
             maxHeapSize = '1500m'
         }
     }

--- a/common/src/main/java/org/conscrypt/SslSessionWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslSessionWrapper.java
@@ -458,7 +458,7 @@ abstract class SslSessionWrapper {
 
     private static void log(Throwable t) {
         // TODO(nathanmittler): Better error handling?
-        logger.log(Level.INFO, "Error inflating SSL session: {}",
+        logger.log(Level.INFO, "Error inflating SSL session: {0}",
                 (t.getMessage() != null ? t.getMessage() : t.getClass().getName()));
     }
 

--- a/common/src/main/java/org/conscrypt/SslSessionWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslSessionWrapper.java
@@ -29,6 +29,8 @@ import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -41,6 +43,8 @@ import javax.security.cert.X509Certificate;
  * This is abstract only to support mocking for tests.
  */
 abstract class SslSessionWrapper {
+    private static final Logger logger = Logger.getLogger(SslSessionWrapper.class.getName());
+
     /**
      * Creates a new instance. Since BoringSSL does not provide an API to get access to all
      * session information via the SSL_SESSION, we get some values (e.g. peer certs) from
@@ -50,9 +54,8 @@ abstract class SslSessionWrapper {
             throws SSLPeerUnverifiedException {
         AbstractSessionContext context = (AbstractSessionContext) activeSession.getSessionContext();
         if (context instanceof ClientSessionContext) {
-            return new Impl(context, ref, activeSession.getPeerHost(),
-                    activeSession.getPeerPort(), activeSession.getPeerCertificates(),
-                    getOcspResponse(activeSession),
+            return new Impl(context, ref, activeSession.getPeerHost(), activeSession.getPeerPort(),
+                    activeSession.getPeerCertificates(), getOcspResponse(activeSession),
                     activeSession.getPeerSignedCertificateTimestamp());
         }
 
@@ -247,10 +250,9 @@ abstract class SslSessionWrapper {
         boolean isValid() {
             long creationTimeMillis = getCreationTime();
             // Use the minimum of the timeout from the context and the session.
-            long timeoutMillis =
-                    Math.max(0,
-                            Math.min(context.getSessionTimeout(),
-                                    NativeCrypto.SSL_SESSION_get_timeout(ref.context)))
+            long timeoutMillis = Math.max(0,
+                                         Math.min(context.getSessionTimeout(),
+                                                 NativeCrypto.SSL_SESSION_get_timeout(ref.context)))
                     * 1000;
             return (System.currentTimeMillis() - timeoutMillis) < creationTimeMillis;
         }
@@ -332,7 +334,7 @@ abstract class SslSessionWrapper {
                 return baos.toByteArray();
             } catch (IOException e) {
                 // TODO(nathanmittler): Better error handling?
-                System.err.println("Failed to convert saved SSL Session: " + e.getMessage());
+                logger.log(Level.WARNING, "Failed to convert saved SSL Session: ", e);
                 return null;
             } catch (CertificateEncodingException e) {
                 log(e);
@@ -456,8 +458,8 @@ abstract class SslSessionWrapper {
 
     private static void log(Throwable t) {
         // TODO(nathanmittler): Better error handling?
-        System.out.println("Error inflating SSL session: "
-                + (t.getMessage() != null ? t.getMessage() : t.getClass().getName()));
+        logger.log(Level.INFO, "Error inflating SSL session: {}",
+                (t.getMessage() != null ? t.getMessage() : t.getClass().getName()));
     }
 
     private static void checkRemaining(ByteBuffer buf, int length) throws IOException {

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -271,11 +271,8 @@ def addNativeTest(nativeClassifier) {
             // TODO(nmittler): Is there a way to copy all properties of the test task?
 
             // Copy the logging configuration from the test task.
-            testLogging.exceptionFormat = test.testLogging.exceptionFormat
-            testLogging.showExceptions test.testLogging.showExceptions
-            testLogging.showCauses test.testLogging.showCauses
-            testLogging.showStackTraces test.testLogging.showStackTraces
-            testLogging.showStandardStreams = test.testLogging.showStandardStreams
+            org.codehaus.groovy.runtime.InvokerHelper.setProperties(testLogging,
+                    test.testLogging.properties)
 
             // Copy heap settings.
             minHeapSize = test.minHeapSize

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -268,6 +268,22 @@ def addNativeTest(nativeClassifier) {
             executable = javaExecutable
             testClassesDir = testSourceSet.output.classesDir
 
+            // TODO(nmittler): Is there a way to copy all properties of the test task?
+
+            // Copy the logging configuration from the test task.
+            testLogging.exceptionFormat = test.testLogging.exceptionFormat
+            testLogging.showExceptions test.testLogging.showExceptions
+            testLogging.showCauses test.testLogging.showCauses
+            testLogging.showStackTraces test.testLogging.showStackTraces
+            testLogging.showStandardStreams = test.testLogging.showStandardStreams
+
+            // Copy heap settings.
+            minHeapSize = test.minHeapSize
+            maxHeapSize = test.maxHeapSize
+
+            // Copy system properties
+            systemProperties = test.systemProperties
+
             // Set the classpath just before we run the test so that the runtime classpath
             // is fully resolved.
             doFirst {

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -1012,7 +1012,6 @@ public class NativeCryptoTest {
                             }
                             return callback;
                         } catch (Exception e) {
-                            e.printStackTrace();
                             throw e;
                         }
                     }
@@ -1252,9 +1251,6 @@ public class NativeCryptoTest {
             client.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
             fail();
         } catch (ExecutionException expected) {
-            if (SocketTimeoutException.class != expected.getCause().getClass()) {
-                expected.printStackTrace();
-            }
             assertEquals(SocketTimeoutException.class, expected.getCause().getClass());
         } finally {
             // Manually close peer socket when testing timeout

--- a/test_logging.properties
+++ b/test_logging.properties
@@ -6,3 +6,6 @@ java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 
 org.conscrypt.level=ALL
 org.conscrypt.handler=java.util.logging.ConsoleHandler
+
+# Avoid nuisance logs in tests.
+org.conscrypt.SslSessionWrapper.level=SEVERE

--- a/test_logging.properties
+++ b/test_logging.properties
@@ -1,0 +1,8 @@
+handlers=java.util.logging.ConsoleHandler
+.level=SEVERE
+
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+
+org.conscrypt.level=ALL
+org.conscrypt.handler=java.util.logging.ConsoleHandler


### PR DESCRIPTION
There are many places in the code that print to System.out/err. We
should use the standard Java logging facilities.

Fixes #212