### PR TITLE
ConscryptFileDescriptorSocket: Null check SslWrapper object before using it

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -1077,8 +1077,10 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
             if (guard != null) {
                 Platform.closeGuardWarnIfOpen(guard);
             }
-            synchronized (ssl) {
-                transitionTo(STATE_CLOSED);
+            if (ssl != null) {
+                synchronized (ssl) {
+                    transitionTo(STATE_CLOSED);
+                }
             }
         } finally {
             super.finalize();


### PR DESCRIPTION
Continued from the discussion at https://android-review.googlesource.com/c/platform/external/conscrypt/+/666741