### PR TITLE
Parse ASN1_TIME structures in constructors.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4630,7 +4630,7 @@ static void NativeCrypto_ASN1_TIME_to_Calendar(JNIEnv* env, jclass, jlong asn1Ti
     }
 
     if (!ASN1_TIME_check(asn1Time)) {
-        conscrypt::jniutil::throwParsingException("Invalid date format");
+        conscrypt::jniutil::throwParsingException(env, "Invalid date format");
         return;
     }
 

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4618,21 +4618,6 @@ static inline void get_ASN1_TIME_data(char** data, int* output, size_t len) {
     *(*data + len) = c;
 }
 
-static jboolean NativeCrypto_ASN1_TIME_check(JNIEnv* env, jclass, jlong asn1TimeRef) {
-    CHECK_ERROR_QUEUE_ON_RETURN;
-    ASN1_TIME* asn1Time = reinterpret_cast<ASN1_TIME*>(static_cast<uintptr_t>(asn1TimeRef));
-    JNI_TRACE("ASN1_TIME_check(%p)", asn1Time);
-
-    if (asn1Time == nullptr) {
-        JNI_TRACE("ASN1_TIME_check(%p) => asn1Time == null", asn1Time);
-        return JNI_FALSE;
-    }
-
-    jboolean ret = ASN1_TIME_check(asn1Time) ? JNI_TRUE : JNI_FALSE;
-    JNI_TRACE("ASN1_TIME_check(%p) => %s", asn1Time, ret ? "true" : "false");
-    return ret;
-}
-
 static void NativeCrypto_ASN1_TIME_to_Calendar(JNIEnv* env, jclass, jlong asn1TimeRef,
                                                jobject calendar) {
     CHECK_ERROR_QUEUE_ON_RETURN;
@@ -4644,9 +4629,14 @@ static void NativeCrypto_ASN1_TIME_to_Calendar(JNIEnv* env, jclass, jlong asn1Ti
         return;
     }
 
+    if (!ASN1_TIME_check(asn1Time)) {
+        conscrypt::jniutil::throwParsingException("Invalid date format");
+        return;
+    }
+
     bssl::UniquePtr<ASN1_GENERALIZEDTIME> gen(ASN1_TIME_to_generalizedtime(asn1Time, nullptr));
     if (gen.get() == nullptr) {
-        conscrypt::jniutil::throwNullPointerException(env, "gen == null");
+        conscrypt::jniutil::throwParsingException(env, "ASN1_TIME_to_generalizedtime returned null");
         return;
     }
 
@@ -9928,7 +9918,6 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(X509_REVOKED_dup, "(J)J"),
         CONSCRYPT_NATIVE_METHOD(i2d_X509_REVOKED, "(J)[B"),
         CONSCRYPT_NATIVE_METHOD(X509_supported_extension, "(J)I"),
-        CONSCRYPT_NATIVE_METHOD(ASN1_TIME_check, "(J)Z"),
         CONSCRYPT_NATIVE_METHOD(ASN1_TIME_to_Calendar, "(JLjava/util/Calendar;)V"),
         CONSCRYPT_NATIVE_METHOD(asn1_read_init, "([B)J"),
         CONSCRYPT_NATIVE_METHOD(asn1_read_sequence, "(J)J"),

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4618,6 +4618,21 @@ static inline void get_ASN1_TIME_data(char** data, int* output, size_t len) {
     *(*data + len) = c;
 }
 
+static jboolean NativeCrypto_ASN1_TIME_check(JNIEnv* env, jclass, jlong asn1TimeRef) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    ASN1_TIME* asn1Time = reinterpret_cast<ASN1_TIME*>(static_cast<uintptr_t>(asn1TimeRef));
+    JNI_TRACE("ASN1_TIME_check(%p)", asn1Time);
+
+    if (asn1Time == nullptr) {
+        JNI_TRACE("ASN1_TIME_check(%p) => asn1Time == null", asn1Time);
+        return JNI_FALSE;
+    }
+
+    jboolean ret = ASN1_TIME_check(asn1Time) ? JNI_TRUE : JNI_FALSE;
+    JNI_TRACE("ASN1_TIME_check(%p) => %s", asn1Time, ret ? "true" : "false");
+    return ret;
+}
+
 static void NativeCrypto_ASN1_TIME_to_Calendar(JNIEnv* env, jclass, jlong asn1TimeRef,
                                                jobject calendar) {
     CHECK_ERROR_QUEUE_ON_RETURN;
@@ -4631,7 +4646,7 @@ static void NativeCrypto_ASN1_TIME_to_Calendar(JNIEnv* env, jclass, jlong asn1Ti
 
     bssl::UniquePtr<ASN1_GENERALIZEDTIME> gen(ASN1_TIME_to_generalizedtime(asn1Time, nullptr));
     if (gen.get() == nullptr) {
-        conscrypt::jniutil::throwNullPointerException(env, "asn1Time == null");
+        conscrypt::jniutil::throwNullPointerException(env, "gen == null");
         return;
     }
 
@@ -9913,6 +9928,7 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(X509_REVOKED_dup, "(J)J"),
         CONSCRYPT_NATIVE_METHOD(i2d_X509_REVOKED, "(J)[B"),
         CONSCRYPT_NATIVE_METHOD(X509_supported_extension, "(J)I"),
+        CONSCRYPT_NATIVE_METHOD(ASN1_TIME_check, "(J)Z"),
         CONSCRYPT_NATIVE_METHOD(ASN1_TIME_to_Calendar, "(JLjava/util/Calendar;)V"),
         CONSCRYPT_NATIVE_METHOD(asn1_read_init, "([B)J"),
         CONSCRYPT_NATIVE_METHOD(asn1_read_sequence, "(J)J"),

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -556,6 +556,11 @@ public final class NativeCrypto {
 
     // --- ASN1_TIME -----------------------------------------------------------
 
+    /**
+     * Returns whether the provided ASN1_TIME* pointer is a valid time value.
+     */
+    static native boolean ASN1_TIME_check(long asn1TimeCtx);
+
     static native void ASN1_TIME_to_Calendar(long asn1TimeCtx, Calendar cal);
 
     // --- ASN1 Encoding -------------------------------------------------------

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -556,12 +556,7 @@ public final class NativeCrypto {
 
     // --- ASN1_TIME -----------------------------------------------------------
 
-    /**
-     * Returns whether the provided ASN1_TIME* pointer is a valid time value.
-     */
-    static native boolean ASN1_TIME_check(long asn1TimeCtx);
-
-    static native void ASN1_TIME_to_Calendar(long asn1TimeCtx, Calendar cal);
+    static native void ASN1_TIME_to_Calendar(long asn1TimeCtx, Calendar cal) throws ParsingException;
 
     // --- ASN1 Encoding -------------------------------------------------------
 

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRLEntry.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRLEntry.java
@@ -21,11 +21,10 @@ import java.math.BigInteger;
 import java.security.cert.CRLException;
 import java.security.cert.X509CRLEntry;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.TimeZone;
+import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * An implementation of {@link X509CRLEntry} based on BoringSSL.
@@ -34,7 +33,7 @@ final class OpenSSLX509CRLEntry extends X509CRLEntry {
     private final long mContext;
     private final Date revocationDate;
 
-    OpenSSLX509CRLEntry(long ctx) throws CRLException {
+    OpenSSLX509CRLEntry(long ctx) throws ParsingException {
         mContext = ctx;
         // The legacy X509 OpenSSL APIs don't validate ASN1_TIME structures until access, so
         // parse them here because this is the only time we're allowed to throw ParsingException

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CertPath.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CertPath.java
@@ -23,6 +23,7 @@ import java.security.cert.CertPath;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -173,7 +174,11 @@ final class OpenSSLX509CertPath extends CertPath {
             if (certRefs[i] == 0) {
                 continue;
             }
-            certs.add(new OpenSSLX509Certificate(certRefs[i]));
+            try {
+                certs.add(new OpenSSLX509Certificate(certRefs[i]));
+            } catch (ParsingException e) {
+                throw new CertificateParsingException(e);
+            }
         }
 
         return new OpenSSLX509CertPath(certs);

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -66,7 +66,7 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     private final Date notBefore;
     private final Date notAfter;
 
-    OpenSSLX509Certificate(long ctx) throws CertificateParsingException {
+    OpenSSLX509Certificate(long ctx) throws ParsingException {
         mContext = ctx;
         // The legacy X509 OpenSSL APIs don't validate ASN1_TIME structures until access, so
         // parse them here because this is the only time we're allowed to throw ParsingException
@@ -81,10 +81,7 @@ public final class OpenSSLX509Certificate extends X509Certificate {
         this.notAfter = notAfter;
     }
 
-    private static Date toDate(long asn1time) throws CertificateParsingException {
-        if (!NativeCrypto.ASN1_TIME_check(asn1time)) {
-            throw new CertificateParsingException("Invalid date format");
-        }
+    private static Date toDate(long asn1time) throws ParsingException {
         Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(Calendar.MILLISECOND, 0);
         NativeCrypto.ASN1_TIME_to_Calendar(asn1time, calendar);
@@ -115,8 +112,6 @@ public final class OpenSSLX509Certificate extends X509Certificate {
             return new OpenSSLX509Certificate(NativeCrypto.d2i_X509(encoded));
         } catch (ParsingException e) {
             throw new CertificateEncodingException(e);
-        } catch (CertificateParsingException e) {
-            throw new CertificateEncodingException(e);
         }
     }
 
@@ -144,11 +139,7 @@ public final class OpenSSLX509Certificate extends X509Certificate {
             if (certRefs[i] == 0) {
                 continue;
             }
-            try {
-                certs.add(new OpenSSLX509Certificate(certRefs[i]));
-            } catch (CertificateParsingException e) {
-                throw new ParsingException(e);
-            }
+            certs.add(new OpenSSLX509Certificate(certRefs[i]));
         }
         return certs;
     }
@@ -192,11 +183,7 @@ public final class OpenSSLX509Certificate extends X509Certificate {
             if (certRefs[i] == 0) {
                 continue;
             }
-            try {
-                certs.add(new OpenSSLX509Certificate(certRefs[i]));
-            } catch (CertificateParsingException e) {
-                throw new ParsingException(e);
-            }
+            certs.add(new OpenSSLX509Certificate(certRefs[i]));
         }
         return certs;
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -63,8 +63,32 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     private transient final long mContext;
     private transient Integer mHashCode;
 
-    OpenSSLX509Certificate(long ctx) {
+    private final Date notBefore;
+    private final Date notAfter;
+
+    OpenSSLX509Certificate(long ctx) throws CertificateParsingException {
         mContext = ctx;
+        // The legacy X509 OpenSSL APIs don't validate ASN1_TIME structures until access, so
+        // parse them here because this is the only time we're allowed to throw ParsingException
+        notBefore = toDate(NativeCrypto.X509_get_notBefore(mContext, this));
+        notAfter = toDate(NativeCrypto.X509_get_notAfter(mContext, this));
+    }
+
+    // A non-throwing constructor used when we have already parsed the dates
+    private OpenSSLX509Certificate(long ctx, Date notBefore, Date notAfter) {
+        mContext = ctx;
+        this.notBefore = notBefore;
+        this.notAfter = notAfter;
+    }
+
+    private static Date toDate(long asn1time) throws CertificateParsingException {
+        if (!NativeCrypto.ASN1_TIME_check(asn1time)) {
+            throw new CertificateParsingException("Invalid date format");
+        }
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.set(Calendar.MILLISECOND, 0);
+        NativeCrypto.ASN1_TIME_to_Calendar(asn1time, calendar);
+        return calendar.getTime();
     }
 
     public static OpenSSLX509Certificate fromX509DerInputStream(InputStream is)
@@ -90,6 +114,8 @@ public final class OpenSSLX509Certificate extends X509Certificate {
         try {
             return new OpenSSLX509Certificate(NativeCrypto.d2i_X509(encoded));
         } catch (ParsingException e) {
+            throw new CertificateEncodingException(e);
+        } catch (CertificateParsingException e) {
             throw new CertificateEncodingException(e);
         }
     }
@@ -118,7 +144,11 @@ public final class OpenSSLX509Certificate extends X509Certificate {
             if (certRefs[i] == 0) {
                 continue;
             }
-            certs.add(new OpenSSLX509Certificate(certRefs[i]));
+            try {
+                certs.add(new OpenSSLX509Certificate(certRefs[i]));
+            } catch (CertificateParsingException e) {
+                throw new ParsingException(e);
+            }
         }
         return certs;
     }
@@ -162,7 +192,11 @@ public final class OpenSSLX509Certificate extends X509Certificate {
             if (certRefs[i] == 0) {
                 continue;
             }
-            certs.add(new OpenSSLX509Certificate(certRefs[i]));
+            try {
+                certs.add(new OpenSSLX509Certificate(certRefs[i]));
+            } catch (CertificateParsingException e) {
+                throw new ParsingException(e);
+            }
         }
         return certs;
     }
@@ -268,18 +302,12 @@ public final class OpenSSLX509Certificate extends X509Certificate {
 
     @Override
     public Date getNotBefore() {
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        calendar.set(Calendar.MILLISECOND, 0);
-        NativeCrypto.ASN1_TIME_to_Calendar(NativeCrypto.X509_get_notBefore(mContext, this), calendar);
-        return calendar.getTime();
+        return (Date) notBefore.clone();
     }
 
     @Override
     public Date getNotAfter() {
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        calendar.set(Calendar.MILLISECOND, 0);
-        NativeCrypto.ASN1_TIME_to_Calendar(NativeCrypto.X509_get_notAfter(mContext, this), calendar);
-        return calendar.getTime();
+        return (Date) notAfter.clone();
     }
 
     @Override
@@ -555,7 +583,7 @@ public final class OpenSSLX509Certificate extends X509Certificate {
      * If the extension is not present, an unmodified copy is returned.
      */
     public OpenSSLX509Certificate withDeletedExtension(String oid) {
-        OpenSSLX509Certificate copy = new OpenSSLX509Certificate(NativeCrypto.X509_dup(mContext, this));
+        OpenSSLX509Certificate copy = new OpenSSLX509Certificate(NativeCrypto.X509_dup(mContext, this), notBefore, notAfter);
         NativeCrypto.X509_delete_ext(copy.getContext(), copy, oid);
         return copy;
     }
@@ -569,20 +597,5 @@ public final class OpenSSLX509Certificate extends X509Certificate {
         } finally {
             super.finalize();
         }
-    }
-
-    /**
-     * Return a possibly null array of X509Certificates given the possibly null
-     * array of DER encoded bytes.
-     */
-    static OpenSSLX509Certificate[] createCertChain(long[] certificateRefs) {
-        if (certificateRefs == null) {
-            return null;
-        }
-        OpenSSLX509Certificate[] certificates = new OpenSSLX509Certificate[certificateRefs.length];
-        for (int i = 0; i < certificateRefs.length; i++) {
-            certificates[i] = new OpenSSLX509Certificate(certificateRefs[i]);
-        }
-        return certificates;
     }
 }


### PR DESCRIPTION
The legacy OpenSSL APIs in BoringSSL don't parse ASN1_TIME values
until they're used, which means that the existing code could explode
in the middle of X509Certificate.getNotAfter() and similar
Date-returning calls, and those calls aren't declared to throw
anything.  Instead, read and cache the values in the constructor,
where we can throw a relevant exception if necessary.

We have to clone the Date values when returning them because Date is
mutable.