### PR TITLE
Remove SHA-2 CBC cipher suites.

### DIFF
--- a/libcore-stub/src/main/java/libcore/java/security/StandardNames.java
+++ b/libcore-stub/src/main/java/libcore/java/security/StandardNames.java
@@ -683,16 +683,16 @@ public final class StandardNames {
         addBoth("SSL_RSA_WITH_3DES_EDE_CBC_SHA");
 
         // TLSv1.2 cipher suites
-        addBoth("TLS_RSA_WITH_AES_128_CBC_SHA256");
-        addBoth("TLS_RSA_WITH_AES_256_CBC_SHA256");
+        addRi("TLS_RSA_WITH_AES_128_CBC_SHA256");
+        addRi("TLS_RSA_WITH_AES_256_CBC_SHA256");
         addOpenSsl("TLS_RSA_WITH_AES_128_GCM_SHA256");
         addOpenSsl("TLS_RSA_WITH_AES_256_GCM_SHA384");
-        addBoth("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256");
-        addBoth("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384");
+        addRi("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256");
+        addRi("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384");
         addOpenSsl("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
         addOpenSsl("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
-        addBoth("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256");
-        addBoth("TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384");
+        addRi("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256");
+        addRi("TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384");
         addOpenSsl("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
         addOpenSsl("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384");
         addOpenSsl("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256");


### PR DESCRIPTION
We automatically pull our supported set of cipher suites from
BoringSSL, and they removed support for these in
https://boringssl.googlesource.com/boringssl/+/6e678eeb.