### PR TITLE
Tag some variable as const.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -7868,7 +7868,7 @@ static jobjectArray NativeCrypto_SSL_get0_peer_certificates(JNIEnv* env, jclass,
         return nullptr;
     }
 
-    STACK_OF(CRYPTO_BUFFER)* chain = SSL_get0_peer_certificates(ssl);
+    const STACK_OF(CRYPTO_BUFFER)* chain = SSL_get0_peer_certificates(ssl);
     if (chain == nullptr) {
         return nullptr;
     }


### PR DESCRIPTION
I'm not sure why we made SSL_get0_peer_certificates return non-const
pointer. In preparation for fixing that, tag the field as const in
Conscrypt.