### PR TITLE
Reorder app_data.h field init ordering.

### DIFF
--- a/common/src/jni/main/include/conscrypt/app_data.h
+++ b/common/src/jni/main/include/conscrypt/app_data.h
@@ -240,9 +240,9 @@ class AppData {
           waitingThreads(0),
           env(nullptr),
           sslHandshakeCallbacks(nullptr),
-          alpnProtocolSelector(nullptr),
           alpnProtocolsData(nullptr),
-          alpnProtocolsLength(static_cast<size_t>(-1)) {
+          alpnProtocolsLength(static_cast<size_t>(-1)),
+          alpnProtocolSelector(nullptr) {
 #ifdef _WIN32
         interruptEvent = nullptr;
 #else


### PR DESCRIPTION
The ordering needs to be in the same order as the fields to comply with
strict warnings.