### PR TITLE
Add -std=c++11 to constants build.

### DIFF
--- a/constants/build.gradle
+++ b/constants/build.gradle
@@ -44,6 +44,8 @@ model {
             binaries.all {
                 if (toolChain in VisualCpp) {
                     cppCompiler.define "WIN32_LEAN_AND_MEAN"
+                } else if (toolChain in Clang || toolChain in Gcc) {
+                    cppCompiler.args "-std=c++11"
                 }
             }
         }


### PR DESCRIPTION
Some combinations of clang binary plus gcc headers result in errors on
the __float128 type, which is present in the gcc headers but
unsupported by clang.  Setting the -std flag makes clang set
preprocessor definitions such that the __float128 type doesn't show up
in the build.  We should be setting the desired standard library
anyway rather than leaving it up to the defaults.