### PR TITLE
Don't return Java7ExtendedSSLSession on Android.

### DIFF
--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -856,9 +856,6 @@ final class Platform {
         if (Build.VERSION.SDK_INT >= 24) {
             return new Java8ExtendedSSLSession(sslSession);
         }
-        if (Build.VERSION.SDK_INT >= 19) {
-            return new Java7ExtendedSSLSession(sslSession);
-        }
 
         return sslSession;
     }


### PR DESCRIPTION
It turns out that ExtendedSSLSession wasn't available until API 24, so
the only API levels that support ExtendedSSLSession also support Java
8.