### PR TITLE
Check if an exception is pending before throwing another one.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -323,7 +323,9 @@ bool throwExceptionIfNecessary(JNIEnv* env, CONSCRYPT_UNUSED const char* locatio
     unsigned long error = ERR_get_error_line_data(&file, &line, &data, &flags);
     bool result = false;
 
-    if (error != 0) {
+    // If there's an error from BoringSSL it may have been caused by an exception in Java code, so
+    // ensure there isn't a pending exception before we throw a new one.
+    if ((error != 0) && !env->ExceptionCheck()) {
         char message[256];
         ERR_error_string_n(error, message, sizeof(message));
         int library = ERR_GET_LIB(error);


### PR DESCRIPTION
This can occur if a BoringSSL call results in a socket read from a
Java socket which throws an exception.  Since throwing an exception
when another exception is pending causes the process to crash, just
let the other exception propagate out of the function.