### PR TITLE
Use printf when tracing on non-Android platforms.

### DIFF
--- a/common/src/jni/main/include/conscrypt/trace.h
+++ b/common/src/jni/main/include/conscrypt/trace.h
@@ -17,6 +17,7 @@
 #ifndef CONSCRYPT_TRACE_H_
 #define CONSCRYPT_TRACE_H_
 
+#include <stdio.h>
 #include <cstddef>
 #include <conscrypt/macros.h>
 
@@ -64,6 +65,8 @@ extern const std::size_t kWithJniTraceDataChunkSize;
 }  // namespace trace
 }  // namespace conscrypt
 
+#ifdef ANDROID
+
 #define JNI_TRACE(...)                               \
     if (conscrypt::trace::kWithJniTrace) {           \
         ALOG(LOG_INFO, LOG_TAG "-jni", __VA_ARGS__); \
@@ -76,6 +79,27 @@ extern const std::size_t kWithJniTraceDataChunkSize;
     if (conscrypt::trace::kWithJniTraceKeys) {       \
         ALOG(LOG_INFO, LOG_TAG "-jni", __VA_ARGS__); \
     }
+
+#else
+
+#define JNI_TRACE(...)                               \
+    if (conscrypt::trace::kWithJniTrace) {           \
+        printf(__VA_ARGS__);                         \
+        printf("\n");                                \
+    }
+#define JNI_TRACE_MD(...)                            \
+    if (conscrypt::trace::kWithJniTraceMd) {         \
+        printf(__VA_ARGS__);                         \
+        printf("\n");                                \
+    }
+#define JNI_TRACE_KEYS(...)                          \
+    if (conscrypt::trace::kWithJniTraceKeys) {       \
+        printf(__VA_ARGS__);                         \
+        printf("\n");                                \
+    }
+
+#endif  // ANDROID
+
 #define JNI_TRACE_PACKET_DATA(ssl, dir, data, len)    \
     if (conscrypt::trace::kWithJniTracePackets) {     \
         debug_print_packet_data(ssl, dir, data, len); \


### PR DESCRIPTION
If the ALOG macro isn't defined, we define it in macros.h to just do
nothing, which means that enabling tracing on OpenJDK or other
platforms doesn't actually result in any tracing output.  On
non-Android platforms, we can make the tracing macros use printf()
instead of ALOG.