### PR TITLE
Allow localhost as an SNI hostname.

### DIFF
--- a/common/src/main/java/org/conscrypt/AddressUtils.java
+++ b/common/src/main/java/org/conscrypt/AddressUtils.java
@@ -41,8 +41,11 @@ final class AddressUtils {
         }
 
         // Must be a FQDN that does not have a trailing dot.
-        return sniHostname.indexOf('.') != -1 && !Platform.isLiteralIpAddress(sniHostname)
-                && !sniHostname.endsWith(".") && sniHostname.indexOf('\0') == -1;
+        return (sniHostname.equalsIgnoreCase("localhost")
+                    || sniHostname.indexOf('.') != -1)
+                && !Platform.isLiteralIpAddress(sniHostname)
+                && !sniHostname.endsWith(".")
+                && sniHostname.indexOf('\0') == -1;
     }
 
     /**

--- a/openjdk/src/test/java/org/conscrypt/AddressUtilsTest.java
+++ b/openjdk/src/test/java/org/conscrypt/AddressUtilsTest.java
@@ -30,6 +30,10 @@ public class AddressUtilsTest extends TestCase {
         assertFalse(AddressUtils.isValidSniHostname("www"));
     }
 
+    public void test_isValidSniHostname_Localhost_Success() throws Exception {
+        assertTrue(AddressUtils.isValidSniHostname("LOCALhost"));
+    }
+
     public void test_isValidSniHostname_IPv4_Failure() throws Exception {
         assertFalse(AddressUtils.isValidSniHostname("192.168.0.1"));
     }


### PR DESCRIPTION
As an exception to the normal rule that you can't have an SNI hostname
without dots, localhost is a fine hostname for SNI.