### PR TITLE
A global default BufferAllocator may be configured

### DIFF
--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -371,6 +371,15 @@ public final class Conscrypt {
     }
 
     /**
+     * Configures the default {@link BufferAllocator} to be used by all future
+     * {@link SSLEngine} instances from this provider.
+     */
+    @ExperimentalApi
+    public static void setDefaultBufferAllocator(BufferAllocator bufferAllocator) {
+        ConscryptEngine.setDefaultBufferAllocator(bufferAllocator);
+    }
+
+    /**
      * This method enables Server Name Indication (SNI) and overrides the hostname supplied
      * during engine creation.
      *

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -111,8 +111,10 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
             new SSLEngineResult(CLOSED, NOT_HANDSHAKING, 0, 0);
     private static final ByteBuffer EMPTY = ByteBuffer.allocateDirect(0);
 
+    private static BufferAllocator defaultBufferAllocator = null;
+
     private final SSLParametersImpl sslParameters;
-    private BufferAllocator bufferAllocator;
+    private BufferAllocator bufferAllocator = defaultBufferAllocator;
 
     /**
      * A lazy-created direct buffer used as a bridge between heap buffers provided by the
@@ -208,6 +210,14 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Configures the default {@link BufferAllocator} to be used by all future
+     * {@link SSLEngine} instances from this provider.
+     */
+    static void setDefaultBufferAllocator(BufferAllocator bufferAllocator) {
+        defaultBufferAllocator = bufferAllocator;
     }
 
     @Override


### PR DESCRIPTION
It can be difficult to intercept all clients usage, causing
excessive direct memory allocation. This change allows applications
to pool direct memory more efficiently.