### PR TITLE
Remove CONSCRYPT_LOG_DEBUG.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -126,13 +126,13 @@ int throwException(JNIEnv* env, const char* className, const char* msg) {
     jclass exceptionClass = env->FindClass(className);
 
     if (exceptionClass == nullptr) {
-        CONSCRYPT_LOG_DEBUG("Unable to find exception class %s", className);
+        CONSCRYPT_LOG_ERROR("Unable to find exception class %s", className);
         /* ClassNotFoundException now pending */
         return -1;
     }
 
     if (env->ThrowNew(exceptionClass, msg) != JNI_OK) {
-        CONSCRYPT_LOG_DEBUG("Failed throwing '%s' '%s'", className, msg);
+        CONSCRYPT_LOG_ERROR("Failed throwing '%s' '%s'", className, msg);
         /* an exception, most likely OOM, will now be pending */
         return -1;
     }

--- a/common/src/jni/main/include/conscrypt/logging.h
+++ b/common/src/jni/main/include/conscrypt/logging.h
@@ -28,7 +28,6 @@
 #define CONSCRYPT_LOG(priority, tag, ...) ALOG(priority, tag, __VA_ARGS__)
 #define CONSCRYPT_LOG_ERROR(...) ALOG(LOG_ERROR, LOG_TAG, __VA_ARGS__)
 #define CONSCRYPT_LOG_INFO(...) ALOG(LOG_INFO, LOG_TAG, __VA_ARGS__)
-#define CONSCRYPT_LOG_DEBUG(...) ALOG(LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 #if LOG_NDEBUG
 #define CONSCRYPT_LOG_VERBOSE(...) ((void)0)
 #else
@@ -45,7 +44,6 @@
 #define CONSCRYPT_LOG(priority, tag, ...) ALOG(priority, tag, __VA_ARGS__)
 #define CONSCRYPT_LOG_ERROR(...) ALOG(LOG_ERROR, LOG_TAG, __VA_ARGS__)
 #define CONSCRYPT_LOG_INFO(...) ALOG(LOG_INFO, LOG_TAG, __VA_ARGS__)
-#define CONSCRYPT_LOG_DEBUG(...) ALOG(LOG_DEBUG, LOG_TAG, __VA_ARGS__)
 #if LOG_NDEBUG
 #define CONSCRYPT_LOG_VERBOSE(...) ((void)0)
 #else
@@ -68,10 +66,6 @@
     fprintf(stderr, "\n");           \
 }
 #define CONSCRYPT_LOG_INFO(...) {    \
-    fprintf(stderr, __VA_ARGS__);    \
-    fprintf(stderr, "\n");           \
-}
-#define CONSCRYPT_LOG_DEBUG(...) {   \
     fprintf(stderr, __VA_ARGS__);    \
     fprintf(stderr, "\n");           \
 }


### PR DESCRIPTION
We only had two places that CONSCRYPT_LOG_DEBUG was used, and they're
really errors, since they're failures in the code that throws Java
exceptions, which "shouldn't" happen.  In addition, _VERBOSE logging
can be suppressed, but _DEBUG can't, which isn't typical for those
names.  Just go with _VERBOSE logging if we need to log something in a
suppressable manner.