### PR TITLE
Fix benchmarks broken by #321

### DIFF
--- a/benchmark-android/src/main/java/org/conscrypt/AndroidEngineFactory.java
+++ b/benchmark-android/src/main/java/org/conscrypt/AndroidEngineFactory.java
@@ -15,8 +15,6 @@
  */
 package org.conscrypt;
 
-import static org.conscrypt.TestUtils.initEngine;
-
 import java.security.NoSuchAlgorithmException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -71,5 +69,12 @@ public enum AndroidEngineFactory implements EngineFactory {
 
     private static SSLContext newConscryptServerContext() {
         return TestUtils.newServerSslContext(TestUtils.getConscryptProvider());
+    }
+
+    static SSLEngine initEngine(SSLEngine engine, String cipher, boolean client) {
+        engine.setEnabledProtocols(new String[]{"TLSv1.2"});
+        engine.setEnabledCipherSuites(new String[] {cipher});
+        engine.setUseClientMode(client);
+        return engine;
     }
 }

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhEngineWrapBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhEngineWrapBenchmark.java
@@ -59,7 +59,7 @@ public class JmhEngineWrapBenchmark {
     @Param
     public BufferType b_buffer;
 
-    @Param({"64", "512", "4096"})
+    @Param({"128", "4096"})
     public int c_message;
 
     @Param

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/OpenJdkEngineFactory.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/OpenJdkEngineFactory.java
@@ -18,7 +18,6 @@ package org.conscrypt;
 import static io.netty.handler.ssl.SslProvider.OPENSSL;
 import static io.netty.handler.ssl.SslProvider.OPENSSL_REFCNT;
 import static org.conscrypt.TestUtils.initClientSslContext;
-import static org.conscrypt.TestUtils.initEngine;
 import static org.conscrypt.TestUtils.initServerSslContext;
 
 import io.netty.buffer.PooledByteBufAllocator;
@@ -42,7 +41,7 @@ final class OpenJdkEngineFactoryConfig {
     static final ApplicationProtocolConfig NETTY_ALPN_CONFIG =
             new ApplicationProtocolConfig(Protocol.ALPN, SelectorFailureBehavior.NO_ADVERTISE,
                     SelectedListenerFailureBehavior.ACCEPT, ApplicationProtocolNames.HTTP_2);
-    static final String PROTOCOL = TestUtils.getProtocols()[0];
+    static final String PROTOCOL = "TLSv1.2";
 }
 
 /**
@@ -254,5 +253,12 @@ public enum OpenJdkEngineFactory implements EngineFactory {
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    static SSLEngine initEngine(SSLEngine engine, String cipher, boolean client) {
+        engine.setEnabledProtocols(new String[]{OpenJdkEngineFactoryConfig.PROTOCOL});
+        engine.setEnabledCipherSuites(new String[] {cipher});
+        engine.setUseClientMode(client);
+        return engine;
     }
 }

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -309,16 +309,6 @@ public final class TestUtils {
         return msg;
     }
 
-    /**
-     * Initializes the given engine with the cipher and client mode.
-     */
-    static SSLEngine initEngine(SSLEngine engine, String cipher, boolean client) {
-        engine.setEnabledProtocols(getProtocols());
-        engine.setEnabledCipherSuites(new String[] {cipher});
-        engine.setUseClientMode(client);
-        return engine;
-    }
-
     static SSLContext newClientSslContext(Provider provider) {
         SSLContext context = newContext(provider);
         return initClientSslContext(context);


### PR DESCRIPTION
The cipher used in the benchmarks requires TLS 1.2.