### PR TITLE
Move jar signing to be part of signArchives.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,14 @@ subprojects {
         sign configurations.archives
     }
 
+    signArchives.doFirst {
+        configurations.archives.allArtifacts.each {
+            if (it.type == 'jar' && it.classifier != 'sources' && it.classifier != 'javadoc') {
+                signJar(it.file.absolutePath)
+            }
+        }
+    }
+
     if (!androidProject) {
         sourceCompatibility = JavaVersion.VERSION_1_6
         targetCompatibility = JavaVersion.VERSION_1_6
@@ -191,13 +199,6 @@ subprojects {
 
         uploadArchives.repositories.mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-            beforeDeployment {
-                configurations.archives.allArtifacts.each {
-                    if (it.type == 'jar' && it.classifier != 'sources' && it.classifier != 'javadoc') {
-                        signJar(it.file.absolutePath)
-                    }
-                }
-            }
             String stagingUrl
             if (rootProject.hasProperty('repositoryId')) {
                 stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +


### PR DESCRIPTION
When done immediately before deployment, we sign the jar (and thus modify
it) after the GPG signature has been generated, which causes the signatures
to fail.  This puts the jar signature into the jar first, then generates
the GPG signatures, so everything verifies properly.