### PR TITLE
Throw SocketException if the FD socket has had its SSL freed

### DIFF
--- a/common/src/main/java/org/conscrypt/SslWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslWrapper.java
@@ -29,7 +29,6 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.SocketException;
-import java.net.SocketTimeoutException;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;

--- a/common/src/main/java/org/conscrypt/SslWrapper.java
+++ b/common/src/main/java/org/conscrypt/SslWrapper.java
@@ -28,6 +28,7 @@ import static org.conscrypt.NativeConstants.SSL_VERIFY_PEER;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
@@ -363,7 +364,10 @@ final class SslWrapper {
 
     // TODO(nathanmittler): Remove once after we switch to the engine socket.
     void doHandshake(FileDescriptor fd, int timeoutMillis)
-            throws CertificateException, SocketTimeoutException, SSLException {
+            throws CertificateException, IOException {
+        if (isClosed() || fd == null || !fd.valid()) {
+            throw new SocketException("Socket is closed");
+        }
         NativeCrypto.SSL_do_handshake(ssl, fd, handshakeCallbacks, timeoutMillis);
     }
 
@@ -374,12 +378,18 @@ final class SslWrapper {
     // TODO(nathanmittler): Remove once after we switch to the engine socket.
     int read(FileDescriptor fd, byte[] buf, int offset, int len, int timeoutMillis)
             throws IOException {
+        if (isClosed() || fd == null || !fd.valid()) {
+            throw new SocketException("Socket is closed");
+        }
         return NativeCrypto.SSL_read(ssl, fd, handshakeCallbacks, buf, offset, len, timeoutMillis);
     }
 
     // TODO(nathanmittler): Remove once after we switch to the engine socket.
     void write(FileDescriptor fd, byte[] buf, int offset, int len, int timeoutMillis)
             throws IOException {
+        if (isClosed() || fd == null || !fd.valid()) {
+            throw new SocketException("Socket is closed");
+        }
         NativeCrypto.SSL_write(ssl, fd, handshakeCallbacks, buf, offset, len, timeoutMillis);
     }
 


### PR DESCRIPTION
Under some circumstances (which are repeatable, but I haven't been able
to lock down), the HTTP connection reuse system in the JDK will attempt to
reuse a finalized ConscryptFileDescriptorSocket.  When this happens, the
socket throws a NullPointerException from the native code when methods
are called, because the native SSL object has been freed, which causes
a lot of problems.  Instead, have the socket throw SocketException instead,
which everything understands and responds properly to.

As best as I can tell, this is happening because the finalizer of some
object that's not ours but has a strong reference to our socket adds
a new strong reference, but our finalizer has already been enqueued
and thus is run even though the object then can later be reused.  I haven't
been able to find this finalizer, but everything tolerates the code as
written and responds properly to the SocketException, so it seems like a
good solution until we get rid of the FD socket entirely.

Fixes #331.