### PR TITLE
Account for OpenSSL 1.1.0 const-correcting a callback.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -6087,7 +6087,15 @@ static int new_session_callback(SSL* ssl, SSL_SESSION* session) {
     return 0;
 }
 
-static SSL_SESSION* server_session_requested_callback(SSL* ssl, uint8_t* id, int id_len,
+// TODO(davidben): Remove the version check once BoringSSL has switched to
+// advertising OpenSSL 1.1.0.
+static SSL_SESSION* server_session_requested_callback(SSL* ssl,
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+                                                      uint8_t* id,
+#else
+                                                      const uint8_t* id,
+#endif
+                                                      int id_len,
                                                       int* out_copy) {
     JNI_TRACE("ssl=%p server_session_requested_callback", ssl);
 


### PR DESCRIPTION
BoringSSL plans to switch to advertising OpenSSL 1.1.0's version number
at some point in the future. (We've been opaquifying the SSL stack which
leaves us in this awkward mix of 1.1.0 and 1.0.2 right now.) In one
case, it is unfortunately a breaking change because OpenSSL changed a
callback's type signature while keeping the name.

To account for that, add an OPENSSL_VERSION_NUMBER check. This makes
Conscrypt compatible with both BoringSSL today and a later BoringSSL. It
can be removed once the migration is completed. I'll send a PR to remove
this when that's happened.