### PR TITLE
Change three ALPN methods to public in Java 8 wrapper.

### DIFF
--- a/common/src/main/java/org/conscrypt/Java8SocketWrapper.java
+++ b/common/src/main/java/org/conscrypt/Java8SocketWrapper.java
@@ -422,21 +422,21 @@ public final class Java8SocketWrapper extends AbstractConscryptSocket {
     @Override
     @Deprecated
     @SuppressWarnings("deprecation")
-    byte[] getAlpnSelectedProtocol() {
+    public byte[] getAlpnSelectedProtocol() {
         return delegate.getAlpnSelectedProtocol();
     }
 
     @Override
     @Deprecated
     @SuppressWarnings("deprecation")
-    void setAlpnProtocols(String[] alpnProtocols) {
+    public void setAlpnProtocols(String[] alpnProtocols) {
         delegate.setAlpnProtocols(alpnProtocols);
     }
 
     @Override
     @Deprecated
     @SuppressWarnings("deprecation")
-    void setAlpnProtocols(byte[] alpnProtocols) {
+    public void setAlpnProtocols(byte[] alpnProtocols) {
         delegate.setAlpnProtocols(alpnProtocols);
     }
 


### PR DESCRIPTION
These methods are public in OpenSSLSocketImpl, so they need to be public
in the wrapper class as well so that callers that are reflectively calling
them don't fail to find them when we return the wrapper.