### PR TITLE
Update build for Android tree.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -60,6 +60,7 @@ core_cppflags := -Wall -Wextra -Werror -Wunused -fvisibility=hidden
 #
 
 include $(CLEAR_VARS)
+LOCAL_CPP_EXTENSION := .cc
 LOCAL_SRC_FILES := constants/src/gen/cpp/generate_constants.cc
 LOCAL_MODULE := conscrypt_generate_constants
 LOCAL_SHARED_LIBRARIES := libcrypto libssl
@@ -144,7 +145,6 @@ bundled_benchmark_java_files := $(call all-java-files-under,testing/src/main/jav
 bundled_benchmark_java_files := $(foreach j,$(bundled_benchmark_java_files),\
 	$(if $(findstring testing/src/main/java/libcore/,$(j)),,$(j)))
 bundled_benchmark_java_files += $(call all-java-files-under,benchmark-base/src/main/java)
-bundled_benchmark_java_files += $(call all-java-files-under,benchmark-caliper/src/main/java)
 bundled_benchmark_java_files += $(call all-java-files-under,benchmark-android/src/main/java)
 
 # Make the conscrypt-benchmarks library.
@@ -164,6 +164,7 @@ endif
 
 # Platform conscrypt crypto JNI library
 include $(CLEAR_VARS)
+LOCAL_CPP_EXTENSION := .cc
 LOCAL_CFLAGS += $(core_cflags)
 LOCAL_CFLAGS += -DJNI_JARJAR_PREFIX="com/android/"
 LOCAL_CPPFLAGS += $(core_cppflags)
@@ -205,6 +206,7 @@ include $(BUILD_STATIC_JAVA_LIBRARY)
 
 # Static unbundled Conscrypt crypto JNI library
 include $(CLEAR_VARS)
+LOCAL_CPP_EXTENSION := .cc
 LOCAL_CFLAGS += $(core_cflags)
 LOCAL_CPPFLAGS += $(core_cppflags) \
         -DJNI_JARJAR_PREFIX="com/google/android/gms/" \
@@ -271,6 +273,7 @@ endif
 
 # Conscrypt native library for host
 include $(CLEAR_VARS)
+LOCAL_CPP_EXTENSION := .cc
 LOCAL_SRC_FILES := $(call all-cpp-files-under,common/src/jni/main/cpp)
 LOCAL_C_INCLUDES += \
         external/openssl/include \

--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -142,56 +142,59 @@ int jniThrowException(JNIEnv* env, const char* className, const char* msg) {
 }
 
 int jniThrowRuntimeException(JNIEnv* env, const char* msg) {
-    return jniThrowException(env, "java/lang/RuntimeException", msg);
+    return conscrypt::jniutil::jniThrowException(env, "java/lang/RuntimeException", msg);
 }
 
 int jniThrowNullPointerException(JNIEnv* env, const char* msg) {
-    return jniThrowException(env, "java/lang/NullPointerException", msg);
+    return conscrypt::jniutil::jniThrowException(env, "java/lang/NullPointerException", msg);
 }
 
 int jniThrowOutOfMemory(JNIEnv* env, const char* message) {
-    return jniThrowException(env, "java/lang/OutOfMemoryError", message);
+    return conscrypt::jniutil::jniThrowException(env, "java/lang/OutOfMemoryError", message);
 }
 
 int throwBadPaddingException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwBadPaddingException %s", message);
-    return jniThrowException(env, "javax/crypto/BadPaddingException", message);
+    return conscrypt::jniutil::jniThrowException(env, "javax/crypto/BadPaddingException", message);
 }
 
 int throwSignatureException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwSignatureException %s", message);
-    return jniThrowException(env, "java/security/SignatureException", message);
+    return conscrypt::jniutil::jniThrowException(env, "java/security/SignatureException", message);
 }
 
 int throwInvalidKeyException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwInvalidKeyException %s", message);
-    return jniThrowException(env, "java/security/InvalidKeyException", message);
+    return conscrypt::jniutil::jniThrowException(env, "java/security/InvalidKeyException", message);
 }
 
 int throwIllegalBlockSizeException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwIllegalBlockSizeException %s", message);
-    return jniThrowException(env, "javax/crypto/IllegalBlockSizeException", message);
+    return conscrypt::jniutil::jniThrowException(
+            env, "javax/crypto/IllegalBlockSizeException", message);
 }
 
 int throwNoSuchAlgorithmException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwUnknownAlgorithmException %s", message);
-    return jniThrowException(env, "java/security/NoSuchAlgorithmException", message);
+    return conscrypt::jniutil::jniThrowException(
+            env, "java/security/NoSuchAlgorithmException", message);
 }
 
 int throwIOException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwIOException %s", message);
