### PR TITLE
Fix some issues with the ChaCha20 implementation.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -1552,26 +1552,22 @@ static void NativeCrypto_chacha20_encrypt_decrypt(JNIEnv* env, jclass, jbyteArra
     JNI_TRACE("chacha20_encrypt_decrypt");
     ScopedByteArrayRO in(env, inBytes);
     if (in.get() == nullptr) {
-        conscrypt::jniutil::jniThrowNullPointerException(env, "Could not access input bytes");
-        JNI_TRACE("chacha20_encrypt_decrypt => threw exception");
+        JNI_TRACE("chacha20_encrypt_decrypt => threw exception: could not read input bytes");
         return;
     }
     ScopedByteArrayRW out(env, outBytes);
     if (out.get() == nullptr) {
-        conscrypt::jniutil::jniThrowNullPointerException(env, "Could not access output bytes");
-        JNI_TRACE("chacha20_encrypt_decrypt => threw exception");
+        JNI_TRACE("chacha20_encrypt_decrypt => threw exception: could not read output bytes");
         return;
     }
     ScopedByteArrayRO key(env, keyBytes);
     if (key.get() == nullptr) {
-        conscrypt::jniutil::jniThrowNullPointerException(env, "Could not access key bytes");
-        JNI_TRACE("chacha20_encrypt_decrypt => threw exception");
+        JNI_TRACE("chacha20_encrypt_decrypt => threw exception: could not read key bytes");
         return;
     }
     ScopedByteArrayRO nonce(env, nonceBytes);
     if (nonce.get() == nullptr) {
-        conscrypt::jniutil::jniThrowNullPointerException(env, "Could not access nonce bytes");
-        JNI_TRACE("chacha20_encrypt_decrypt => threw exception");
+        JNI_TRACE("chacha20_encrypt_decrypt => threw exception: could not read nonce bytes");
         return;
     }
 


### PR DESCRIPTION
First, ScopedByteArray* already throws NullPointerException if it can't
load the array, so throwing it again actually causes problems, because
you're not allowed to throw an exception while a different exception
is pending.  Just log that the exception was thrown and why.

Second, use OpenSSLCipher's key storage instead of keeping our own copy.
There's no need to keep redundant copies.

Third, implement reset() properly.  Only reset on final(), not on init(),
and don't clear the data from init() when resetting, only the
per-operation values.