### PR TITLE
Fix NullPointerException when IOException is thrown during socket creation

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -375,6 +375,12 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
     public final void close() throws IOException {
         // TODO: Close SSL sockets using a background thread so they close gracefully.
 
+        if (stateLock == null) {
+            // close() has been called before we've initialized the socket, so just
+            // return.
+            return;
+        }
+
         synchronized (stateLock) {
             if (state == STATE_CLOSED) {
                 // close() has already been called, so do nothing and return.

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -938,6 +938,12 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
         SSLInputStream sslInputStream;
         SSLOutputStream sslOutputStream;
 
+        if (ssl == null) {
+            // close() has been called before we've initialized the socket, so just
+            // return.
+            return;
+        }
+
         synchronized (ssl) {
             if (state == STATE_CLOSED) {
                 // close() has already been called, so do nothing and return.

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -2738,14 +2738,12 @@ public class SSLSocketTest {
     @Test
     public void test_SSLSocket_CloseCleanlyOnConstructorFailure() throws Exception {
         TestSSLContext c = TestSSLContext.create();
-        Exception ex = null;
         try {
-            SSLSocket client =
-                (SSLSocket) c.clientContext.getSocketFactory().createSocket(c.host, 1);
-        } catch (ConnectException e) {
-            ex = e;
+            c.clientContext.getSocketFactory().createSocket(c.host, 1);
+            fail();
+        } catch (ConnectException ignored) {
+            // Ignored.
         }
-        assumeNoException(ex);
     }
 
     private static void setWriteTimeout(Object socket, int timeout) {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -39,6 +39,7 @@ import java.io.OutputStream;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
+import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -2730,6 +2731,21 @@ public class SSLSocketTest {
                 pair.server.close();
             }
         }
+    }
+
+    // Tests that a socket will close cleanly even if it fails to create due to an
+    // internal IOException
+    @Test
+    public void test_SSLSocket_CloseCleanlyOnConstructorFailure() throws Exception {
+        TestSSLContext c = TestSSLContext.create();
+        Exception ex = null;
+        try {
+            SSLSocket client =
+                (SSLSocket) c.clientContext.getSocketFactory().createSocket(c.host, 0);
+        } catch (ConnectException e) {
+            ex = e;
+        }
+        assumeNoException(ex);
     }
 
     private static void setWriteTimeout(Object socket, int timeout) {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -2741,7 +2741,7 @@ public class SSLSocketTest {
         Exception ex = null;
         try {
             SSLSocket client =
-                (SSLSocket) c.clientContext.getSocketFactory().createSocket(c.host, 0);
+                (SSLSocket) c.clientContext.getSocketFactory().createSocket(c.host, 1);
         } catch (ConnectException e) {
             ex = e;
         }


### PR DESCRIPTION
This fixes the issue mentioned in #404 

Failing tests before fix:
```
:conscrypt-openjdk-integ-tests:testEngineSocket

org.conscrypt.ConscryptSuite > org.conscrypt.javax.net.ssl.SSLSocketTest.test_SSLSocket_CloseCleanlyOnConstructorFailure FAILED
    java.lang.NullPointerException at SSLSocketTest.java:2741

200 tests completed, 1 failed, 3 skipped
:conscrypt-openjdk-integ-tests:testEngineSocket FAILED
```


```
org.conscrypt.ConscryptSuite > org.conscrypt.javax.net.ssl.SSLSocketTest.test_SSLSocket_CloseCleanlyOnConstructorFailure FAILED
    java.lang.NullPointerException
        at org.conscrypt.ConscryptFileDescriptorSocket.close(ConscryptFileDescriptorSocket.java:947)
        at java.net.Socket.<init>(Socket.java:437)
        at java.net.Socket.<init>(Socket.java:244)
        at javax.net.ssl.SSLSocket.<init>(SSLSocket.java:196)
        at org.conscrypt.AbstractConscryptSocket.<init>(AbstractConscryptSocket.java:41)
        at org.conscrypt.ConscryptSocketBase.<init>(ConscryptSocketBase.java:101)
        at org.conscrypt.OpenSSLSocketImpl.<init>(OpenSSLSocketImpl.java:44)
        at org.conscrypt.ConscryptFileDescriptorSocket.<init>(ConscryptFileDescriptorSocket.java:137)
        at org.conscrypt.Java8FileDescriptorSocket.<init>(Java8FileDescriptorSocket.java:30)
        at org.conscrypt.Platform.createFileDescriptorSocket(Platform.java:415)
        at org.conscrypt.OpenSSLSocketFactoryImpl.createSocket(OpenSSLSocketFactoryImpl.java:126)
        at org.conscrypt.javax.net.ssl.SSLSocketTest.test_SSLSocket_CloseCleanlyOnConstructorFailure(SSLSocketTest.java:2744)
<===========--> 88% EXECUTING
```