### PR TITLE
Check an X509-like structure submember for nullness.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -5481,7 +5481,7 @@ static jbyteArray NativeCrypto_X509_REVOKED_get_ext_oid(JNIEnv* env, jclass, jlo
             env, revoked, oidString);
 }
 
-template <typename T, int (*get_ext_by_critical_func)(T*, int, int),
+template <typename T, typename C, C T::*member, int (*get_ext_by_critical_func)(T*, int, int),
           X509_EXTENSION* (*get_ext_func)(T*, int)>
 static jobjectArray get_X509Type_ext_oids(JNIEnv* env, jlong x509Ref, jint critical) {
     T* x509 = reinterpret_cast<T*>(static_cast<uintptr_t>(x509Ref));
@@ -5490,6 +5490,11 @@ static jobjectArray get_X509Type_ext_oids(JNIEnv* env, jlong x509Ref, jint criti
     if (x509 == nullptr) {
         conscrypt::jniutil::jniThrowNullPointerException(env, "x509 == null");
         JNI_TRACE("get_X509Type_ext_oids(%p, %d) => x509 == null", x509, critical);
+        return nullptr;
+    }
+    if (x509->*member == nullptr) {
+        conscrypt::jniutil::jniThrowNullPointerException(env, "x509->*member == null");
+        JNI_TRACE("get_X509Type_ext_oids(%p, %d) => x509->*member == null", x509, critical);
         return nullptr;
     }
 
@@ -5530,24 +5535,24 @@ static jobjectArray NativeCrypto_get_X509_ext_oids(JNIEnv* env, jclass, jlong x5
                                                    jint critical) {
     // NOLINTNEXTLINE(runtime/int)
     JNI_TRACE("get_X509_ext_oids(0x%llx, %d)", (long long)x509Ref, critical);
-    return get_X509Type_ext_oids<X509, X509_get_ext_by_critical, X509_get_ext>(env, x509Ref,
-                                                                               critical);
+    return get_X509Type_ext_oids<X509, decltype(X509::cert_info), &X509::cert_info,
+            X509_get_ext_by_critical, X509_get_ext>(env, x509Ref, critical);
 }
 
 static jobjectArray NativeCrypto_get_X509_CRL_ext_oids(JNIEnv* env, jclass, jlong x509CrlRef,
                                                        jint critical) {
     // NOLINTNEXTLINE(runtime/int)
     JNI_TRACE("get_X509_CRL_ext_oids(0x%llx, %d)", (long long)x509CrlRef, critical);
-    return get_X509Type_ext_oids<X509_CRL, X509_CRL_get_ext_by_critical, X509_CRL_get_ext>(
-            env, x509CrlRef, critical);
+    return get_X509Type_ext_oids<X509_CRL, decltype(X509_CRL::crl), &X509_CRL::crl,
+            X509_CRL_get_ext_by_critical, X509_CRL_get_ext>(env, x509CrlRef, critical);
 }
 
 static jobjectArray NativeCrypto_get_X509_REVOKED_ext_oids(JNIEnv* env, jclass,
                                                            jlong x509RevokedRef, jint critical) {
     // NOLINTNEXTLINE(runtime/int)
     JNI_TRACE("get_X509_CRL_ext_oids(0x%llx, %d)", (long long)x509RevokedRef, critical);
-    return get_X509Type_ext_oids<X509_REVOKED, X509_REVOKED_get_ext_by_critical,
-                                 X509_REVOKED_get_ext>(env, x509RevokedRef, critical);
+    return get_X509Type_ext_oids<X509_REVOKED, decltype(X509_REVOKED::extensions), &X509_REVOKED::extensions,
+            X509_REVOKED_get_ext_by_critical, X509_REVOKED_get_ext>(env, x509RevokedRef, critical);
 }
 
 /**


### PR DESCRIPTION
We've seen very sporadic crashes due to null pointer dereferencing
somewhere inside X509_get_ext_by_critical, and this is the only way I
can see that that can happen.  X509_get_ext_by_critical passes
x->cert_info->extensions to X509v3_get_ext_by_critical, and that's the
only pointer that isn't explicitly checked for nullness.  These
crashes are incredibly rare, so it's not out of the realm of
possibility for them to be memory corruption or something, but better
safe than sorry.