### PR TITLE
Use std:atomic<bool> instead of "volatile int".

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -8022,7 +8022,7 @@ static void NativeCrypto_SSL_interrupt(JNIEnv* env, jclass, jlong ssl_address, j
      */
     AppData* appData = toAppData(ssl);
     if (appData != nullptr) {
-        appData->aliveAndKicking = 0;
+        appData->aliveAndKicking = false;
 
         // At most two threads can be waiting.
         sslNotify(appData);


### PR DESCRIPTION
The usage of volatile wasn't necessarily correct on multi-core systems,
as the (now removed) comment used to state. Use std::atomic instead.

Note that we can't use our existing mutex without fairly invasive
changes to extend its scope, which seem unnecessary and may be
infeasible because we wouldn't want SSL_interrupt to have to acquire
the lock before it can notify other threads that they have been
interrupted.