### PR TITLE
Two way ssl uses trustchain, android as a service.

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -475,7 +475,7 @@ final class NativeSsl {
                 if (issuers != null && issuers.length != 0) {
                     byte[][] issuersBytes;
                     try {
-                        issuersBytes = SSLUtils.encodeIssuerX509Principals(issuers);
+                        issuersBytes = SSLUtils.encodeSubjectX509Principals(issuers);
                     } catch (CertificateEncodingException e) {
                         throw new SSLException("Problem encoding principals", e);
                     }

--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -277,11 +277,11 @@ final class SSLUtils {
         return result;
     }
 
-    static byte[][] encodeIssuerX509Principals(X509Certificate[] certificates)
+    static byte[][] encodeSubjectX509Principals(X509Certificate[] certificates)
             throws CertificateEncodingException {
         byte[][] principalBytes = new byte[certificates.length][];
         for (int i = 0; i < certificates.length; i++) {
-            principalBytes[i] = certificates[i].getIssuerX500Principal().getEncoded();
+            principalBytes[i] = certificates[i].getSubjectX500Principal().getEncoded();
         }
         return principalBytes;
     }


### PR DESCRIPTION
Service usually send a Certificate Request to client,
then client send a certificate to service. The Certificate Request of service has certificate types and
distinguished name. The distinguished names are should the subject name of trustchains, not issure name.
For example there are there trustchain cert, {[subject=RootCA, issure=RootCA], [subject=SecondCA, issure=RootCA],
[subject=ThirdCA, issure=SecondCA], the service now sends distinguished name{SecondCA, RootCA, RootCA}, so client
can't find certificate.The service should sends{ThirdCA, SecondCA, RootCA}.