### PR TITLE
Cache session values when SSL is being closed.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1622,6 +1622,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     private void closeAndFreeResources() {
         state = STATE_CLOSED;
         if (!ssl.isClosed()) {
+            sslSession.cacheCurrentValues();
             ssl.close();
             networkBio.close();
         }

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -978,6 +978,7 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
 
     private void free() {
         if (!ssl.isClosed()) {
+            sslSession.cacheCurrentValues();
             ssl.close();
             Platform.closeGuardClose(guard);
         }


### PR DESCRIPTION
There's no documentation on what the behavior of an SSLSession object
should be after the connection it's associated with has been closed,
but callers reasonably expect that it remains callable, especially
since the connection can be closed by the remote peer without notice.
This makes the ActiveSession cache any values it extracts from the SSL
object locally before the object is freed, so that the getters can
continue to be called.  Prior to this, calling any getter whose value
wasn't already cached would result in a NullPointerException.

Fixes #379.