### PR TITLE
Mark env as intentionally unused.

### DIFF
--- a/common/src/jni/main/include/conscrypt/jniutil.h
+++ b/common/src/jni/main/include/conscrypt/jniutil.h
@@ -294,7 +294,7 @@ private:
 
 #define CHECK_ERROR_QUEUE_ON_RETURN conscrypt::jniutil::ErrorQueueChecker __checker(env)
 #else
-#define CHECK_ERROR_QUEUE_ON_RETURN ((void)0)
+#define CHECK_ERROR_QUEUE_ON_RETURN UNUSED_ARGUMENT(env)
 #endif  // CONSCRYPT_CHECK_ERROR_QUEUE
 
 }  // namespace jniutil


### PR DESCRIPTION
When CHECK_ERROR_QUEUE_ON_RETURN is disabled, we need to inform the
compiler that we intended not to use env.