### PR TITLE
Allow `boringsslHome` and `jdkHome` to be set by project properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,11 +60,21 @@ subprojects {
             throw new GradleException("Unsupported os: " + os.name)
         }
 
-        boringsslHome = "$System.env.BORINGSSL_HOME"
+        if (project.hasProperty("boringsslHome")) {
+            boringsslHome = project.property("boringsslHome")
+        } else {
+            boringsslHome = "$System.env.BORINGSSL_HOME"
+        }
+
         boringsslIncludeDir = normalizePath("$boringsslHome/include")
         boringssl32BuildDir = normalizePath("$boringsslHome/build32")
         boringssl64BuildDir = normalizePath("$boringsslHome/build64")
-        jdkHome = "$System.env.JAVA_HOME"
+
+        if (project.hasProperty("jdkHome")) {
+            jdkHome = project.property("jdkHome")
+        } else {
+            jdkHome = "$System.env.JAVA_HOME"
+        }
         jdkIncludeDir = normalizePath("$jdkHome/include")
         // Needs to be binary compatible with androidMinSdkVersion
         androidMinJavaVersion = JavaVersion.VERSION_1_7


### PR DESCRIPTION
Right now these must be set by environment variables. This makes it difficult to propagate settings to gradle instances spun up by IDEs. Using properties allows these values to be set in `gradle.properties` and picked up in all gradle contests.