### PR TITLE
Switch R_RSA_DATA_TOO_LARGE{,_FOR_MODULUS} exception

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -281,7 +281,6 @@ int throwForRsaError(JNIEnv* env, int reason, const char* message,
             return throwBadPaddingException(env, message);
             break;
         case RSA_R_BAD_SIGNATURE:
-        case RSA_R_DATA_TOO_LARGE_FOR_MODULUS:
         case RSA_R_INVALID_MESSAGE_LENGTH:
         case RSA_R_WRONG_SIGNATURE_LENGTH:
             return throwSignatureException(env, message);
@@ -293,6 +292,8 @@ int throwForRsaError(JNIEnv* env, int reason, const char* message,
         case RSA_R_NO_PUBLIC_EXPONENT:
             return throwInvalidKeyException(env, message);
             break;
+        case RSA_R_DATA_TOO_LARGE:
+        case RSA_R_DATA_TOO_LARGE_FOR_MODULUS:
         case RSA_R_DATA_TOO_LARGE_FOR_KEY_SIZE:
             return throwIllegalBlockSizeException(env, message);
             break;


### PR DESCRIPTION
These error codes can be generated by the methods used in both raw RSA
signatures and RSA ciphers, but the Java APIs for Cipher and Signature
have disjoint declared exceptions.  Luckily, in our Signature
implementations we catch any Exception and wrap it in a SignatureException,
so we can safely turn these into the appropriate exceptions for Cipher
and they'll be thrown as SignatureException from Signature anyway.