### PR TITLE
Suppress duplicative progress from sdkmanager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,15 @@ matrix:
         - mkdir $ANDROID_HOME/licenses
         - echo -ne "\n8933bad161af4178b1185d1a37fbf41ea5269c55" >> $ANDROID_HOME/licenses/android-sdk-license
         - echo -ne "\n84831b9409646a918e30573bab4c9c91346d8abd\n504667f4c0de7af1a06de9f4b1727b84351f2910" >> $ANDROID_HOME/licenses/android-sdk-preview-license
-        - $ANDROID_HOME/tools/bin/sdkmanager tools
-        - $ANDROID_HOME/tools/bin/sdkmanager platform-tools
-        - $ANDROID_HOME/tools/bin/sdkmanager 'build-tools;25.0.0'
-        - $ANDROID_HOME/tools/bin/sdkmanager 'platforms;android-25'
-        - $ANDROID_HOME/tools/bin/sdkmanager 'extras;android;m2repository'
-        - $ANDROID_HOME/tools/bin/sdkmanager --channel=1 ndk-bundle
-        - $ANDROID_HOME/tools/bin/sdkmanager 'cmake;3.6.4111459'
+        # sdkmanager 26.1.1 produces an enormous amount of progress info
+        # Append tr '\r' '\n' | uniq to all the commands to suppress it
+        - $ANDROID_HOME/tools/bin/sdkmanager tools | tr '\r' '\n' | uniq
+        - $ANDROID_HOME/tools/bin/sdkmanager platform-tools | tr '\r' '\n' | uniq
+        - $ANDROID_HOME/tools/bin/sdkmanager 'build-tools;25.0.0' | tr '\r' '\n' | uniq
+        - $ANDROID_HOME/tools/bin/sdkmanager 'platforms;android-25' | tr '\r' '\n' | uniq
+        - $ANDROID_HOME/tools/bin/sdkmanager 'extras;android;m2repository' | tr '\r' '\n' | uniq
+        - $ANDROID_HOME/tools/bin/sdkmanager --channel=1 ndk-bundle | tr '\r' '\n' | uniq
+        - $ANDROID_HOME/tools/bin/sdkmanager 'cmake;3.6.4111459' | tr '\r' '\n' | uniq
 
       addons:
         apt:


### PR DESCRIPTION
The 26.1.1 release of sdkmanager produces constant progress messages,
many of which are duplicates, which fills up the Travis logs
unnecessarily.  Replace the CRs (which make it look nice in the terminal)
with linefeeds, then use uniq to suppress any duplicated lines, which
means any given install will produce at most 100 lines in the
log instead of many thousands.