### PR TITLE
Check for zero-length output buffers.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -9362,6 +9362,7 @@ static jint NativeCrypto_ENGINE_SSL_read_direct(JNIEnv* env, jclass, jlong ssl_a
         // but if we passed in an empty destination buffer, it can also mean a successful operation
         // that produced 0 bytes of output.  Assume it means the latter.  If it actually meant
         // EOF, a later operation with a nonempty buffer will get that error anyway.
+        ERR_clear_error();
         JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_read_direct address=%p length=%d shc=%p result=%d",
                   ssl, destPtr, length, shc, result);
         return result;

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -9357,6 +9357,15 @@ static jint NativeCrypto_ENGINE_SSL_read_direct(JNIEnv* env, jclass, jlong ssl_a
         JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_read_direct => THROWN_EXCEPTION", ssl);
         return -1;
     }
+    if (length == 0 && result == 0) {
+        // A result of 0 normally means an EOF (and that's how SSL_get_error() will interpret it),
+        // but if we passed in an empty destination buffer, it can also mean a successful operation
+        // that produced 0 bytes of output.  Assume it means the latter.  If it actually meant
+        // EOF, a later operation with a nonempty buffer will get that error anyway.
+        JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_read_direct address=%p length=%d shc=%p result=%d",
+                  ssl, destPtr, length, shc, result);
+        return result;
+    }
 
     SslError sslError(ssl, result);
     switch (sslError.get()) {

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -9357,16 +9357,6 @@ static jint NativeCrypto_ENGINE_SSL_read_direct(JNIEnv* env, jclass, jlong ssl_a
         JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_read_direct => THROWN_EXCEPTION", ssl);
         return -1;
     }
-    if (length == 0 && result == 0) {
-        // A result of 0 normally means an EOF (and that's how SSL_get_error() will interpret it),
-        // but if we passed in an empty destination buffer, it can also mean a successful operation
-        // that produced 0 bytes of output.  Assume it means the latter.  If it actually meant
-        // EOF, a later operation with a nonempty buffer will get that error anyway.
-        ERR_clear_error();
-        JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_read_direct address=%p length=%d shc=%p result=%d",
-                  ssl, destPtr, length, shc, result);
-        return result;
-    }
 
     SslError sslError(ssl, result);
     switch (sslError.get()) {
@@ -9646,6 +9636,85 @@ static int NativeCrypto_ENGINE_SSL_read_BIO_heap(JNIEnv* env, jclass, jlong ssl_
     JNI_TRACE_PACKET_DATA(ssl, 'I', reinterpret_cast<char*>(dest.get()) + destOffset,
                           static_cast<size_t>(result));
     return result;
+}
+
+static void NativeCrypto_ENGINE_SSL_force_read(JNIEnv* env, jclass, jlong ssl_address, CONSCRYPT_UNUSED jobject ssl_holder,
+                                               jobject shc) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    if (ssl == nullptr) {
+        return;
+    }
+    JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_force_read shc=%p", ssl, shc);
+    if (shc == nullptr) {
+        conscrypt::jniutil::throwNullPointerException(env, "sslHandshakeCallbacks == null");
+        JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_force_read => sslHandshakeCallbacks == null",
+                  ssl);
+        return;
+    }
+    AppData* appData = toAppData(ssl);
+    if (appData == nullptr) {
+        conscrypt::jniutil::throwSSLExceptionStr(env, "Unable to retrieve application data");
+        JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_force_read => appData == null", ssl);
+        return;
+    }
+    if (!appData->setCallbackState(env, shc, nullptr)) {
+        conscrypt::jniutil::throwSSLExceptionStr(env, "Unable to set appdata callback");
+        ERR_clear_error();
+        JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_force_read => exception", ssl);
+        return;
+    }
+    char c;
+    int result = SSL_peek(ssl, &c, 1);
+    appData->clearCallbackState();
+    if (env->ExceptionCheck()) {
+        // An exception was thrown by one of the callbacks. Just propagate that exception.
+        ERR_clear_error();
+        JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_force_read => THROWN_EXCEPTION", ssl);
+        return;
+    }
+
+    SslError sslError(ssl, result);
+    switch (sslError.get()) {
+        case SSL_ERROR_NONE:
+        case SSL_ERROR_ZERO_RETURN:
+        case SSL_ERROR_WANT_READ:
+        case SSL_ERROR_WANT_WRITE: {
+            // The call succeeded, lacked data, or the SSL is closed.  All is well.
+            break;
+        }
+        case SSL_ERROR_SYSCALL: {
+            // A problem occurred during a system call, but this is not
+            // necessarily an error.
+            if (result == 0) {
+                // TODO(nmittler): Can this happen with memory BIOs?
+                // Connection closed without proper shutdown. Tell caller we
+                // have reached end-of-stream.
+                conscrypt::jniutil::throwException(env, "java/io/EOFException", "Read error");
+                break;
+            }
+
+            if (errno == EINTR) {
+                // TODO(nmittler): Can this happen with memory BIOs?
+                // System call has been interrupted. Simply retry.
+                conscrypt::jniutil::throwException(env, "java/io/InterruptedIOException",
+                                                      "Read error");
+                break;
+            }
+
+            // Note that for all other system call errors we fall through
+            // to the default case, which results in an Exception.
+            FALLTHROUGH_INTENDED;
+        }
+        default: {
+            // Everything else is basically an error.
+            conscrypt::jniutil::throwSSLExceptionWithSslErrors(env, ssl, sslError.release(),
+                                                               "Read error");
+            break;
+        }
+    }
+
+    JNI_TRACE("ssl=%p NativeCrypto_ENGINE_SSL_force_read shc=%p", ssl, shc);
 }
 
 /**
@@ -10126,6 +10195,7 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_read_BIO_direct, "(J" REF_SSL "JJI" SSL_CALLBACKS ")I"),
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_write_BIO_heap, "(J" REF_SSL "J[BII" SSL_CALLBACKS ")I"),
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_read_BIO_heap, "(J" REF_SSL "J[BII" SSL_CALLBACKS ")I"),
+        CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_force_read, "(J" REF_SSL SSL_CALLBACKS ")V"),
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_shutdown, "(J" REF_SSL SSL_CALLBACKS ")V"),
 
         // Used for testing only.

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -109,7 +109,6 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
             new SSLEngineResult(CLOSED, NEED_WRAP, 0, 0);
     private static final SSLEngineResult CLOSED_NOT_HANDSHAKING =
             new SSLEngineResult(CLOSED, NOT_HANDSHAKING, 0, 0);
-    private static final ByteBuffer EMPTY = ByteBuffer.allocateDirect(0);
 
     private static BufferAllocator defaultBufferAllocator = null;
 
@@ -884,7 +883,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
                     // If the capacity of all destination buffers is 0 we need to trigger a SSL_read
                     // anyway to ensure everything is flushed in the BIO pair and so we can detect
                     // it in the pendingInboundCleartextBytes() call.
-                    readPlaintextData(EMPTY);
+                    ssl.forceRead();
                 }
             } catch (SSLException e) {
                 if (pendingOutboundEncryptedBytes() > 0) {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1335,6 +1335,12 @@ public final class NativeCrypto {
             throws IOException, IndexOutOfBoundsException;
 
     /**
+     * Forces the SSL object to process any data pending in the BIO.
+     */
+    static native void ENGINE_SSL_force_read(long ssl, NativeSsl ssl_holder,
+            SSLHandshakeCallbacks shc) throws IOException;
+
+    /**
      * Variant of the {@link #SSL_shutdown} used by {@link ConscryptEngine}. This version does not
      * lock.
      */

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -517,6 +517,10 @@ final class NativeSsl {
                 ssl, this, sourceAddress, sourceLength, handshakeCallbacks);
     }
 
