### PR TITLE
Do not strip symbols from openjdk build artifacts.

### DIFF
--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -441,28 +441,19 @@ model {
             // Make sure we build and copy the native library to the output directory.
             compileJava.dependsOn "$copyTaskName"
 
-            if (osName == "linux") {
-                // Now define a task to extract debug symbols from the release binary.
-                def extractDebugSymbolsTaskName = "extractDebugSymbols${sourceSetName}"
-                task "${extractDebugSymbolsTaskName}"(type: Exec) {
-                    dependsOn binary.tasks.link
-                    commandLine "objcopy", "--only-keep-debug", binary.tasks.link.outputFile, "${binary.tasks.link.outputFile}.debuginfo"
+            // Now define a task to extract debug symbols from the release binary (linux only)
+            def extractDebugSymbolsTask = binary.tasks.taskName("extractDebugSymbols")
+            t.create(extractDebugSymbolsTask) {
+                dependsOn binary.tasks.link
+                doFirst {
+                    if (osName == 'linux') {
+                        ["objcopy", "--only-keep-debug", binary.tasks.link.outputFile, "${binary.tasks.link.outputFile}.debuginfo"].execute().waitForOrKill(60000)
+                        ["objcopy", "--strip-debug", binary.tasks.link.outputFile].execute().waitForOrKill(60000)
+                        ["objcopy", "--add-gnu-debuglink=${binary.tasks.link.outputFile}.debuginfo", binary.tasks.link.outputFile].execute().waitForOrKill(60000)
+                    }
                 }
-
-                def stripDebugSymbolsTaskName = "stripDebugSymbols${sourceSetName}"
-                task "${stripDebugSymbolsTaskName}"(type: Exec) {
-                    dependsOn extractDebugSymbolsTaskName
-                    commandLine "objcopy", "--only-keep-debug", binary.tasks.link.outputFile, "${binary.tasks.link.outputFile}.debuginfo"
-                }
-
-                def addDebugLinkTaskName = "addDebugLink${sourceSetName}"
-                task "${addDebugLinkTaskName}"(type: Exec) {
-                    dependsOn stripDebugSymbolsTaskName
-                    commandLine "objcopy", "--add-gnu-debuglink=${binary.tasks.link.outputFile}.debuginfo", binary.tasks.link.outputFile
-                }
-
-                binary.tasks.build.dependsOn addDebugLinkTaskName
             }
+            binary.tasks.build.dependsOn extractDebugSymbolsTask
         }
     }
 }

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -440,20 +440,6 @@ model {
 
             // Make sure we build and copy the native library to the output directory.
             compileJava.dependsOn "$copyTaskName"
-
-            // Now define a task to extract debug symbols from the release binary (linux only)
-            def extractDebugSymbolsTask = binary.tasks.taskName("extractDebugSymbols")
-            t.create(extractDebugSymbolsTask) {
-                dependsOn binary.tasks.link
-                doFirst {
-                    if (osName == 'linux') {
-                        ["objcopy", "--only-keep-debug", binary.tasks.link.outputFile, "${binary.tasks.link.outputFile}.debuginfo"].execute().waitForOrKill(60000)
-                        ["objcopy", "--strip-debug", binary.tasks.link.outputFile].execute().waitForOrKill(60000)
-                        ["objcopy", "--add-gnu-debuglink=${binary.tasks.link.outputFile}.debuginfo", binary.tasks.link.outputFile].execute().waitForOrKill(60000)
-                    }
-                }
-            }
-            binary.tasks.build.dependsOn extractDebugSymbolsTask
         }
     }
 }

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -440,18 +440,6 @@ model {
 
             // Make sure we build and copy the native library to the output directory.
             compileJava.dependsOn "$copyTaskName"
-
-            // Now define a task to strip the release binary (linux only)
-            def stripTask = binary.tasks.taskName("strip")
-            t.create(stripTask) {
-                dependsOn binary.tasks.link
-                doFirst {
-                    if (osName == 'linux') {
-                        ["strip", binary.tasks.link.outputFile].execute().waitForOrKill(1000)
-                    }
-                }
-            }
-            binary.tasks.build.dependsOn stripTask
         }
     }
 }

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -442,16 +442,15 @@ model {
             compileJava.dependsOn "$copyTaskName"
 
             // Now define a task to strip the release binary (linux only)
-            def stripTask = binary.tasks.taskName("strip")
-            t.create(stripTask) {
-                dependsOn binary.tasks.link
-                doFirst {
-                    if (osName == 'linux') {
-                        ["strip", binary.tasks.link.outputFile].execute().waitForOrKill(1000)
+            if (osName == 'linux' && (!rootProject.hasProperty('nostrip') ||
+                !rootProject.nostrip.toBoolean())) {
+                def stripTask = binary.tasks.taskName("strip")
+                    task "$stripTask"(type: Exec) {
+                        dependsOn binary.tasks.link
+                        commandLine "strip", "${binary.tasks.link.outputFile}"
                     }
-                }
+                binary.tasks.build.dependsOn stripTask
             }
-            binary.tasks.build.dependsOn stripTask
         }
     }
 }

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -443,7 +443,7 @@ model {
 
             // Now define a task to strip the release binary (linux only)
             if (osName == 'linux' && (!rootProject.hasProperty('nostrip') ||
-                !rootProject.nostrip.toBoolean())) {
+                    !rootProject.nostrip.toBoolean())) {
                 def stripTask = binary.tasks.taskName("strip")
                     task "$stripTask"(type: Exec) {
                         dependsOn binary.tasks.link

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -440,6 +440,18 @@ model {
 
             // Make sure we build and copy the native library to the output directory.
             compileJava.dependsOn "$copyTaskName"
+
+            // Now define a task to strip the release binary (linux only)
+            def stripTask = binary.tasks.taskName("strip")
+            t.create(stripTask) {
+                dependsOn binary.tasks.link
+                doFirst {
+                    if (osName == 'linux') {
+                        ["strip", binary.tasks.link.outputFile].execute().waitForOrKill(1000)
+                    }
+                }
+            }
+            binary.tasks.build.dependsOn stripTask
         }
     }
 }

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -441,19 +441,28 @@ model {
             // Make sure we build and copy the native library to the output directory.
             compileJava.dependsOn "$copyTaskName"
 
-            // Now define a task to extract debug symbols from the release binary (linux only)
-            def extractDebugSymbolsTask = binary.tasks.taskName("extractDebugSymbols")
-            t.create(extractDebugSymbolsTask) {
-                dependsOn binary.tasks.link
-                doFirst {
-                    if (osName == 'linux') {
-                        ["objcopy", "--only-keep-debug", binary.tasks.link.outputFile, "${binary.tasks.link.outputFile}.debuginfo"].execute().waitForOrKill(60000)
-                        ["objcopy", "--strip-debug", binary.tasks.link.outputFile].execute().waitForOrKill(60000)
-                        ["objcopy", "--add-gnu-debuglink=${binary.tasks.link.outputFile}.debuginfo", binary.tasks.link.outputFile].execute().waitForOrKill(60000)
-                    }
+            if (osName == "linux") {
+                // Now define a task to extract debug symbols from the release binary.
+                def extractDebugSymbolsTaskName = "extractDebugSymbols${sourceSetName}"
+                task "${extractDebugSymbolsTaskName}"(type: Exec) {
+                    dependsOn binary.tasks.link
+                    commandLine "objcopy", "--only-keep-debug", binary.tasks.link.outputFile, "${binary.tasks.link.outputFile}.debuginfo"
                 }
+
+                def stripDebugSymbolsTaskName = "stripDebugSymbols${sourceSetName}"
+                task "${stripDebugSymbolsTaskName}"(type: Exec) {
+                    dependsOn extractDebugSymbolsTaskName
+                    commandLine "objcopy", "--only-keep-debug", binary.tasks.link.outputFile, "${binary.tasks.link.outputFile}.debuginfo"
+                }
+
+                def addDebugLinkTaskName = "addDebugLink${sourceSetName}"
+                task "${addDebugLinkTaskName}"(type: Exec) {
+                    dependsOn stripDebugSymbolsTaskName
+                    commandLine "objcopy", "--add-gnu-debuglink=${binary.tasks.link.outputFile}.debuginfo", binary.tasks.link.outputFile
+                }
+
+                binary.tasks.build.dependsOn addDebugLinkTaskName
             }
-            binary.tasks.build.dependsOn extractDebugSymbolsTask
         }
     }
 }

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -440,6 +440,20 @@ model {
 
             // Make sure we build and copy the native library to the output directory.
             compileJava.dependsOn "$copyTaskName"
+
+            // Now define a task to extract debug symbols from the release binary (linux only)
+            def extractDebugSymbolsTask = binary.tasks.taskName("extractDebugSymbols")
+            t.create(extractDebugSymbolsTask) {
+                dependsOn binary.tasks.link
+                doFirst {
+                    if (osName == 'linux') {
+                        ["objcopy", "--only-keep-debug", binary.tasks.link.outputFile, "${binary.tasks.link.outputFile}.debuginfo"].execute().waitForOrKill(60000)
+                        ["objcopy", "--strip-debug", binary.tasks.link.outputFile].execute().waitForOrKill(60000)
+                        ["objcopy", "--add-gnu-debuglink=${binary.tasks.link.outputFile}.debuginfo", binary.tasks.link.outputFile].execute().waitForOrKill(60000)
+                    }
+                }
+            }
+            binary.tasks.build.dependsOn extractDebugSymbolsTask
         }
     }
 }


### PR DESCRIPTION
It sounds like the only value symbol stripping provides in this context is reduced binary size.

I recently ran into an issue where it would have been _very_ helpful to have had at least a symbol table around, but everything is currently stripped from the binary during the build process.

There are certainly situations where the stripping is necessary (e.g., when building for Android), but this is also applied to the OpenJDK build. If stripping is still desirable in some cases, then I suggest using some sort of build flag to toggle this (ideally setting unstripped as the default).