### PR TITLE
Add support for token binding and EKM.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -7131,10 +7131,13 @@ static jbyteArray NativeCrypto_SSL_export_keying_material(JNIEnv* env, jclass, j
         return nullptr;
     }
     jbyteArray result = env->NewByteArray(static_cast<jsize>(num_bytes));
-    if (result != nullptr) {
-        const jbyte* src = reinterpret_cast<jbyte*>(out.get());
-        env->SetByteArrayRegion(result, 0, static_cast<jsize>(num_bytes), src);
+    if (result == nullptr) {
+        conscrypt::jniutil::throwSSLExceptionStr(env, "Could not create result array");
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_export_keying_material => could not create array", ssl);
+        return nullptr;
     }
+    const jbyte* src = reinterpret_cast<jbyte*>(out.get());
+    env->SetByteArrayRegion(result, 0, static_cast<jsize>(num_bytes), src);
     JNI_TRACE("ssl=%p NativeCrypto_SSL_export_keying_material => success", ssl);
     return result;
 }

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -7048,6 +7048,97 @@ static jbyteArray NativeCrypto_SSL_get_tls_unique(JNIEnv* env, jclass, jlong ssl
     return byteArray.release();
 }
 
+static void NativeCrypto_SSL_set_token_binding_params(JNIEnv* env, jclass, jlong ssl_address,
+        CONSCRYPT_UNUSED jobject ssl_holder, jintArray params) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_set_token_binding_params", ssl);
+    if (ssl == nullptr) {
+        return;
+    }
+    ScopedIntArrayRO paramsValues(env, params);
+    int ret;
+    if (paramsValues.get() == nullptr) {
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_set_token_binding_params params==null", ssl);
+        ret = SSL_set_token_binding_params(ssl, nullptr, 0);
+    } else {
+        uint8_t paramsBytes[paramsValues.size()];
+        for (int i = 0; i < paramsValues.size(); i++) {
+            paramsBytes[i] = static_cast<uint8_t>(paramsValues[i]);
+        }
+        ret = SSL_set_token_binding_params(ssl, paramsBytes, paramsValues.size());
+    }
+
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_set_token_binding_params => %d", ssl, ret);
+
+    if (!ret) {
+        conscrypt::jniutil::throwSSLExceptionStr(env, "Could not set token binding parameters");
+        ERR_clear_error();
+    }
+}
+
+static int NativeCrypto_SSL_get_token_binding_params(JNIEnv* env, jclass, jlong ssl_address,
+        CONSCRYPT_UNUSED jobject ssl_holder) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_get_token_binding_params", ssl);
+    if (ssl == nullptr) {
+        return 0;
+    }
+    int ret;
+    if (!SSL_is_token_binding_negotiated(ssl)) {
+        ret = -1;
+    } else {
+        ret = SSL_get_negotiated_token_binding_param(ssl);
+    }
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_set_token_binding_params => %d", ssl, ret);
+    return ret;
+}
+
+static jbyteArray NativeCrypto_SSL_export_keying_material(JNIEnv* env, jclass, jlong ssl_address,
+        CONSCRYPT_UNUSED jobject ssl_holder, jbyteArray label, jbyteArray context, jint num_bytes) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_export_keying_material", ssl);
+    if (ssl == nullptr) {
+        return nullptr;
+    }
+    ScopedByteArrayRO labelBytes(env, label);
+    if (labelBytes.get() == nullptr) {
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_export_keying_material label == null => exception", ssl);
+        return nullptr;
+    }
+    uint8_t out[num_bytes];
+    int ret;
+    if (context == nullptr) {
+        ret = SSL_export_keying_material(ssl, out, num_bytes,
+                        reinterpret_cast<const char*>(labelBytes.get()), labelBytes.size(),
+                        nullptr, 0, 0);
+    } else {
+        ScopedByteArrayRO contextBytes(env, context);
+        if (contextBytes.get() == nullptr) {
+            JNI_TRACE("ssl=%p NativeCrypto_SSL_export_keying_material context == null => exception", ssl);
+            return nullptr;
+        }
+        ret = SSL_export_keying_material(ssl, out, num_bytes,
+                        reinterpret_cast<const char*>(labelBytes.get()), labelBytes.size(),
+                        reinterpret_cast<const uint8_t*>(contextBytes.get()), contextBytes.size(), 1);
+    }
+    if (!ret) {
+        conscrypt::jniutil::throwExceptionFromBoringSSLError(env, "SSL_export_keying_material",
+                conscrypt::jniutil::throwSSLExceptionStr);
+        JNI_TRACE("ssl=%p NativeCrypto_SSL_export_keying_material => exception", ssl);
+        return nullptr;
+    }
+    jbyteArray result = env->NewByteArray(static_cast<jsize>(num_bytes));
+    if (result != nullptr) {
+        const jbyte* src = reinterpret_cast<jbyte*>(out);
+        env->SetByteArrayRegion(result, 0, static_cast<jsize>(num_bytes), src);
+    }
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_export_keying_material => success", ssl);
+    return result;
+}
+
 static void NativeCrypto_SSL_use_psk_identity_hint(JNIEnv* env, jclass, jlong ssl_address, CONSCRYPT_UNUSED jobject ssl_holder,
                                                    jstring identityHintJava) {
     CHECK_ERROR_QUEUE_ON_RETURN;
@@ -9956,6 +10047,9 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(SSL_get_ocsp_response, "(J" REF_SSL ")[B"),
         CONSCRYPT_NATIVE_METHOD(SSL_set_ocsp_response, "(J" REF_SSL "[B)V"),
         CONSCRYPT_NATIVE_METHOD(SSL_get_tls_unique, "(J" REF_SSL ")[B"),
+        CONSCRYPT_NATIVE_METHOD(SSL_set_token_binding_params, "(J" REF_SSL "[I)V"),
+        CONSCRYPT_NATIVE_METHOD(SSL_get_token_binding_params, "(J" REF_SSL ")I"),
+        CONSCRYPT_NATIVE_METHOD(SSL_export_keying_material, "(J" REF_SSL "[B[BI)[B"),
         CONSCRYPT_NATIVE_METHOD(SSL_use_psk_identity_hint, "(J" REF_SSL "Ljava/lang/String;)V"),
         CONSCRYPT_NATIVE_METHOD(set_SSL_psk_client_callback_enabled, "(J" REF_SSL "Z)V"),
         CONSCRYPT_NATIVE_METHOD(set_SSL_psk_server_callback_enabled, "(J" REF_SSL "Z)V"),

--- a/common/src/main/java/org/conscrypt/AbstractConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptEngine.java
@@ -164,4 +164,40 @@ abstract class AbstractConscryptEngine extends SSLEngine {
      * has not yet completed or this connection is closed.
      */
     abstract byte[] getTlsUnique();
+
+    /**
+     * Enables token binding parameter negotiation on this engine, or disables it if an
+     * empty set of parameters are provided.
+     *
+     * <p>This method needs to be invoked before the handshake starts.
+     *
+     * @param params a list of Token Binding key parameters in descending order of preference,
+     * as described in draft-ietf-tokbind-negotiation-09.
+     * @throws IllegalStateException if the handshake has already started.
+     * @throws SSLException if the setting could not be applied.
+     */
+    abstract void setTokenBindingParams(int... params) throws SSLException;
+
+    /**
+     * Returns the token binding parameters that were negotiated during the handshake, or -1 if
+     * token binding parameters were not negotiated, the handshake has not yet completed,
+     * or the connection has been closed.
+     */
+    abstract int getTokenBindingParams();
+
+    /**
+     * Exports a value derived from the TLS master secret as described in RFC 5705.
+     *
+     * @param label the label to use in calculating the exported value.  This must be
+     * an ASCII-only string.
+     * @param context the application-specific context value to use in calculating the
+     * exported value.  This may be {@code null} to use no application context, which is
+     * treated differently than an empty byte array.
+     * @param length the number of bytes of keying material to return.
+     * @return a value of the specified length, or {@code null} if the handshake has not yet
+     * completed or the connection has been closed.
+     * @throws SSLException if the value could not be exported.
+     */
+    abstract byte[] exportKeyingMaterial(String label, byte[] context, int length)
+            throws SSLException;
 }

--- a/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
@@ -217,4 +217,40 @@ abstract class AbstractConscryptSocket extends SSLSocket {
      * has not yet completed or this connection is closed.
      */
     abstract byte[] getTlsUnique();
+
+    /**
+     * Enables token binding parameter negotiation on this socket, or disables it if an
+     * empty set of parameters are provided.
+     *
+     * <p>This method needs to be invoked before the handshake starts.
+     *
+     * @param params a list of Token Binding key parameters in descending order of preference,
+     * as described in draft-ietf-tokbind-negotiation-09.
+     * @throws IllegalStateException if the handshake has already started.
+     * @throws SSLException if the setting could not be applied.
+     */
+    abstract void setTokenBindingParams(int... params) throws SSLException;
+
+    /**
+     * Returns the token binding parameters that were negotiated during the handshake, or -1 if
+     * token binding parameters were not negotiated, the handshake has not yet completed,
+     * or the connection has been closed.
+     */
+    abstract int getTokenBindingParams();
+
+    /**
+     * Exports a value derived from the TLS master secret as described in RFC 5705.
+     *
+     * @param label the label to use in calculating the exported value.  This must be
+     * an ASCII-only string.
+     * @param context the application-specific context value to use in calculating the
+     * exported value.  This may be {@code null} to use no application context, which is
+     * treated differently than an empty byte array.
+     * @param length the number of bytes of keying material to return.
+     * @return a value of the specified length, or {@code null} if the handshake has not yet
+     * completed or the connection has been closed.
+     * @throws SSLException if the value could not be exported.
+     */
+    abstract byte[] exportKeyingMaterial(String label, byte[] context, int length)
+            throws SSLException;
 }

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -348,6 +348,48 @@ public final class Conscrypt {
     }
 
     /**
+     * Enables token binding parameter negotiation on this socket, or disables it if an
+     * empty set of parameters are provided.
+     *
+     * <p>This method needs to be invoked before the handshake starts.
+     *
+     * @param params a list of Token Binding key parameters in descending order of preference,
+     * as described in draft-ietf-tokbind-negotiation-09.
+     * @throws IllegalStateException if the handshake has already started.
+     * @throws SSLException if the setting could not be applied.
+     */
+    public static void setTokenBindingParams(SSLSocket socket, int... params) throws SSLException {
+        toConscrypt(socket).setTokenBindingParams(params);
+    }
+
+    /**
+     * Returns the token binding parameters that were negotiated during the handshake, or -1 if
+     * token binding parameters were not negotiated, the handshake has not yet completed,
+     * or the connection has been closed.
+     */
+    public static int getTokenBindingParams(SSLSocket socket) {
+        return toConscrypt(socket).getTokenBindingParams();
+    }
+
+    /**
+     * Exports a value derived from the TLS master secret as described in RFC 5705.
+     *
+     * @param label the label to use in calculating the exported value.  This must be
+     * an ASCII-only string.
+     * @param context the application-specific context value to use in calculating the
+     * exported value.  This may be {@code null} to use no application context, which is
+     * treated differently than an empty byte array.
+     * @param length the number of bytes of keying material to return.
+     * @return a value of the specified length, or {@code null} if the handshake has not yet
+     * completed or the connection has been closed.
+     * @throws SSLException if the value could not be exported.
+     */
+    public static byte[] exportKeyingMaterial(SSLSocket socket, String label, byte[] context,
+            int length) throws SSLException {
+        return toConscrypt(socket).exportKeyingMaterial(label, context, length);
+    }
+
+    /**
      * Indicates whether the given {@link SSLEngine} was created by this distribution of Conscrypt.
      */
     public static boolean isConscrypt(SSLEngine engine) {
@@ -555,5 +597,47 @@ public final class Conscrypt {
      */
     public static byte[] getTlsUnique(SSLEngine engine) {
         return toConscrypt(engine).getTlsUnique();
+    }
+
+    /**
+     * Enables token binding parameter negotiation on this engine, or disables it if an
+     * empty set of parameters are provided.
+     *
+     * <p>This method needs to be invoked before the handshake starts.
+     *
+     * @param params a list of Token Binding key parameters in descending order of preference,
+     * as described in draft-ietf-tokbind-negotiation-09.
+     * @throws IllegalStateException if the handshake has already started.
+     * @throws SSLException if the setting could not be applied.
+     */
+    public static void setTokenBindingParams(SSLEngine engine, int... params) throws SSLException {
+        toConscrypt(engine).setTokenBindingParams(params);
+    }
+
+    /**
+     * Returns the token binding parameters that were negotiated during the handshake, or -1 if
+     * token binding parameters were not negotiated, the handshake has not yet completed,
+     * or the connection has been closed.
+     */
+    public static int getTokenBindingParams(SSLEngine engine) {
+        return toConscrypt(engine).getTokenBindingParams();
+    }
+
+    /**
+     * Exports a value derived from the TLS master secret as described in RFC 5705.
+     *
+     * @param label the label to use in calculating the exported value.  This must be
+     * an ASCII-only string.
+     * @param context the application-specific context value to use in calculating the
+     * exported value.  This may be {@code null} to use no application context, which is
+     * treated differently than an empty byte array.
+     * @param length the number of bytes of keying material to return.
+     * @return a value of the specified length, or {@code null} if the handshake has not yet
+     * completed or the connection has been closed.
+     * @throws SSLException if the value could not be exported.
+     */
+    public static byte[] exportKeyingMaterial(SSLEngine engine, String label, byte[] context,
+            int length) throws SSLException {
+        return toConscrypt(engine).exportKeyingMaterial(label, context, length);
     }
 }

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -353,11 +353,15 @@ public final class Conscrypt {
      *
      * <p>This method needs to be invoked before the handshake starts.
      *
+     * <p>Token binding is currently an Internet Draft that's subject to change, so the
+     * current implementation may not be compatible with future changes in the protocol.
+     *
      * @param params a list of Token Binding key parameters in descending order of preference,
      * as described in draft-ietf-tokbind-negotiation-09.
      * @throws IllegalStateException if the handshake has already started.
      * @throws SSLException if the setting could not be applied.
      */
+    @ExperimentalApi
     public static void setTokenBindingParams(SSLSocket socket, int... params) throws SSLException {
         toConscrypt(socket).setTokenBindingParams(params);
     }
@@ -367,6 +371,7 @@ public final class Conscrypt {
      * token binding parameters were not negotiated, the handshake has not yet completed,
      * or the connection has been closed.
      */
+    @ExperimentalApi
     public static int getTokenBindingParams(SSLSocket socket) {
         return toConscrypt(socket).getTokenBindingParams();
     }

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1754,6 +1754,32 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         return ssl.getTlsUnique();
     }
 
+    @Override
+    void setTokenBindingParams(int... params) throws SSLException {
+        synchronized (ssl) {
+            if (isHandshakeStarted()) {
+                throw new IllegalStateException(
+                        "Cannot set token binding params after handshake has started.");
+            }
+        }
+        ssl.setTokenBindingParams(params);
+    };
+
+    @Override
+    int getTokenBindingParams() {
+        return ssl.getTokenBindingParams();
+    }
+
+    @Override
+    byte[] exportKeyingMaterial(String label, byte[] context, int length) throws SSLException {
+        synchronized (ssl) {
+            if (state < STATE_HANDSHAKE_COMPLETED || state == STATE_CLOSED) {
+                return null;
+            }
+        }
+        return ssl.exportKeyingMaterial(label, context, length);
+    }
+
     void setApplicationProtocolSelector(ApplicationProtocolSelectorAdapter adapter) {
         sslParameters.setApplicationProtocolSelector(adapter);
     }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -341,6 +341,21 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
     }
 
     @Override
+    void setTokenBindingParams(int... params) throws SSLException {
+        engine.setTokenBindingParams(params);
+    }
+
+    @Override
+    int getTokenBindingParams() {
+        return engine.getTokenBindingParams();
+    }
+
+    @Override
+    byte[] exportKeyingMaterial(String label, byte[] context, int length) throws SSLException {
+        return engine.exportKeyingMaterial(label, context, length);
+    }
+
+    @Override
     public final boolean getUseClientMode() {
         return engine.getUseClientMode();
     }

--- a/common/src/main/java/org/conscrypt/Java8EngineWrapper.java
+++ b/common/src/main/java/org/conscrypt/Java8EngineWrapper.java
@@ -301,6 +301,21 @@ final class Java8EngineWrapper extends AbstractConscryptEngine {
     }
 
     @Override
+    void setTokenBindingParams(int... params) throws SSLException {
+        delegate.setTokenBindingParams(params);
+    }
+
+    @Override
+    int getTokenBindingParams() {
+        return delegate.getTokenBindingParams();
+    }
+
+    @Override
+    byte[] exportKeyingMaterial(String label, byte[] context, int length) throws SSLException {
+        return delegate.exportKeyingMaterial(label, context, length);
+    }
+
+    @Override
     public String getHandshakeApplicationProtocol() {
         return delegate.getHandshakeApplicationProtocol();
     }

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -905,6 +905,12 @@ public final class NativeCrypto {
 
     static native byte[] SSL_get_tls_unique(long ssl, NativeSsl ssl_holder);
 
+    static native void SSL_set_token_binding_params(long ssl, NativeSsl ssl_holder, int[] params) throws SSLException;
+
+    static native int SSL_get_token_binding_params(long ssl, NativeSsl ssl_holder);
+
+    static native byte[] SSL_export_keying_material(long ssl, NativeSsl ssl_holder, byte[] label, byte[] context, int num_bytes) throws SSLException;
+
     static native void SSL_use_psk_identity_hint(long ssl, NativeSsl ssl_holder, String identityHint) throws SSLException;
 
     static native void set_SSL_psk_client_callback_enabled(long ssl, NativeSsl ssl_holder, boolean enabled);

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -29,6 +29,7 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.SocketException;
+import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -123,6 +124,22 @@ final class NativeSsl {
 
     byte[] getTlsUnique() {
         return NativeCrypto.SSL_get_tls_unique(ssl, this);
+    }
+
+    void setTokenBindingParams(int... params) throws SSLException {
+        NativeCrypto.SSL_set_token_binding_params(ssl, this, params);
+    }
+
+    int getTokenBindingParams() {
+        return NativeCrypto.SSL_get_token_binding_params(ssl, this);
+    }
+
+    byte[] exportKeyingMaterial(String label, byte[] context, int length) throws SSLException {
+        if (label == null) {
+            throw new NullPointerException("Label is null");
+        }
+        byte[] labelBytes = label.getBytes(Charset.forName("US-ASCII"));
+        return NativeCrypto.SSL_export_keying_material(ssl, this, labelBytes, context, length);
     }
 
     byte[] getPeerTlsSctData() {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -1091,10 +1091,12 @@ public class SSLEngineTest {
 
             try {
                 Conscrypt.setTokenBindingParams(pair.client, 1);
+                fail("setTokenBindingParams after handshake should throw");
             } catch (IllegalStateException expected) {
             }
             try {
                 Conscrypt.setTokenBindingParams(pair.server, 1);
+                fail("setTokenBindingParams after handshake should throw");
             } catch (IllegalStateException expected) {
             }
         } finally {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -956,6 +956,193 @@ public class SSLEngineTest {
         }
     }
 
+    @Test
+    public void test_SSLEngine_TokenBinding_Success() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create(new TestSSLEnginePair.Hooks() {
+            @Override
+            void beforeBeginHandshake(SSLEngine client, SSLEngine server) {
+                try {
+                    Conscrypt.setTokenBindingParams(client, 1, 2);
+                    Conscrypt.setTokenBindingParams(server, 2, 3);
+                } catch (SSLException e) {
+                    throw new RuntimeException(e);
+                }
+                assertEquals(-1, Conscrypt.getTokenBindingParams(client));
+                assertEquals(-1, Conscrypt.getTokenBindingParams(server));
+            }
+        });
+        try {
+            assertConnected(pair);
+
+            assertEquals(2, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(2, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLEngine_TokenBinding_NoClientSupport() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create(new TestSSLEnginePair.Hooks() {
+            @Override
+            void beforeBeginHandshake(SSLEngine client, SSLEngine server) {
+                try {
+                    // Do not enable on client
+                    Conscrypt.setTokenBindingParams(server, 2, 3);
+                } catch (SSLException e) {
+                    throw new RuntimeException(e);
+                }
+                assertEquals(-1, Conscrypt.getTokenBindingParams(client));
+                assertEquals(-1, Conscrypt.getTokenBindingParams(server));
+            }
+        });
+        try {
+            assertConnected(pair);
+
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLEngine_TokenBinding_NoServerSupport() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create(new TestSSLEnginePair.Hooks() {
+            @Override
+            void beforeBeginHandshake(SSLEngine client, SSLEngine server) {
+                try {
+                    // Do not enable on server
+                    Conscrypt.setTokenBindingParams(client, 2, 3);
+                } catch (SSLException e) {
+                    throw new RuntimeException(e);
+                }
+                assertEquals(-1, Conscrypt.getTokenBindingParams(client));
+                assertEquals(-1, Conscrypt.getTokenBindingParams(server));
+            }
+        });
+        try {
+            assertConnected(pair);
+
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLEngine_TokenBinding_MismatchedSupport() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create(new TestSSLEnginePair.Hooks() {
+            @Override
+            void beforeBeginHandshake(SSLEngine client, SSLEngine server) {
+                try {
+                    Conscrypt.setTokenBindingParams(client, 2);
+                    Conscrypt.setTokenBindingParams(server, 1, 3);
+                } catch (SSLException e) {
+                    throw new RuntimeException(e);
+                }
+                assertEquals(-1, Conscrypt.getTokenBindingParams(client));
+                assertEquals(-1, Conscrypt.getTokenBindingParams(server));
+            }
+        });
+        try {
+            assertConnected(pair);
+
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLEngine_TokenBinding_MismatchedOrdering() throws Exception {
+        // When the server and client disagree on the preference order, the server should
+        // select the server's most highly preferred value.
+        TestSSLEnginePair pair = TestSSLEnginePair.create(new TestSSLEnginePair.Hooks() {
+            @Override
+            void beforeBeginHandshake(SSLEngine client, SSLEngine server) {
+                try {
+                    Conscrypt.setTokenBindingParams(client, 1, 2, 3, 4);
+                    Conscrypt.setTokenBindingParams(server, 3, 2);
+                } catch (SSLException e) {
+                    throw new RuntimeException(e);
+                }
+                assertEquals(-1, Conscrypt.getTokenBindingParams(client));
+                assertEquals(-1, Conscrypt.getTokenBindingParams(server));
+            }
+        });
+        try {
+            assertConnected(pair);
+
+            assertEquals(3, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(3, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLEngine_TokenBinding_ExceptionAfterConnect() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create();
+        try {
+            assertConnected(pair);
+
+            try {
+                Conscrypt.setTokenBindingParams(pair.client, 1);
+            } catch (IllegalStateException expected) {
+            }
+            try {
+                Conscrypt.setTokenBindingParams(pair.server, 1);
+            } catch (IllegalStateException expected) {
+            }
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLEngine_EKM() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create(new TestSSLEnginePair.Hooks() {
+            @Override
+            void beforeBeginHandshake(SSLEngine client, SSLEngine server) {
+                try {
+                    assertNull(Conscrypt.exportKeyingMaterial(client, "FOO", null, 20));
+                    assertNull(Conscrypt.exportKeyingMaterial(server, "FOO", null, 20));
+                } catch (SSLException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        try {
+            assertConnected(pair);
+
+            byte[] clientEkm = Conscrypt.exportKeyingMaterial(pair.client, "FOO", null, 20);
+            byte[] serverEkm = Conscrypt.exportKeyingMaterial(pair.server, "FOO", null, 20);
+            assertNotNull(clientEkm);
+            assertNotNull(serverEkm);
+            assertEquals(20, clientEkm.length);
+            assertEquals(20, serverEkm.length);
+            assertArrayEquals(clientEkm, serverEkm);
+
+            byte[] clientContextEkm = Conscrypt.exportKeyingMaterial(
+                    pair.client, "FOO", new byte[0], 20);
+            byte[] serverContextEkm = Conscrypt.exportKeyingMaterial(
+                    pair.server, "FOO", new byte[0], 20);
+            assertNotNull(clientContextEkm);
+            assertNotNull(serverContextEkm);
+            assertEquals(20, clientContextEkm.length);
+            assertEquals(20, serverContextEkm.length);
+            assertArrayEquals(clientContextEkm, serverContextEkm);
+
+            // An empty context should be different than a null context
+            assertFalse(Arrays.equals(clientEkm, clientContextEkm));
+        } finally {
+            pair.close();
+        }
+    }
+
     private void assertConnected(TestSSLEnginePair e) {
         assertConnected(e.client, e.server);
     }

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -2841,10 +2841,12 @@ public class SSLSocketTest {
 
             try {
                 Conscrypt.setTokenBindingParams(pair.client, 1);
+                fail("setTokenBindingParams after handshake should throw");
             } catch (IllegalStateException expected) {
             }
             try {
                 Conscrypt.setTokenBindingParams(pair.server, 1);
+                fail("setTokenBindingParams after handshake should throw");
             } catch (IllegalStateException expected) {
             }
         } finally {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -2741,6 +2741,152 @@ public class SSLSocketTest {
         }
     }
 
+    @Test
+    public void test_SSLSocket_TokenBinding_Success() throws Exception {
+        TestSSLSocketPair pair = TestSSLSocketPair.create();
+        try {
+            Conscrypt.setTokenBindingParams(pair.client, 1, 2);
+            Conscrypt.setTokenBindingParams(pair.server, 2, 3);
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+
+            pair.connect();
+
+            assertEquals(2, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(2, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLSocket_TokenBinding_NoClientSupport() throws Exception {
+        TestSSLSocketPair pair = TestSSLSocketPair.create();
+        try {
+            // Do not enable on client
+            Conscrypt.setTokenBindingParams(pair.server, 2, 3);
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+
+            pair.connect();
+
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLSocket_TokenBinding_NoServerSupport() throws Exception {
+        TestSSLSocketPair pair = TestSSLSocketPair.create();
+        try {
+            // Do not enable on server
+            Conscrypt.setTokenBindingParams(pair.client, 2, 3);
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+
+            pair.connect();
+
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLSocket_TokenBinding_MismatchedSupport() throws Exception {
+        TestSSLSocketPair pair = TestSSLSocketPair.create();
+        try {
+            Conscrypt.setTokenBindingParams(pair.client, 2);
+            Conscrypt.setTokenBindingParams(pair.server, 1, 3);
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+
+            pair.connect();
+
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLSocket_TokenBinding_MismatchedOrdering() throws Exception {
+        // When the server and client disagree on the preference order, the server should
+        // select the server's most highly preferred value.
+        TestSSLSocketPair pair = TestSSLSocketPair.create();
+        try {
+            Conscrypt.setTokenBindingParams(pair.client, 1, 2, 3, 4);
+            Conscrypt.setTokenBindingParams(pair.server, 3, 2);
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(-1, Conscrypt.getTokenBindingParams(pair.server));
+
+            pair.connect();
+
+            assertEquals(3, Conscrypt.getTokenBindingParams(pair.client));
+            assertEquals(3, Conscrypt.getTokenBindingParams(pair.server));
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLSocket_TokenBinding_ExceptionAfterConnect() throws Exception {
+        TestSSLSocketPair pair = TestSSLSocketPair.create();
+        try {
+            pair.connect();
+
+            try {
+                Conscrypt.setTokenBindingParams(pair.client, 1);
+            } catch (IllegalStateException expected) {
+            }
+            try {
+                Conscrypt.setTokenBindingParams(pair.server, 1);
+            } catch (IllegalStateException expected) {
+            }
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
+    public void test_SSLSocket_EKM() throws Exception {
+        TestSSLSocketPair pair = TestSSLSocketPair.create();
+        try {
+            // No EKM values available before handshaking
+            assertNull(Conscrypt.exportKeyingMaterial(pair.client, "FOO", null, 20));
+            assertNull(Conscrypt.exportKeyingMaterial(pair.server, "FOO", null, 20));
+
+            pair.connect();
+
+            byte[] clientEkm = Conscrypt.exportKeyingMaterial(pair.client, "FOO", null, 20);
+            byte[] serverEkm = Conscrypt.exportKeyingMaterial(pair.server, "FOO", null, 20);
+            assertNotNull(clientEkm);
+            assertNotNull(serverEkm);
+            assertEquals(20, clientEkm.length);
+            assertEquals(20, serverEkm.length);
+            assertArrayEquals(clientEkm, serverEkm);
+
+            byte[] clientContextEkm = Conscrypt.exportKeyingMaterial(
+                    pair.client, "FOO", new byte[0], 20);
+            byte[] serverContextEkm = Conscrypt.exportKeyingMaterial(
+                    pair.server, "FOO", new byte[0], 20);
+            assertNotNull(clientContextEkm);
+            assertNotNull(serverContextEkm);
+            assertEquals(20, clientContextEkm.length);
+            assertEquals(20, serverContextEkm.length);
+            assertArrayEquals(clientContextEkm, serverContextEkm);
+
+            // An empty context should be different than a null context
+            assertFalse(Arrays.equals(clientEkm, clientContextEkm));
+        } finally {
+            pair.close();
+        }
+    }
+
     // Tests that a socket will close cleanly even if it fails to create due to an
     // internal IOException
     @Test


### PR DESCRIPTION
Token binding allows higher-level protocols to bind their higher-level
authentication tokens to their TLS sessions, making it more difficult
for attackers to present those higher-level tokens in a future
session.  At the TLS level, all that needs to occur is a parameter
negotiation, the rest of the token binding protocol is left up to the
caller.

Parameter options are specified as integers, and I decided not to
supply constants for the currently-defined values.  This is a niche
enough use case that any user of it should be able to decide what
values they want to support (and will want to share constants with
whatever higher-level protocol they're using with token binding).
BoringSSL also doesn't supply constants for these values, so we're in
good company there.

Keying material exporting (aka EKM, for exported keying material) is
specified in RFC 5705, and is necessary for implementing token binding
as well as other protocols.