### PR TITLE
Don't load libgmscore in NativeCryptoJni

### DIFF
--- a/android/src/main/java/org/conscrypt/NativeCryptoJni.java
+++ b/android/src/main/java/org/conscrypt/NativeCryptoJni.java
@@ -23,7 +23,6 @@ package org.conscrypt;
 class NativeCryptoJni {
     public static void init() {
         if ("com.google.android.gms.org.conscrypt".equals(NativeCrypto.class.getPackage().getName())) {
-            System.loadLibrary("gmscore");
             System.loadLibrary("conscrypt_gmscore_jni");
         } else {
             System.loadLibrary("conscrypt_jni");


### PR DESCRIPTION
This load is no longer necessary in GMS Core.

ATTN: flooey@