### PR TITLE
Throw SSLException from newSsl().

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -165,12 +165,8 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     }
 
     private static NativeSsl newSsl(SSLParametersImpl sslParameters,
-            ConscryptFileDescriptorSocket engine) {
-        try {
-            return NativeSsl.newInstance(sslParameters, engine, engine, engine);
-        } catch (SSLException e) {
-            throw new RuntimeException(e);
-        }
+            ConscryptFileDescriptorSocket engine) throws SSLException {
+        return NativeSsl.newInstance(sslParameters, engine, engine, engine);
     }
 
     /**


### PR DESCRIPTION
The constructors already declare that they throw IOException, so I
don't see why this should be a problem.

Fixes #399.