### PR TITLE
Revert "Throw SocketException on ERR_SSL_SYSCALL. (#430)"

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -7886,12 +7886,10 @@ static int sslRead(JNIEnv* env, SSL* ssl, jobject fdObject, jobject shc, char* b
             // A problem occurred during a system call, but this is not
             // necessarily an error.
             case SSL_ERROR_SYSCALL: {
-                // Connection closed without proper shutdown.  Throw a SocketException to
-                // indicate that the socket is closed.
+                // Connection closed without proper shutdown. Tell caller we
+                // have reached end-of-stream.
                 if (result == 0) {
-                    conscrypt::jniutil::throwException(env, "java/net/SocketException",
-                                                       "Socket closed");
-                    return THROWN_EXCEPTION;
+                    return -1;
                 }
 
                 // System call has been interrupted. Simply retry.


### PR DESCRIPTION
We've had reports from people that depended on "normal" connection
termination (such as in HTTP where the peer sends data and then closes
the TCP connection) returning -1 from read(), and in some cases this
change causes read() to throw a SocketException in that circumstance.

Rather than causing such a fundamental change in behavior, probably
better to just adjust the test to allow for a -1 return.

This reverts commit d84f6f57b216ab53dc3a71d30fd2252ce2208c13.