### PR TITLE
Remove warning that's triggered in BoringSSL in some builds.

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -21,7 +21,17 @@ add_definitions(-DANDROID
                 -DBORINGSSL_IMPLEMENTATION
                 -DOPENSSL_SMALL
                 -D_XOPEN_SOURCE=700
-                -Wno-unused-parameter)
+                -Wno-unused-parameter
+                # The following two lines are taken from BoringSSL's build file.  As written there:
+                #
+                # Clang's -Wtautological-constant-compare is far too aggressive and does not
+                # account for, say, wanting the same code to work on both 32-bit and 64-bit
+                # platforms.
+                #
+                # TODO: Remove these when the NDK no longer includes a version that has
+                # -Wtautological-constant-compare enabled as part of -Wall
+                -Wno-tautological-constant-compare
+                -Wtautological-constant-out-of-range-compare)
 
 if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
     set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -march=armv8-a+crypto")


### PR DESCRIPTION
The newest version of the NDK now includes this warning in -Wall, so
follow the practice of BoringSSL and disable it.  (Future versions of
clang remove it from -Wall, so we can remove this once one of those is
bundled with the NDK.)