### PR TITLE
Put back sdk_version: "current"

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -252,8 +252,7 @@ java_library_static {
 
     libs: ["conscrypt-stubs"],
 
-    // TODO(ccross): put this back to "current" once it is supported
-    sdk_version: "26",
+    sdk_version: "current",
     java_version: "1.7",
 }
 
@@ -263,8 +262,7 @@ java_library_static {
 
     srcs: ["android-stub/src/main/java/**/*.java"],
 
-    // TODO(ccross): put this back to "current" once it is supported
-    sdk_version: "26",
+    sdk_version: "current",
     java_version: "1.7",
 }
 


### PR DESCRIPTION
The workaround is handled in soong now.

Test: m checkbuild
Change-Id: I3b83f44b51b2d49c21e28d0e250bd44492c10b9b
Signed-off-by: Adam Vartanian <flooey@google.com>