### PR TITLE
Disallow invalid SNI hostnames in setHostname().

### DIFF
--- a/common/src/main/java/org/conscrypt/AddressUtils.java
+++ b/common/src/main/java/org/conscrypt/AddressUtils.java
@@ -40,9 +40,9 @@ final class AddressUtils {
             return false;
         }
 
-        // Must be a FQDN.
-        return sniHostname.indexOf('.') != -1 && !Platform.isLiteralIpAddress(sniHostname);
-
+        // Must be a FQDN that does not have a trailing dot.
+        return sniHostname.indexOf('.') != -1 && !Platform.isLiteralIpAddress(sniHostname)
+                && !sniHostname.endsWith(".");
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/AddressUtils.java
+++ b/common/src/main/java/org/conscrypt/AddressUtils.java
@@ -42,7 +42,7 @@ final class AddressUtils {
 
         // Must be a FQDN that does not have a trailing dot.
         return sniHostname.indexOf('.') != -1 && !Platform.isLiteralIpAddress(sniHostname)
-                && !sniHostname.endsWith(".");
+                && !sniHostname.endsWith(".") && sniHostname.indexOf('\0') == -1;
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -214,6 +214,7 @@ public final class Conscrypt {
      *
      * @param socket the socket
      * @param hostname the desired SNI hostname, or null to disable
+     * @throws IllegalArgumentException if the supplied hostname is not a valid SNI hostname.
      */
     public static void setHostname(SSLSocket socket, String hostname) {
         toConscrypt(socket).setHostname(hostname);

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -362,9 +362,14 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     /**
      * This method enables Server Name Indication (SNI) and overrides the {@link PeerInfoProvider}
      * supplied during engine creation.
+     *
+     * @throws IllegalArgumentException if the supplied hostname is not a valid SNI hostname.
      */
     @Override
     void setHostname(String hostname) {
+        if ((hostname != null) && !AddressUtils.isValidSniHostname(hostname)) {
+            throw new IllegalArgumentException("Invalid SNI hostname: " + hostname);
+        }
         sslParameters.setUseSni(hostname != null);
         this.peerHostname = hostname;
     }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -308,6 +308,7 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
      * This method enables Server Name Indication
      *
      * @param hostname the desired SNI hostname, or null to disable
+     * @throws IllegalArgumentException if the supplied hostname is not a valid SNI hostname.
      */
     @Override
     public final void setHostname(String hostname) {

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -758,9 +758,13 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
      * This method enables Server Name Indication
      *
      * @param hostname the desired SNI hostname, or null to disable
+     * @throws IllegalArgumentException if the supplied hostname is not a valid SNI hostname.
      */
     @Override
     public final void setHostname(String hostname) {
+        if ((hostname != null) && !AddressUtils.isValidSniHostname(hostname)) {
+            throw new IllegalArgumentException("Invalid SNI hostname: " + hostname);
+        }
         sslParameters.setUseSni(hostname != null);
         super.setHostname(hostname);
     }

--- a/openjdk/src/test/java/org/conscrypt/AddressUtilsTest.java
+++ b/openjdk/src/test/java/org/conscrypt/AddressUtilsTest.java
@@ -42,6 +42,10 @@ public class AddressUtilsTest extends TestCase {
         assertFalse(AddressUtils.isValidSniHostname("www.google.com."));
     }
 
+    public void test_isValidSniHostname_NullByte() throws Exception {
+        assertFalse(AddressUtils.isValidSniHostname("www\0.google.com"));
+    }
+
     public void test_isLiteralIpAddress_IPv4_Success() throws Exception {
         assertTrue(AddressUtils.isLiteralIpAddress("127.0.0.1"));
         assertTrue(AddressUtils.isLiteralIpAddress("255.255.255.255"));

--- a/openjdk/src/test/java/org/conscrypt/AddressUtilsTest.java
+++ b/openjdk/src/test/java/org/conscrypt/AddressUtilsTest.java
@@ -38,6 +38,10 @@ public class AddressUtilsTest extends TestCase {
         assertFalse(AddressUtils.isValidSniHostname("2001:db8::1"));
     }
 
+    public void test_isValidSniHostname_TrailingDot() throws Exception {
+        assertFalse(AddressUtils.isValidSniHostname("www.google.com."));
+    }
+
     public void test_isLiteralIpAddress_IPv4_Success() throws Exception {
         assertTrue(AddressUtils.isLiteralIpAddress("127.0.0.1"));
         assertTrue(AddressUtils.isLiteralIpAddress("255.255.255.255"));


### PR DESCRIPTION
The code that sets the SNI value on the connection checks for

impl.getUseSni() && AddressUtils.isValidSniHostname(hostname)

which is good for hostnames that were supplied as the hostname to
connect to, since they may or may not be valid for SNI, but means that
if you set an invalid hostname with setHostname() it will just
silently be omitted from the connection and no SNI extension will be
included in the handshake.  Better to reject the hostname immediately.

Also disallow hostnames with trailing dots, which aren't legal SNI
hostnames per RFC 6066.