### PR TITLE
Don't depend on openjdk classes in platform build.

### DIFF
--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -272,19 +272,19 @@ final class Platform {
     }
 
     static SSLEngine wrapEngine(ConscryptEngine engine) {
-        return Java8PlatformUtil.wrapEngine(engine);
+        return new Java8EngineWrapper(engine);
     }
 
     static SSLEngine unwrapEngine(SSLEngine engine) {
-        return Java8PlatformUtil.unwrapEngine(engine);
+        return Java8EngineWrapper.getDelegate(engine);
     }
 
     static SSLSocket wrapSocket(ConscryptSocketBase socket) {
-        return Java8PlatformUtil.wrapSocket(socket);
+        return new Java8SocketWrapper(socket);
     }
 
     static SSLSocket unwrapSocket(SSLSocket socket) {
-        return Java8PlatformUtil.unwrapSocket(socket);
+        return Java8SocketWrapper.getDelegate(socket);
     }
 
     /**


### PR DESCRIPTION
The platform gradle build currently has a build dependency on openjdk
and doesn't include its own Platform class, so this works in the GitHub
build, but it doesn't work when it gets imported into Android's build
tree.  I'm working on a change to fix the build setup as well, but
platform's Platform.java depends on a lot of non-public functionality
in the Android world, so it's going to be more complicated than this.