### PR TITLE
Remove zero-width spaces.

### DIFF
--- a/common/src/main/java/org/conscrypt/AbstractConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptEngine.java
@@ -147,10 +147,10 @@ abstract class AbstractConscryptEngine extends SSLEngine {
     abstract String[] getApplicationProtocols();
 
     @SuppressWarnings("MissingOverride") // For compiling pre Java 9.
-    public abstract String getApplicationProtocol​();
+    public abstract String getApplicationProtocol();
 
     @SuppressWarnings("MissingOverride") // For compiling pre Java 9.
-    public abstract String getHandshakeApplicationProtocol​();
+    public abstract String getHandshakeApplicationProtocol();
 
     /**
      * Sets an application-provided ALPN protocol selector. If provided, this will override

--- a/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
@@ -157,7 +157,7 @@ abstract class AbstractConscryptSocket extends SSLSocket {
      * Returns the protocol agreed upon by client and server, or {@code null} if
      * no protocol was agreed upon.
      *
-     * @deprecated use {@link #getApplicationProtocol​()} instead.
+     * @deprecated use {@link #getApplicationProtocol()} instead.
      */
     @Deprecated
     abstract byte[] getAlpnSelectedProtocol();
@@ -198,10 +198,10 @@ abstract class AbstractConscryptSocket extends SSLSocket {
     abstract String[] getApplicationProtocols();
 
     @SuppressWarnings("MissingOverride") // For compiling pre Java 9.
-    public abstract String getApplicationProtocol​();
+    public abstract String getApplicationProtocol();
 
     @SuppressWarnings("MissingOverride") // For compiling pre Java 9.
-    public abstract String getHandshakeApplicationProtocol​();
+    public abstract String getHandshakeApplicationProtocol();
 
     /**
      * Sets an application-provided ALPN protocol selector. If provided, this will override

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -298,8 +298,8 @@ public final class Conscrypt {
      * @param socket the socket
      * @return the selected protocol or {@code null} if no protocol was agreed upon.
      */
-    public static String getApplicationProtocol​(SSLSocket socket) {
-        return toConscrypt(socket).getApplicationProtocol​();
+    public static String getApplicationProtocol(SSLSocket socket) {
+        return toConscrypt(socket).getApplicationProtocol();
     }
 
     /**
@@ -526,7 +526,7 @@ public final class Conscrypt {
      * @param engine the engine
      * @return the selected protocol or {@code null} if no protocol was agreed upon.
      */
-    public static String getApplicationProtocol​(SSLEngine engine) {
-        return toConscrypt(engine).getApplicationProtocol​();
+    public static String getApplicationProtocol(SSLEngine engine) {
+        return toConscrypt(engine).getApplicationProtocol();
     }
 }

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1706,14 +1706,14 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     }
 
     @Override
-    public String getApplicationProtocol​() {
+    public String getApplicationProtocol() {
         return SSLUtils.toProtocolString(ssl.getApplicationProtocol());
     }
 
     @Override
-    public String getHandshakeApplicationProtocol​() {
+    public String getHandshakeApplicationProtocol() {
         synchronized (ssl) {
-            return state == STATE_HANDSHAKE_STARTED ? getApplicationProtocol​() : null;
+            return state == STATE_HANDSHAKE_STARTED ? getApplicationProtocol() : null;
         }
     }
 

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -400,13 +400,13 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
     }
 
     @Override
-    public final String getApplicationProtocol​() {
-        return engine.getApplicationProtocol​();
+    public final String getApplicationProtocol() {
+        return engine.getApplicationProtocol();
     }
 
     @Override
-    public final String getHandshakeApplicationProtocol​() {
-        return engine.getHandshakeApplicationProtocol​();
+    public final String getHandshakeApplicationProtocol() {
+        return engine.getHandshakeApplicationProtocol();
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -1034,15 +1034,15 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     }
 
     @Override
-    public final String getApplicationProtocol​() {
+    public final String getApplicationProtocol() {
         return SSLUtils.toProtocolString(ssl.getApplicationProtocol());
     }
 
     @Override
-    public final String getHandshakeApplicationProtocol​() {
+    public final String getHandshakeApplicationProtocol() {
         synchronized (ssl) {
             return state >= STATE_HANDSHAKE_STARTED && state < STATE_READY
-                ? getApplicationProtocol​() : null;
+                ? getApplicationProtocol() : null;
         }
     }
 

--- a/common/src/main/java/org/conscrypt/Java8EngineSocket.java
+++ b/common/src/main/java/org/conscrypt/Java8EngineSocket.java
@@ -10,7 +10,7 @@ import javax.net.ssl.SSLSocket;
 
 /**
  * A version of ConscryptEngineSocket that includes the new Java 9 (and potentially later
- * patches of 8) {@code setHandshakeApplicationProtocolSelector​} API (which requires Java 8 for
+ * patches of 8) {@code setHandshakeApplicationProtocolSelector} API (which requires Java 8 for
  * compilation, due to the use of {@link BiFunction}).
  */
 final class Java8EngineSocket extends ConscryptEngineSocket {
@@ -47,7 +47,7 @@ final class Java8EngineSocket extends ConscryptEngineSocket {
 
     /* @Override */
     @SuppressWarnings("MissingOverride") // For compilation with Java < 9.
-    public void setHandshakeApplicationProtocolSelector​(
+    public void setHandshakeApplicationProtocolSelector(
             final BiFunction<SSLSocket, List<String>, String> selector) {
         this.selector = selector;
         setApplicationProtocolSelector(toApplicationProtocolSelector(selector));
@@ -55,7 +55,7 @@ final class Java8EngineSocket extends ConscryptEngineSocket {
 
     /* @Override */
     @SuppressWarnings("MissingOverride") // For compilation with Java < 9.
-    public BiFunction<SSLSocket, List<String>, String> getHandshakeApplicationProtocolSelector​() {
+    public BiFunction<SSLSocket, List<String>, String> getHandshakeApplicationProtocolSelector() {
         return selector;
     }
 

--- a/common/src/main/java/org/conscrypt/Java8EngineWrapper.java
+++ b/common/src/main/java/org/conscrypt/Java8EngineWrapper.java
@@ -32,7 +32,7 @@ import javax.net.ssl.SSLSocket;
 
 /**
  * A wrapper around {@link ConscryptEngine} that adapts to the new Java 9 (and potentially later
- * patches of 8) {@code setHandshakeApplicationProtocolSelector​} API (which requires Java 8 for
+ * patches of 8) {@code setHandshakeApplicationProtocolSelector} API (which requires Java 8 for
  * compilation, due to the use of {@link BiFunction}).
  */
 final class Java8EngineWrapper extends AbstractConscryptEngine {
@@ -285,8 +285,8 @@ final class Java8EngineWrapper extends AbstractConscryptEngine {
     }
 
     @Override
-    public String getApplicationProtocol​() {
-        return delegate.getApplicationProtocol​();
+    public String getApplicationProtocol() {
+        return delegate.getApplicationProtocol();
     }
 
     @Override
@@ -296,13 +296,13 @@ final class Java8EngineWrapper extends AbstractConscryptEngine {
     }
 
     @Override
-    public String getHandshakeApplicationProtocol​() {
-        return delegate.getHandshakeApplicationProtocol​();
+    public String getHandshakeApplicationProtocol() {
+        return delegate.getHandshakeApplicationProtocol();
     }
 
     /* @Override */
     @SuppressWarnings("MissingOverride") // For compilation with Java < 9.
-    public void setHandshakeApplicationProtocolSelector​(
+    public void setHandshakeApplicationProtocolSelector(
             final BiFunction<SSLEngine, List<String>, String> selector) {
         this.selector = selector;
         setApplicationProtocolSelector(toApplicationProtocolSelector(selector));
@@ -310,7 +310,7 @@ final class Java8EngineWrapper extends AbstractConscryptEngine {
 
     /* @Override */
     @SuppressWarnings("MissingOverride") // For compilation with Java < 9.
-    public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector​() {
+    public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
         return selector;
     }
 

--- a/common/src/main/java/org/conscrypt/Java8FileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/Java8FileDescriptorSocket.java
@@ -10,7 +10,7 @@ import javax.net.ssl.SSLSocket;
 
 /**
  * A version of ConscryptFileDescriptorSocket that includes the new Java 9 (and potentially later
- * patches of 8) {@code setHandshakeApplicationProtocolSelector​} API (which requires Java 8 for
+ * patches of 8) {@code setHandshakeApplicationProtocolSelector} API (which requires Java 8 for
  * compilation, due to the use of {@link BiFunction}).
  */
 final class Java8FileDescriptorSocket extends ConscryptFileDescriptorSocket {
@@ -47,7 +47,7 @@ final class Java8FileDescriptorSocket extends ConscryptFileDescriptorSocket {
 
     /* @Override */
     @SuppressWarnings("MissingOverride") // For compilation with Java < 9.
-    public void setHandshakeApplicationProtocolSelector​(
+    public void setHandshakeApplicationProtocolSelector(
             final BiFunction<SSLSocket, List<String>, String> selector) {
         this.selector = selector;
         setApplicationProtocolSelector(toApplicationProtocolSelector(selector));
@@ -55,7 +55,7 @@ final class Java8FileDescriptorSocket extends ConscryptFileDescriptorSocket {
 
     /* @Override */
     @SuppressWarnings("MissingOverride") // For compilation with Java < 9.
-    public BiFunction<SSLSocket, List<String>, String> getHandshakeApplicationProtocolSelector​() {
+    public BiFunction<SSLSocket, List<String>, String> getHandshakeApplicationProtocolSelector() {
         return selector;
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -131,7 +131,7 @@ public abstract class OpenSSLSocketImpl extends ConscryptSocketBase {
     @Deprecated
     @Override
     public final byte[] getAlpnSelectedProtocol() {
-        return SSLUtils.toProtocolBytes(getApplicationProtocol​());
+        return SSLUtils.toProtocolBytes(getApplicationProtocol());
     }
 
     /**

--- a/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
@@ -277,8 +277,8 @@ public class ConscryptEngineTest {
         Conscrypt.setApplicationProtocols(serverEngine, serverAlpnProtocols);
 
         doHandshake(true);
-        assertEquals("spdy/2", Conscrypt.getApplicationProtocol​(clientEngine));
-        assertEquals("spdy/2", Conscrypt.getApplicationProtocol​(serverEngine));
+        assertEquals("spdy/2", Conscrypt.getApplicationProtocol(clientEngine));
+        assertEquals("spdy/2", Conscrypt.getApplicationProtocol(serverEngine));
     }
 
     @Test
@@ -293,8 +293,8 @@ public class ConscryptEngineTest {
         Conscrypt.setApplicationProtocols(serverEngine, serverAlpnProtocols);
 
         doHandshake(true);
-        assertNull(Conscrypt.getApplicationProtocol​(clientEngine));
-        assertNull(Conscrypt.getApplicationProtocol​(serverEngine));
+        assertNull(Conscrypt.getApplicationProtocol(clientEngine));
+        assertNull(Conscrypt.getApplicationProtocol(serverEngine));
     }
 
     @Test
@@ -312,8 +312,8 @@ public class ConscryptEngineTest {
         Conscrypt.setApplicationProtocolSelector(serverEngine, selector);
 
         doHandshake(true);
-        assertEquals("spdy/2", Conscrypt.getApplicationProtocol​(clientEngine));
-        assertEquals("spdy/2", Conscrypt.getApplicationProtocol​(serverEngine));
+        assertEquals("spdy/2", Conscrypt.getApplicationProtocol(clientEngine));
+        assertEquals("spdy/2", Conscrypt.getApplicationProtocol(serverEngine));
     }
 
     @Test
@@ -331,8 +331,8 @@ public class ConscryptEngineTest {
         Conscrypt.setApplicationProtocolSelector(serverEngine, selector);
 
         doHandshake(true);
-        assertNull(Conscrypt.getApplicationProtocol​(clientEngine));
-        assertNull(Conscrypt.getApplicationProtocol​(serverEngine));
+        assertNull(Conscrypt.getApplicationProtocol(clientEngine));
+        assertNull(Conscrypt.getApplicationProtocol(serverEngine));
     }
 
     /**

--- a/openjdk/src/test/java/org/conscrypt/ConscryptSocketTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptSocketTest.java
@@ -426,8 +426,8 @@ public class ConscryptSocketTest {
 
         c.doHandshake();
 
-        assertEquals("spdy/2", Conscrypt.getApplicationProtocol​(c.client));
-        assertEquals("spdy/2", Conscrypt.getApplicationProtocol​(c.server));
+        assertEquals("spdy/2", Conscrypt.getApplicationProtocol(c.client));
+        assertEquals("spdy/2", Conscrypt.getApplicationProtocol(c.server));
     }
 
     @Test
@@ -443,8 +443,8 @@ public class ConscryptSocketTest {
 
         c.doHandshake();
 
-        assertNull(Conscrypt.getApplicationProtocol​(c.client));
-        assertNull(Conscrypt.getApplicationProtocol​(c.server));
+        assertNull(Conscrypt.getApplicationProtocol(c.client));
+        assertNull(Conscrypt.getApplicationProtocol(c.server));
     }
 
     @Test
@@ -463,8 +463,8 @@ public class ConscryptSocketTest {
 
         c.doHandshake();
 
-        assertEquals("spdy/2", Conscrypt.getApplicationProtocol​(c.client));
-        assertEquals("spdy/2", Conscrypt.getApplicationProtocol​(c.server));
+        assertEquals("spdy/2", Conscrypt.getApplicationProtocol(c.client));
+        assertEquals("spdy/2", Conscrypt.getApplicationProtocol(c.server));
     }
 
     @Test
@@ -483,8 +483,8 @@ public class ConscryptSocketTest {
 
         c.doHandshake();
 
-        assertNull(Conscrypt.getApplicationProtocol​(c.client));
-        assertNull(Conscrypt.getApplicationProtocol​(c.server));
+        assertNull(Conscrypt.getApplicationProtocol(c.client));
+        assertNull(Conscrypt.getApplicationProtocol(c.server));
     }
 
     @Test


### PR DESCRIPTION
This appears to do nothing in many diff tools, but it's removing a trailing
zero-width space character from the names of a bunch of method identifiers.
Zero-width spaces are valid identifier characters, so this actually changes
the identifier to what one would expect it should be, and to boot some
compilers can't handle zero-width spaces in identifiers.