### PR TITLE
Update release docs and Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN yum install -y git \
 RUN yum install -y epel-release
 RUN yum install -y clang
 
+RUN yum update -y nss
+
 # Install Java 8
 RUN wget -q --no-cookies --no-check-certificate \
     --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,7 +69,7 @@ These steps need to be performed once per `X.Y` release series.
 
 ### Create the release branch
 
-We use a branch named `v<major>.<minor>.x` for all releases in a series.
+We use a branch named `<major>.<minor>.x` for all releases in a series.
 
 Create the branch and push it to GitHub:
 
@@ -77,6 +77,11 @@ Create the branch and push it to GitHub:
 $ git checkout -b 1.0.x master
 $ git push upstream 1.0.x
 ```
+
+### Set the branch protection settings
+
+In the GitHub UI, go to Settings -> Branches and mark the new branch as
+protected, with administrators included and restrict pushes to administrators.
 
 ### Update the master version
 


### PR DESCRIPTION
Fix the name of release branches, we don't use a leading v.

Indicate that branch protection settings need to be set for new
release branches.

Something changed that makes the version of git in CentOS 6.6 unable
to fetch Ninja, but updating NSS fixes it.