### PR TITLE
Fix NullPointerException when calling setAlpnProtocols().

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -125,7 +125,7 @@ public abstract class OpenSSLSocketImpl extends ConscryptSocketBase {
     @Override
     @Deprecated
     public final void setAlpnProtocols(String[] alpnProtocols) {
-        setApplicationProtocols(alpnProtocols);
+        setApplicationProtocols(alpnProtocols == null ? EmptyArray.STRING : alpnProtocols);
     }
 
     @Deprecated
@@ -140,6 +140,6 @@ public abstract class OpenSSLSocketImpl extends ConscryptSocketBase {
     @Override
     @Deprecated
     public final void setAlpnProtocols(byte[] protocols) {
-        setApplicationProtocols(SSLUtils.decodeProtocols(protocols));
+        setApplicationProtocols(SSLUtils.decodeProtocols(protocols == null ? EmptyArray.BYTE : protocols));
     }
 }


### PR DESCRIPTION
setAlpnProtocols() (a Conscrypt-specific function) can be called with
null and treats it the same as an empty array, whereas the RI's definition
of setApplicationProtocols(), which is used for the same purpose, disallows
null.  Replace null with empty array when mapping from one to the other.