### PR TITLE
Update short buffer handling.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -178,6 +178,12 @@ int throwIllegalBlockSizeException(JNIEnv* env, const char* message) {
             env, "javax/crypto/IllegalBlockSizeException", message);
 }
 
+int throwShortBufferException(JNIEnv* env, const char* message) {
+    JNI_TRACE("throwShortBufferException %s", message);
+    return conscrypt::jniutil::throwException(
+            env, "javax/crypto/ShortBufferException", message);
+}
+
 int throwNoSuchAlgorithmException(JNIEnv* env, const char* message) {
     JNI_TRACE("throwUnknownAlgorithmException %s", message);
     return conscrypt::jniutil::throwException(
@@ -241,6 +247,9 @@ int throwForCipherError(JNIEnv* env, int reason, const char* message,
         case CIPHER_R_BAD_KEY_LENGTH:
         case CIPHER_R_UNSUPPORTED_KEY_SIZE:
             return throwInvalidKeyException(env, message);
+            break;
+        case CIPHER_R_BUFFER_TOO_SMALL:
+            return throwShortBufferException(env, message);
             break;
     }
     return defaultThrow(env, message);

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Set;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.ShortBufferException;
 import javax.net.ssl.SSLException;
 import javax.security.auth.x500.X500Principal;
 import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
@@ -327,11 +328,11 @@ public final class NativeCrypto {
 
     static native int EVP_AEAD_CTX_seal(long evpAead, byte[] key, int tagLengthInBytes, byte[] out,
             int outOffset, byte[] nonce, byte[] in, int inOffset, int inLength, byte[] ad)
-            throws BadPaddingException, IndexOutOfBoundsException;
+            throws ShortBufferException, BadPaddingException, IndexOutOfBoundsException;
 
     static native int EVP_AEAD_CTX_open(long evpAead, byte[] key, int tagLengthInBytes, byte[] out,
             int outOffset, byte[] nonce, byte[] in, int inOffset, int inLength, byte[] ad)
-            throws BadPaddingException, IndexOutOfBoundsException;
+            throws ShortBufferException, BadPaddingException, IndexOutOfBoundsException;
 
     // --- HMAC functions ------------------------------------------------------
 

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherChaCha20.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherChaCha20.java
@@ -72,6 +72,9 @@ public class OpenSSLCipherChaCha20 extends OpenSSLCipher {
     @Override
     int updateInternal(byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset,
             int maximumLen) throws ShortBufferException {
+        if (inputLen > output.length - outputOffset) {
+            throw new ShortBufferException("Insufficient output space");
+        }
         int inputLenRemaining = inputLen;
         if (currentBlockConsumedBytes > 0) {
             // A previous operation ended with a partial block, so we need to encrypt using


### PR DESCRIPTION
This fixes a number of problems in Conscrypt's ciphers when they are
given an output buffer that is too small for the output.

We didn't specifically handle CIPHER_R_BUFFER_TOO_SMALL errors from
BoringSSL, so we threw RuntimeException on encountering them.  We
should be throwing ShortBufferException.

Raw ChaCha20 didn't check for a short buffer at all, so it just passed
the arrays down to native code, which could cause crashes or other
weird behavior.

EVP_AEAD ciphers used update() to only record data that needed to be
encrypted and then did the actual encrypting in doFinal().  This
combined with our implementation that implements doFinal() as a
combination of updateInternal() + doFinalInternal() led to a situation
where if the buffer passed to doFinal() was too small, the data would
get added to the buffer to be encrypted in updateInternal() and then
doFinalInternal() call would fail, which would mean a future call to
doFinal() with the same data would end up encrypting that data twice.
This call pattern is used by some internal CipherSpi methods from
OpenJDK, so you could see it in practice even if the caller did
nothing wrong.

Also add tests around short buffer handling.