### PR TITLE
Remove exception throwing on bad hostnames.

### DIFF
--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -210,11 +210,11 @@ public final class Conscrypt {
 
     /**
      * This method enables Server Name Indication (SNI) and overrides the hostname supplied
-     * during socket creation.
+     * during socket creation.  If the hostname is not a valid SNI hostname, the SNI extension
+     * will be omitted from the handshake.
      *
      * @param socket the socket
      * @param hostname the desired SNI hostname, or null to disable
-     * @throws IllegalArgumentException if the supplied hostname is not a valid SNI hostname.
      */
     public static void setHostname(SSLSocket socket, String hostname) {
         toConscrypt(socket).setHostname(hostname);

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -361,15 +361,11 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
 
     /**
      * This method enables Server Name Indication (SNI) and overrides the {@link PeerInfoProvider}
-     * supplied during engine creation.
-     *
-     * @throws IllegalArgumentException if the supplied hostname is not a valid SNI hostname.
+     * supplied during engine creation.  If the hostname is not a valid SNI hostname, the SNI
+     * extension will be omitted from the handshake.
      */
     @Override
     void setHostname(String hostname) {
-        if ((hostname != null) && !AddressUtils.isValidSniHostname(hostname)) {
-            throw new IllegalArgumentException("Invalid SNI hostname: " + hostname);
-        }
         sslParameters.setUseSni(hostname != null);
         this.peerHostname = hostname;
     }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -305,10 +305,10 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
     }
 
     /**
-     * This method enables Server Name Indication
+     * This method enables Server Name Indication.  If the hostname is not a valid SNI hostname,
+     * the SNI extension will be omitted from the handshake.
      *
      * @param hostname the desired SNI hostname, or null to disable
-     * @throws IllegalArgumentException if the supplied hostname is not a valid SNI hostname.
      */
     @Override
     public final void setHostname(String hostname) {

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -755,16 +755,13 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     }
 
     /**
-     * This method enables Server Name Indication
+     * This method enables Server Name Indication.  If the hostname is not a valid SNI hostname,
+     * the SNI extension will be omitted from the handshake.
      *
      * @param hostname the desired SNI hostname, or null to disable
-     * @throws IllegalArgumentException if the supplied hostname is not a valid SNI hostname.
      */
     @Override
     public final void setHostname(String hostname) {
-        if ((hostname != null) && !AddressUtils.isValidSniHostname(hostname)) {
-            throw new IllegalArgumentException("Invalid SNI hostname: " + hostname);
-        }
         sslParameters.setUseSni(hostname != null);
         super.setHostname(hostname);
     }

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.ConnectException;

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -2315,33 +2315,6 @@ public class SSLSocketTest {
     }
 
     @Test
-    public void test_SSLSocket_setInvalidHostname() throws Exception {
-        TestSSLContext context = TestSSLContext.create();
-        SSLSocket client =
-                (SSLSocket) context.clientContext.getSocketFactory().createSocket();
-        try {
-            client.connect(new InetSocketAddress(context.host, context.port));
-            Method getHostname = client.getClass().getMethod("getHostname");
-            getHostname.setAccessible(true);
-            String originalHostname = (String) getHostname.invoke(client);
-
-            try {
-                Method setHostname = client.getClass().getMethod("setHostname", String.class);
-                setHostname.setAccessible(true);
-                setHostname.invoke(client, "sslsockettest.androidcts.google.com.");
-            } catch (InvocationTargetException expected) {
-                assertTrue(expected.getCause() instanceof IllegalArgumentException);
-            }
-            
-            // Ensure that setting an illegal hostname doesn't change getHostname
-            assertEquals(originalHostname, getHostname.invoke(client));
-        } finally {
-            client.close();
-            context.close();
-        }
-    }
-
-    @Test
     public void test_SSLSocket_SNIHostName() throws Exception {
         TestUtils.assumeSNIHostnameAvailable();
         TestSSLContext c = TestSSLContext.create();


### PR DESCRIPTION
Testing on Android has indicated that there are too many things that
rely on passing whatever string has been passed to them to
setHostname() and aren't prepared to get an exception (including IP
addresses, single-element hostnames, and whatnot) for it to be
reasonable to throw an exception here.  Settle for documenting what
the behavior of passing an invalid hostname is.