+    void forceRead() throws IOException {
+        NativeCrypto.ENGINE_SSL_force_read(ssl, this, handshakeCallbacks);
+    }
+
     int getPendingReadableBytes() {
         return NativeCrypto.SSL_pending_readable_bytes(ssl, this);
     }

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -102,12 +102,33 @@ public class SSLEngineTest {
     @Test
     public void test_SSLEngine_underflowsOnEmptyBuffersAfterHandshake() throws Exception {
         // Note that create performs the handshake.
-        final TestSSLEnginePair engines = TestSSLEnginePair.create(null /* hooks */);
+        final TestSSLEnginePair engines = TestSSLEnginePair.create();
         ByteBuffer input = ByteBuffer.allocate(1024);
         input.flip();
         ByteBuffer output = ByteBuffer.allocate(1024);
         assertEquals(SSLEngineResult.Status.BUFFER_UNDERFLOW,
                 engines.client.unwrap(input, output).getStatus());
+    }
+
+    @Test
+    public void test_SSLEngine_wrap_overflowOnEmptyOutputBuffer() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create();
+        ByteBuffer input = ByteBuffer.allocate(10);
+        ByteBuffer output = ByteBuffer.allocate(1024);
+        output.flip();
+        assertEquals(Status.BUFFER_OVERFLOW, pair.client.wrap(input, output).getStatus());
+    }
+
+    @Test
+    public void test_SSLEngine_unwrap_overflowOnEmptyOutputBuffer() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create();
+        ByteBuffer input = ByteBuffer.allocate(10);
+        ByteBuffer wrapped = ByteBuffer.allocate(1024);
+        assertEquals(Status.OK, pair.client.wrap(input, wrapped).getStatus());
+        wrapped.flip();
+        ByteBuffer output = ByteBuffer.allocate(1024);
+        output.flip();
+        assertEquals(Status.BUFFER_OVERFLOW, pair.server.unwrap(wrapped, output).getStatus());
     }
 
     private void test_SSLEngine_getSupportedCipherSuites_connect(


### PR DESCRIPTION
SSL_read()'s return value is the number of output bytes on success or
<= 0 on failure, with the failure details interpreted by calling
SSL_get_error().  When an empty output buffer is used, then a
successful operation can return 0, since there isn't room for any
output to be produced, but SSL_get_error() will still treat it like
the failure mode that a 0 result would indicate (specifically, an
unexpected EOF).  Check for this case and return a successful result.

Fixes #452.