### PR TITLE
Updates for new java.security tests.

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParameterGeneratorTestDH.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParameterGeneratorTestDH.java
@@ -15,6 +15,10 @@
  */
 package org.conscrypt.java.security;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
 public class AlgorithmParameterGeneratorTestDH extends
         AbstractAlgorithmParameterGeneratorTest {
 

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParameterGeneratorTestDSA.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParameterGeneratorTestDSA.java
@@ -16,7 +16,10 @@
 package org.conscrypt.java.security;
 
 import java.security.spec.DSAParameterSpec;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParameterGeneratorTestDSA extends
         AbstractAlgorithmParameterGeneratorTest {
 

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersPSSTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersPSSTest.java
@@ -33,7 +33,10 @@ import java.util.Map;
 import java.util.TreeMap;
 import org.conscrypt.TestUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParametersPSSTest {
 
     // ASN.1 DER-encoded forms of DEFAULT_SPEC and WEIRD_SPEC were generated using

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestAES.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestAES.java
@@ -26,7 +26,10 @@ import java.util.Arrays;
 import javax.crypto.spec.IvParameterSpec;
 import org.conscrypt.TestUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParametersTestAES extends AbstractAlgorithmParametersTest {
 
     private static final byte[] parameterData = new byte[] {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestDES.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestDES.java
@@ -26,7 +26,10 @@ import java.util.Arrays;
 import javax.crypto.spec.IvParameterSpec;
 import org.conscrypt.TestUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParametersTestDES extends AbstractAlgorithmParametersTest {
 
     private static final byte[] parameterData = new byte[] {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestDESede.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestDESede.java
@@ -26,7 +26,10 @@ import java.util.Arrays;
 import javax.crypto.spec.IvParameterSpec;
 import org.conscrypt.TestUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParametersTestDESede extends AbstractAlgorithmParametersTest {
 
     private static final byte[] parameterData = new byte[] {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestDH.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestDH.java
@@ -17,7 +17,10 @@ package org.conscrypt.java.security;
 
 import java.math.BigInteger;
 import javax.crypto.spec.DHParameterSpec;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParametersTestDH extends AbstractAlgorithmParametersTest {
 
     private static final byte[] P = new byte[] {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestDSA.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestDSA.java
@@ -25,7 +25,10 @@ import java.security.Security;
 import java.security.spec.DSAParameterSpec;
 import org.conscrypt.TestUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParametersTestDSA extends AbstractAlgorithmParametersTest {
 
     /*

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestGCM.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestGCM.java
@@ -26,7 +26,10 @@ import java.util.Arrays;
 import java.util.Base64;
 import javax.crypto.spec.GCMParameterSpec;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParametersTestGCM extends AbstractAlgorithmParametersTest {
 
     private static final byte[] IV = new byte[] {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestOAEP.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestOAEP.java
@@ -28,7 +28,10 @@ import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import org.conscrypt.TestUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class AlgorithmParametersTestOAEP extends AbstractAlgorithmParametersTest {
 
     // The ASN.1 encoding for OAEP params (specified in RFC 4055 section 4.1) specifies

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestDH.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestDH.java
@@ -18,7 +18,10 @@ package org.conscrypt.java.security;
 import java.security.KeyPair;
 import javax.crypto.spec.DHPrivateKeySpec;
 import javax.crypto.spec.DHPublicKeySpec;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class KeyFactoryTestDH extends AbstractKeyFactoryTest<DHPublicKeySpec, DHPrivateKeySpec> {
 
     public KeyFactoryTestDH() {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestDSA.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestDSA.java
@@ -18,7 +18,10 @@ package org.conscrypt.java.security;
 import java.security.KeyPair;
 import java.security.spec.DSAPrivateKeySpec;
 import java.security.spec.DSAPublicKeySpec;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class KeyFactoryTestDSA extends
         AbstractKeyFactoryTest<DSAPublicKeySpec, DSAPrivateKeySpec> {
 

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
@@ -23,7 +23,11 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class KeyFactoryTestRSA extends
         AbstractKeyFactoryTest<RSAPublicKeySpec, RSAPrivateKeySpec> {
 
@@ -37,6 +41,7 @@ public class KeyFactoryTestRSA extends
         new CipherAsymmetricCryptHelper("RSA").test(keyPair);
     }
 
+    @Test
     public void testExtraBufferSpace_Private() throws Exception {
         PrivateKey privateKey = DefaultKeys.getPrivateKey("RSA");
         byte[] encoded = privateKey.getEncoded();
@@ -45,6 +50,7 @@ public class KeyFactoryTestRSA extends
         KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(longBuffer));
     }
 
+    @Test
     public void testExtraBufferSpace_Public() throws Exception {
         PublicKey publicKey = DefaultKeys.getPublicKey("RSA");
         byte[] encoded = publicKey.getEncoded();

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
@@ -60,7 +60,10 @@ import org.conscrypt.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class KeyPairGeneratorTest {
 
     private List<Provider> providers = new ArrayList<Provider>();

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTestDH.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTestDH.java
@@ -15,6 +15,10 @@
  */
 package org.conscrypt.java.security;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
 public class KeyPairGeneratorTestDH extends AbstractKeyPairGeneratorTest {
 
     public KeyPairGeneratorTestDH() {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTestDSA.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTestDSA.java
@@ -15,6 +15,10 @@
  */
 package org.conscrypt.java.security;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
 public class KeyPairGeneratorTestDSA extends AbstractKeyPairGeneratorTest {
 
     public KeyPairGeneratorTestDSA() {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTestRSA.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTestRSA.java
@@ -15,6 +15,10 @@
  */
 package org.conscrypt.java.security;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
 public class KeyPairGeneratorTestRSA extends AbstractKeyPairGeneratorTest {
 
     @SuppressWarnings("unchecked")

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/MessageDigestTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/MessageDigestTest.java
@@ -27,7 +27,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public final class MessageDigestTest {
 
     private final byte[] sha_456 = {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
@@ -63,7 +63,10 @@ import org.bouncycastle.x509.X509V3CertificateGenerator;
 import org.bouncycastle.x509.extension.AuthorityKeyIdentifierStructure;
 import org.conscrypt.Conscrypt;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class CertificateFactoryTest {
 
     private static final String VALID_CERTIFICATE_PEM =


### PR DESCRIPTION
Synchronize a number of Signature methods.  If these methods are
called concurrently, it can lead to crashes due to the native memory
management stepping on itself.

Add @RunWith(JUnit4.class) to the classes and @Test to a couple
missing places.

Fix the concurrent usage Signature test.  Previously it didn't init
the signature object, so all of the threads just immediately threw
without actually doing anything.  Also check the created Futures to
satisfy ErrorProne.