### PR TITLE
Switch to custom-built base64 encoding/decoding.

### DIFF
--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -46,7 +46,6 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocketFactory;
-import javax.xml.bind.DatatypeConverter;
 import libcore.io.Streams;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.conscrypt.java.security.TestKeyStore;

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -565,24 +565,73 @@ public final class TestUtils {
                 " at offset " + offset);
     }
 
+    private static final String BASE64_ALPHABET =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
     public static String encodeBase64(byte[] data) {
         // Base64 was introduced in Java 8, so if it's not available we can use a hacky
-        // solution available in previous versions
+        // solution that works in previous versions
         if (isClassAvailable("java.util.Base64")) {
             return Base64.getEncoder().encodeToString(data);
         } else {
-            return DatatypeConverter.printBase64Binary(data);
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < data.length; i += 3) {
+                int padding = (i + 2 < data.length) ? 0 : (i + 3 - data.length);
+                byte b1 = data[i];
+                byte b2 = padding >= 2 ? 0 : data[i+1];
+                byte b3 = padding >= 1 ? 0 : data[i+2];
+
+                char c1 = BASE64_ALPHABET.charAt((b1 & 0xFF) >>> 2);
+                char c2 = BASE64_ALPHABET.charAt(((b1 & 0x03) << 4) | ((b2 & 0xFF) >>> 4));
+                char c3 = BASE64_ALPHABET.charAt(((b2 & 0x0F) << 2) | ((b3 & 0xFF) >>> 6));
+                char c4 = BASE64_ALPHABET.charAt(b3 & 0x3F);
+
+                if (padding >= 1) {
+                    c4 = '=';
+                }
+                if (padding >= 2) {
+                    c3 = '=';
+                }
+                builder.append(c1).append(c2).append(c3).append(c4);
+            }
+            return builder.toString();
         }
     }
 
     public static byte[] decodeBase64(String data) {
         // Base64 was introduced in Java 8, so if it's not available we can use a hacky
-        // solution available in previous versions
+        // solution that works in previous versions
         if (isClassAvailable("java.util.Base64")) {
             return Base64.getDecoder().decode(data);
         } else {
-            return DatatypeConverter.parseBase64Binary(data);
+            while (data.endsWith("=")) {
+                data = data.substring(0, data.length() - 1);
+            }
+            int padding = (data.length() % 4 == 0) ? 0 : 4 - (data.length() % 4);
+            byte[] output = new byte[((data.length() - 1) / 4) * 3 + 3 - padding];
+            int outputindex = 0;
+            for (int i = 0; i < data.length(); i += 4) {
+                char c1 = data.charAt(i);
+                char c2 = data.charAt(i+1);
+                char c3 = (i+2 < data.length()) ? data.charAt(i+2) : 'A';
+                char c4 = (i+3 < data.length()) ? data.charAt(i+3) : 'A';
+
+                byte b1 = (byte)
+                        (BASE64_ALPHABET.indexOf(c1) << 2 | BASE64_ALPHABET.indexOf(c2) >>> 4);
+                byte b2 = (byte)
+                        ((BASE64_ALPHABET.indexOf(c2) & 0x0F) << 4 | BASE64_ALPHABET.indexOf(c3) >>> 2);
+                byte b3 = (byte)
+                        ((BASE64_ALPHABET.indexOf(c3) & 0x03) << 6 | BASE64_ALPHABET.indexOf(c4));
+
+                output[outputindex++] = b1;
+                if (outputindex < output.length) {
+                    output[outputindex++] = b2;
+                }
+                if (outputindex < output.length) {
+                    output[outputindex++] = b3;
+                }
+            }
+            return output;
         }
     }
 }


### PR DESCRIPTION
Some versions of Android have neither Base64 nor DatatypeConverter, so
use a not-very-sophisticated homegrown base64 encoder/decoder when
Base64 isn't available.