### PR TITLE
Clean up exception throwing in native code.

### DIFF
--- a/common/src/jni/main/include/conscrypt/jniutil.h
+++ b/common/src/jni/main/include/conscrypt/jniutil.h
@@ -146,25 +146,28 @@ extern bool isGetByteArrayElementsLikelyToReturnACopy(size_t size);
  *
  * Returns 0 on success, nonzero if something failed (e.g. the exception
  * class couldn't be found, so *an* exception will still be pending).
- *
- * Currently aborts the VM if it can't throw the exception.
  */
-extern int jniThrowException(JNIEnv* env, const char* className, const char* msg);
+extern int throwException(JNIEnv* env, const char* className, const char* msg);
 
 /**
  * Throw a java.lang.RuntimeException, with an optional message.
  */
-extern int jniThrowRuntimeException(JNIEnv* env, const char* msg);
+extern int throwRuntimeException(JNIEnv* env, const char* msg);
+
+/**
+ * Throw a java.lang.AssertionError, with an optional message.
+ */
+extern int throwAssertionError(JNIEnv* env, const char* msg);
 
 /*
  * Throw a java.lang.NullPointerException, with an optional message.
  */
-extern int jniThrowNullPointerException(JNIEnv* env, const char* msg);
+extern int throwNullPointerException(JNIEnv* env, const char* msg);
 
 /**
  * Throws a OutOfMemoryError with the given string as a message.
  */
-extern int jniThrowOutOfMemory(JNIEnv* env, const char* message);
+extern int throwOutOfMemory(JNIEnv* env, const char* message);
 
 /**
  * Throws a BadPaddingException with the given string as a message.
@@ -219,14 +222,13 @@ extern int throwForX509Error(JNIEnv* env, int reason, const char* message,
                              int (*defaultThrow)(JNIEnv*, const char*));
 
 /*
- * Checks this thread's OpenSSL error queue and throws a RuntimeException if
- * necessary.
- *
- * @return true if an exception was thrown, false if not.
+ * Checks this thread's OpenSSL error stack and throws an appropriate exception
+ * type based on the type of error found.  If no error is present, throws
+ * AssertionError.
  */
-extern bool throwExceptionIfNecessary(JNIEnv* env, const char* location,
-                                      int (*defaultThrow)(JNIEnv*,
-                                                          const char*) = jniThrowRuntimeException);
+extern void throwExceptionFromBoringSSLError(JNIEnv* env, const char* location,
+                                             int (*defaultThrow)(JNIEnv*,
+                                                                 const char*) = throwRuntimeException);
 
 /**
  * Throws an SocketTimeoutException with the given string as a message.

--- a/common/src/jni/unbundled/include/NetFd.h
+++ b/common/src/jni/unbundled/include/NetFd.h
@@ -31,7 +31,7 @@ class NetFd {
         mFd = conscrypt::jniutil::jniGetFDFromFileDescriptor(mEnv, mFileDescriptor);
         bool closed = (mFd == -1);
         if (closed) {
-            conscrypt::jniutil::jniThrowException(mEnv, "java/net/SocketException",
+            conscrypt::jniutil::throwException(mEnv, "java/net/SocketException",
                                                   "Socket closed");
         }
         return closed;

--- a/common/src/jni/unbundled/include/nativehelper/ScopedPrimitiveArray.h
+++ b/common/src/jni/unbundled/include/nativehelper/ScopedPrimitiveArray.h
@@ -31,7 +31,7 @@
         Scoped##NAME##ArrayRO(JNIEnv* env, PRIMITIVE_TYPE##Array javaArray)           \
             : mEnv(env), mJavaArray(javaArray), mRawArray(nullptr) {                  \
             if (mJavaArray == nullptr) {                                              \
-                conscrypt::jniutil::jniThrowNullPointerException(mEnv, nullptr);      \
+                conscrypt::jniutil::throwNullPointerException(mEnv, nullptr);      \
             } else {                                                                  \
                 mRawArray = mEnv->Get##NAME##ArrayElements(mJavaArray, nullptr);      \
             }                                                                         \
@@ -89,7 +89,7 @@ INSTANTIATE_SCOPED_PRIMITIVE_ARRAY_RO(jshort, Short);
         Scoped##NAME##ArrayRW(JNIEnv* env, PRIMITIVE_TYPE##Array javaArray)      \
             : mEnv(env), mJavaArray(javaArray), mRawArray(nullptr) {             \
             if (mJavaArray == nullptr) {                                         \
-                conscrypt::jniutil::jniThrowNullPointerException(mEnv, nullptr); \
+                conscrypt::jniutil::throwNullPointerException(mEnv, nullptr); \
             } else {                                                             \
                 mRawArray = mEnv->Get##NAME##ArrayElements(mJavaArray, nullptr); \
             }                                                                    \

--- a/common/src/jni/unbundled/include/nativehelper/ScopedUtfChars.h
+++ b/common/src/jni/unbundled/include/nativehelper/ScopedUtfChars.h
@@ -34,7 +34,7 @@ class ScopedUtfChars {
     ScopedUtfChars(JNIEnv* env, jstring s) : env_(env), string_(s) {
         if (s == nullptr) {
             utf_chars_ = nullptr;
-            conscrypt::jniutil::jniThrowNullPointerException(env, nullptr);
+            conscrypt::jniutil::throwNullPointerException(env, nullptr);
         } else {
             utf_chars_ = env->GetStringUTFChars(s, nullptr);
         }


### PR DESCRIPTION
Change throwExceptionIfNecessary to throwExceptionFromBoringSSLError.
The definition changes from throwing an exception if there's an error
on the stack to having a precondition of having an error on the stack.
This makes its behavior and the expected usage more clear (it always
results in an exception pending).  This also should let us know if
we're encountering return-failure-but-don't-stack-an-error situations
that we didn't know about.

Normalize function names to throwFooException.

Ensure that we always return immediately after throwing an exception.
Some call sites allowed the exception-throwing branch to fall through
to the return statement from a non-throwing branch, which is unclear,
since that return statement is useless, and runs the risk of
additional code being inserted after the exception.

Fixes #97.