### PR TITLE
Implement engineGetKeySize() in Ciphers.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipher.java
@@ -422,6 +422,20 @@ public abstract class OpenSSLCipher extends CipherSpi {
         }
     }
 
+    @Override
+    protected int engineGetKeySize(Key key) throws InvalidKeyException {
+        if (!(key instanceof SecretKey)) {
+            throw new InvalidKeyException("Only SecretKey is supported");
+        }
+        byte[] encodedKey = key.getEncoded();
+        if (encodedKey == null) {
+            throw new InvalidKeyException("key.getEncoded() == null");
+        }
+        checkSupportedKeySize(encodedKey.length);
+        // The return value is in bits
+        return encodedKey.length * 8;
+    }
+
     private byte[] checkAndSetEncodedKey(int opmode, Key key) throws InvalidKeyException {
         if (opmode == Cipher.ENCRYPT_MODE || opmode == Cipher.WRAP_MODE) {
             encrypting = true;

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -219,20 +219,23 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
     protected int engineGetKeySize(Key key) throws InvalidKeyException {
         if (key instanceof OpenSSLRSAPrivateKey) {
             return ((OpenSSLRSAPrivateKey) key).getModulus().bitLength();
-        } else if (key instanceof RSAPrivateCrtKey) {
-            return ((RSAPrivateCrtKey) key).getModulus().bitLength();
-        } else if (key instanceof RSAPrivateKey) {
-            return ((RSAPrivateKey) key).getModulus().bitLength();
-        } else if (key instanceof OpenSSLRSAPublicKey) {
-            return ((OpenSSLRSAPublicKey) key).getModulus().bitLength();
-        } else if (key instanceof RSAPublicKey) {
-            return ((RSAPublicKey) key).getModulus().bitLength();
-        } else {
-            if (null == key) {
-                throw new InvalidKeyException("RSA private or public key is null");
-            }
-            throw new InvalidKeyException("Need RSA private or public key");
         }
+        if (key instanceof RSAPrivateCrtKey) {
+            return ((RSAPrivateCrtKey) key).getModulus().bitLength();
+        }
+        if (key instanceof RSAPrivateKey) {
+            return ((RSAPrivateKey) key).getModulus().bitLength();
+        }
+        if (key instanceof OpenSSLRSAPublicKey) {
+            return ((OpenSSLRSAPublicKey) key).getModulus().bitLength();
+        }
+        if (key instanceof RSAPublicKey) {
+            return ((RSAPublicKey) key).getModulus().bitLength();
+        }
+        if (null == key) {
+            throw new InvalidKeyException("RSA private or public key is null");
+        }
+        throw new InvalidKeyException("Need RSA private or public key");
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -216,6 +216,26 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
     }
 
     @Override
+    protected int engineGetKeySize(Key key) throws InvalidKeyException {
+        if (key instanceof OpenSSLRSAPrivateKey) {
+            return ((OpenSSLRSAPrivateKey) key).getModulus().bitLength();
+        } else if (key instanceof RSAPrivateCrtKey) {
+            return ((RSAPrivateCrtKey) key).getModulus().bitLength();
+        } else if (key instanceof RSAPrivateKey) {
+            return ((RSAPrivateKey) key).getModulus().bitLength();
+        } else if (key instanceof OpenSSLRSAPublicKey) {
+            return ((OpenSSLRSAPublicKey) key).getModulus().bitLength();
+        } else if (key instanceof RSAPublicKey) {
+            return ((RSAPublicKey) key).getModulus().bitLength();
+        } else {
+            if (null == key) {
+                throw new InvalidKeyException("RSA private or public key is null");
+            }
+            throw new InvalidKeyException("Need RSA private or public key");
+        }
+    }
+
+    @Override
     protected void engineInit(int opmode, Key key, SecureRandom random) throws InvalidKeyException {
         try {
             engineInitInternal(opmode, key, null);


### PR DESCRIPTION
This method is only called when the unlimited strength policy files aren't
installed, and thus the JDK needs to check whether the key sizes being
used are allowed, but it causes an UnsupportedOperationException if it's
missing in that situation.

Fixes #324.