### PR TITLE
Fix error detection in RSA_generate_key_ex.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -1319,14 +1319,14 @@ static jlong NativeCrypto_RSA_generate_key_ex(JNIEnv* env, jclass, jint modulusB
         return 0;
     }
 
-    if (RSA_generate_key_ex(rsa.get(), modulusBits, e.get(), nullptr) < 0) {
-        conscrypt::jniutil::throwExceptionIfNecessary(env, "RSA_generate_key_ex");
+    if (RSA_generate_key_ex(rsa.get(), modulusBits, e.get(), nullptr) != 1) {
+        conscrypt::jniutil::throwExceptionIfNecessary(env, "RSA_generate_key_ex failed");
         return 0;
     }
 
     bssl::UniquePtr<EVP_PKEY> pkey(EVP_PKEY_new());
     if (pkey.get() == nullptr) {
-        conscrypt::jniutil::jniThrowRuntimeException(env, "RSA_generate_key_ex failed");
+        conscrypt::jniutil::jniThrowOutOfMemory(env, "Unable to allocate RSA key");
         return 0;
     }
 


### PR DESCRIPTION
RSA_generate_key_ex returns 1 on success and 0 on failure, so we could
never detect failures that happened.  Also update an allocation
failure to throw OutOfMemoryError instead of RuntimeException.