### PR TITLE
Allow modes (ECB and NONE) and padding (NOPADDING) for ARC4.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipher.java
@@ -56,6 +56,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
      * Modes that a block cipher may support.
      */
     enum Mode {
+        NONE,
         CBC,
         CTR,
         ECB,
@@ -958,12 +959,16 @@ public abstract class OpenSSLCipher extends CipherSpi {
 
             @Override
             void checkSupportedMode(Mode mode) throws NoSuchAlgorithmException {
-                throw new NoSuchAlgorithmException("ARC4 does not support modes");
+                if (mode != Mode.NONE && mode != Mode.ECB) {
+                    throw new NoSuchAlgorithmException("Unsupported mode " + mode.toString());
+                }
             }
 
             @Override
             void checkSupportedPadding(Padding padding) throws NoSuchPaddingException {
-                throw new NoSuchPaddingException("ARC4 does not support padding");
+                if (padding != Padding.NOPADDING) {
+                    throw new NoSuchPaddingException("Unsupported padding " + padding.toString());
+                }
             }
 
             @Override


### PR DESCRIPTION
This allows callers to request ARC4/NONE/NOPADDING as an equivalent
name to requesting just ARC4.  Both NONE and ECB are supported as
modes for RSA and for other providers' implementations of stream
ciphers like ARC4 that don't use modes, so we accept both here as
well.