### PR TITLE
Add method to OS and arch enums for building filenames.

### DIFF
--- a/openjdk/src/main/java/org/conscrypt/HostProperties.java
+++ b/openjdk/src/main/java/org/conscrypt/HostProperties.java
@@ -67,7 +67,14 @@ public class HostProperties {
         NETBSD,
         SUNOS,
         WINDOWS,
-        UNKNOWN
+        UNKNOWN;
+
+        /**
+         * Returns the value to use when building filenames for this OS.
+         */
+        public String getFileComponent() {
+            return name().toLowerCase();
+        }
     }
 
     /**
@@ -75,7 +82,11 @@ public class HostProperties {
      */
     enum Architecture {
         X86_64,
-        X86_32,
+        X86_32 {
+            @Override public String getFileComponent() {
+                return "x86";
+            }
+        },
         ITANIUM_64,
         SPARC_32,
         SPARC_64,
@@ -86,7 +97,14 @@ public class HostProperties {
         PPCLE_64,
         S390_32,
         S390_64,
-        UNKNOWN
+        UNKNOWN;
+
+        /**
+         * Returns the value to use when building filenames for this architecture.
+         */
+        public String getFileComponent() {
+            return name().toLowerCase();
+        }
     }
 
     static boolean isWindows() {

--- a/openjdk/src/main/java/org/conscrypt/NativeCryptoJni.java
+++ b/openjdk/src/main/java/org/conscrypt/NativeCryptoJni.java
@@ -88,11 +88,11 @@ final class NativeCryptoJni {
     }
 
     private static String osName() {
-        return HostProperties.OS.name().toLowerCase();
+        return HostProperties.OS.getFileComponent();
     }
 
     private static String archName() {
-        return HostProperties.ARCH.name().toLowerCase();
+        return HostProperties.ARCH.getFileComponent();
     }
 
     /**


### PR DESCRIPTION
Customize X86_32 to return "x86", since nobody calls the architecture
"x86_32", so switching the filename to that would be pretty odd.

Fixes #447.