-    return jniThrowException(env, "java/io/IOException", message);
+    return conscrypt::jniutil::jniThrowException(env, "java/io/IOException", message);
 }
 
 int throwParsingException(JNIEnv* env, const char* message) {
-    return jniThrowException(env, TO_STRING(JNI_JARJAR_PREFIX)
+    return conscrypt::jniutil::jniThrowException(env, TO_STRING(JNI_JARJAR_PREFIX)
                             "org/conscrypt/OpenSSLX509CertificateFactory$ParsingException",
                             message);
 }
 
 int throwInvalidAlgorithmParameterException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwInvalidAlgorithmParameterException %s", message);
-    return jniThrowException(env, "java/security/InvalidAlgorithmParameterException", message);
+    return conscrypt::jniutil::jniThrowException(
+            env, "java/security/InvalidAlgorithmParameterException", message);
 }
 
 int throwForAsn1Error(JNIEnv* env, int reason, const char* message,
@@ -359,22 +362,24 @@ bool throwExceptionIfNecessary(JNIEnv* env, CONSCRYPT_UNUSED const char* locatio
 
 int throwSocketTimeoutException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwSocketTimeoutException %s", message);
-    return jniThrowException(env, "java/net/SocketTimeoutException", message);
+    return conscrypt::jniutil::jniThrowException(env, "java/net/SocketTimeoutException", message);
 }
 
 int throwSSLHandshakeExceptionStr(JNIEnv* env, const char* message) {
     JNI_TRACE("throwSSLExceptionStr %s", message);
-    return jniThrowException(env, "javax/net/ssl/SSLHandshakeException", message);
+    return conscrypt::jniutil::jniThrowException(
+            env, "javax/net/ssl/SSLHandshakeException", message);
 }
 
 int throwSSLExceptionStr(JNIEnv* env, const char* message) {
     JNI_TRACE("throwSSLExceptionStr %s", message);
-    return jniThrowException(env, "javax/net/ssl/SSLException", message);
+    return conscrypt::jniutil::jniThrowException(env, "javax/net/ssl/SSLException", message);
 }
 
 int throwSSLProtocolExceptionStr(JNIEnv* env, const char* message) {
     JNI_TRACE("throwSSLProtocolExceptionStr %s", message);
-    return jniThrowException(env, "javax/net/ssl/SSLProtocolException", message);
+    return conscrypt::jniutil::jniThrowException(
+            env, "javax/net/ssl/SSLProtocolException", message);
 }
 
 int throwSSLExceptionWithSslErrors(JNIEnv* env, SSL* ssl, int sslErrorCode, const char* message,

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -364,7 +364,7 @@ jbyteArray CryptoBufferToByteArray(JNIEnv* env, const CRYPTO_BUFFER* buf) {
 }
 
 bssl::UniquePtr<CRYPTO_BUFFER> ByteArrayToCryptoBuffer(JNIEnv* env, const jbyteArray array,
-                                                       CRYPTO_BUFFER_POOL* pool) {
+                                                       CONSCRYPT_UNUSED CRYPTO_BUFFER_POOL* pool) {
     if (array == nullptr) {
         JNI_TRACE("array was null");
         conscrypt::jniutil::jniThrowNullPointerException(env, "array == null");
@@ -447,17 +447,6 @@ static void safeSslClear(SSL* ssl) {
     if (SSL_clear(ssl) != 1) {
         ERR_clear_error();
     }
-}
-
-/**
- * To avoid the round-trip to ASN.1 and back in X509_dup, we just up the reference count.
- */
-static X509* X509_dup_nocopy(X509* x509) {
-    if (x509 == nullptr) {
-        return nullptr;
-    }
-    X509_up_ref(x509);
-    return x509;
 }
 
 static int bio_stream_create(BIO* b) {
@@ -5777,7 +5766,7 @@ static AppData* toAppData(const SSL* ssl) {
     return reinterpret_cast<AppData*>(SSL_get_app_data(ssl));
 }
 
-static ssl_verify_result_t cert_verify_callback(SSL* ssl, uint8_t* out_alert) {
+static ssl_verify_result_t cert_verify_callback(SSL* ssl, CONSCRYPT_UNUSED uint8_t* out_alert) {
     JNI_TRACE("ssl=%p cert_verify_callback", ssl);
 
     AppData* appData = toAppData(ssl);


### PR DESCRIPTION
Android assumes the extensions for C++ files is .cpp, so inform it
that we use .cc now.

Mark some unused parameters and remove an unused function.

Disambiguate calls to jniThrowException, which is also a function in an
Android header with the same name and signature.