### PR TITLE
A few small fixes in prep for adding tests.

### DIFF
--- a/common/src/main/java/org/conscrypt/KeyGeneratorImpl.java
+++ b/common/src/main/java/org/conscrypt/KeyGeneratorImpl.java
@@ -178,4 +178,17 @@ public abstract class KeyGeneratorImpl extends KeyGeneratorSpi {
             }
         }
     }
+
+    public static final class ARC4 extends KeyGeneratorImpl {
+        public ARC4() {
+            super("ARC4", 128);
+        }
+
+        @Override
+        protected void checkKeySize(int keySize) {
+            if (keySize < 40 || 2048 < keySize) {
+                throw new InvalidParameterException("Key size must be between 40 and 2048 bits");
+            }
+        }
+    }
 }

--- a/common/src/main/java/org/conscrypt/OpenSSLCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipher.java
@@ -70,7 +70,16 @@ public abstract class OpenSSLCipher extends CipherSpi {
     enum Padding {
         NOPADDING,
         PKCS5PADDING,
-        ISO10126PADDING,
+        PKCS7PADDING,
+        ;
+
+        public static Padding getNormalized(String value) {
+            Padding p = Padding.valueOf(value);
+            if (p == PKCS7PADDING) {
+                return PKCS5PADDING;
+            }
+            return p;
+        }
     }
 
     /**
@@ -194,7 +203,7 @@ public abstract class OpenSSLCipher extends CipherSpi {
         final String paddingStrUpper = paddingStr.toUpperCase(Locale.US);
         final Padding padding;
         try {
-            padding = Padding.valueOf(paddingStrUpper);
+            padding = Padding.getNormalized(paddingStrUpper);
         } catch (IllegalArgumentException e) {
             NoSuchPaddingException newE = new NoSuchPaddingException("No such padding: "
                     + paddingStr);

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -475,7 +475,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         @Override
         protected void engineSetPadding(String padding) throws NoSuchPaddingException {
             String paddingUpper = padding.toUpperCase(Locale.US);
-            if (paddingUpper.equals("OAEPPadding")) {
+            if (paddingUpper.equals("OAEPPADDING")) {
                 this.padding = NativeConstants.RSA_PKCS1_OAEP_PADDING;
                 return;
             }

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -115,6 +115,10 @@ public final class OpenSSLProvider extends Provider {
         put("Alg.Alias.MessageDigest.1.2.840.113549.2.5", "MD5");
 
         /* == KeyGenerators == */
+        put("KeyGenerator.ARC4", PREFIX + "KeyGeneratorImpl$ARC4");
+        put("Alg.Alias.KeyGenerator.RC4", "ARC4");
+        put("Alg.Alias.KeyGenerator.1.2.840.113549.3.4", "ARC4");
+
         put("KeyGenerator.AES", PREFIX + "KeyGeneratorImpl$AES");
 
         put("KeyGenerator.ChaCha20", PREFIX + "KeyGeneratorImpl$ChaCha20");


### PR DESCRIPTION
Add ARC4 KeyGenerator.  Upcoming tests assume that every cipher also
has a KeyGenerator available, so provide one.

Add support for PKCS7PADDING constant and remove ISO10126PADDING.  We
never use the latter, and the former is used in an alias.  When a user
requests an alias, OpenJDK provides the alias name in the
engineSetPadding call, whereas Android provides the concrete name, so
make sure we can handle either.

Fix a problem where engineSetPadding would never recognize OAEPPadding
when passed to OpenSSLCipherRSA.