### PR TITLE
Swap if conditions to avoid warning.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLSocketFactoryImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketFactoryImpl.java
@@ -148,7 +148,7 @@ final class OpenSSLSocketFactoryImpl extends SSLSocketFactory {
             throw new SocketException("Socket is not connected.");
         }
 
-        if (hasFileDescriptor(socket) && !useEngineSocket) {
+        if (!useEngineSocket && hasFileDescriptor(socket)) {
             return createFileDescriptorSocket(
                     socket, hostname, port, autoClose, (SSLParametersImpl) sslParameters.clone());
         } else {


### PR DESCRIPTION
JDK9+ produces a warning when accessing the internal field that
hasFileDescriptor() checks to see if a file descriptor is available.
Users using the engine socket don't need to do that check, so swap the
order of if conditions so it comes second and gets avoided if the
engine socket is enabled.

Fixes #472.