### PR TITLE
Clean up some ErrorProne warnings.

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/MessageDigestTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/MessageDigestTest.java
@@ -232,17 +232,13 @@ public final class MessageDigestTest {
             } else {
                 throw new AssertionError(inputName);
             }
-            assertDigest(algorithm, expected, actual);
+            assertEquals(algorithm, javaBytes(expected), javaBytes(actual));
             assertEquals(algorithm, expected.length, md.getDigestLength());
         }
     }
 
-    private void assertDigest(String algorithm, byte[] actual, byte[] expected) {
-        assertEquals(algorithm, javaBytes(actual), javaBytes(expected));
-    }
-
     private String javaBytes(byte[] bytes) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("new byte[] { ");
         for (byte b : bytes) {
             buf.append(b);

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/SignatureTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/SignatureTest.java
@@ -2650,7 +2650,7 @@ public class SignatureTest {
         final int oneTooBig = RSA_2048_modulus.bitLength() + 1;
         final byte[] vector = new byte[oneTooBig];
         for (int i = 0; i < oneTooBig; i++) {
-            vector[i] = (byte) Vector1Data[i % Vector1Data.length];
+            vector[i] = Vector1Data[i % Vector1Data.length];
         }
         sig.update(vector);
 
@@ -2760,13 +2760,16 @@ public class SignatureTest {
     }
 
     @Test
+    // Suppress ErrorProne's warning about the try block that doesn't call fail() but
+    // expects an exception, it's intentional
+    @SuppressWarnings("MissingFail")
     public void testVerify_NONEwithECDSA_Key_SingleByte_Failure() throws Exception {
         PublicKey pub = getNamedCurveEcPublicKey();
         MessageDigest sha1 = MessageDigest.getInstance("SHA1");
         Signature sig = Signature.getInstance("NONEwithECDSA");
 
         byte[] corrupted = new byte[NAMED_CURVE_SIGNATURE.length];
-        corrupted[0] ^= 1;
+        corrupted[0] = (byte) (corrupted[0] ^ 1);
 
         sig.initVerify(pub);
         sig.update(sha1.digest(NAMED_CURVE_VECTOR));

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
@@ -399,11 +399,8 @@ public class CertificateFactoryTest {
                 // to accept them
                 {
                     final CertPath duplicatedPath = cf.generateCertPath(duplicatedCerts);
-                    try {
-                        duplicatedPath.getEncoded();
-                    } catch (CertificateEncodingException expected) {
-                        fail("duplicate certificates should pass: " + p.getName());
-                    }
+                    // This shouldn't cause an exception
+                    duplicatedPath.getEncoded();
                 }
             }
 

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLContextTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLContextTest.java
@@ -696,7 +696,7 @@ public class SSLContextTest {
     }
 
     private static int majorVersion(final String javaSpecVersion) {
-        final String[] components = javaSpecVersion.split("\\.");
+        final String[] components = javaSpecVersion.split("\\.", -1);
         final int[] version = new int[components.length];
         for (int i = 0; i < components.length; i++) {
             version[i] = Integer.parseInt(components[i]);

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -658,7 +658,7 @@ final class Platform {
     }
 
     private static int majorVersion(final String javaSpecVersion) {
-        final String[] components = javaSpecVersion.split("\\.");
+        final String[] components = javaSpecVersion.split("\\.", -1);
         final int[] version = new int[components.length];
         for (int i = 0; i < components.length; i++) {
             version[i] = Integer.parseInt(components[i]);

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -990,8 +990,8 @@ public class NativeCryptoTest {
                         if (DEBUG) {
                             System.out.println("ssl=0x" + Long.toString(s, 16) + " handshake"
                                     + " context=0x" + Long.toString(c, 16) + " socket=" + socket
-                                    + " fd=" + fd + " timeout=" + timeout + " client="
-                                    + client);
+                                    + " fd=0x" + Long.toString(System.identityHashCode(fd), 16)
+                                    + " timeout=" + timeout + " client=" + client);
                         }
                         long session = NULL;
                         try {

--- a/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterAsymmetricHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterAsymmetricHelper.java
@@ -47,10 +47,10 @@ public class AlgorithmParameterAsymmetricHelper extends TestHelper<AlgorithmPara
 
         Cipher cipher = Cipher.getInstance(algorithmName);
         cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), parameters);
-        byte[] bs = cipher.doFinal(plainData.getBytes());
+        byte[] bs = cipher.doFinal(plainData.getBytes("UTF-8"));
 
         cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), parameters);
         byte[] decrypted = cipher.doFinal(bs);
-        assertTrue(Arrays.equals(plainData.getBytes(), decrypted));
+        assertTrue(Arrays.equals(plainData.getBytes("UTF-8"), decrypted));
     }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSignatureHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSignatureHelper.java
@@ -46,11 +46,11 @@ public class AlgorithmParameterSignatureHelper<T extends AlgorithmParameterSpec>
         KeyPair keyPair = generator.genKeyPair();
 
         signature.initSign(keyPair.getPrivate());
-        signature.update(plainData.getBytes());
+        signature.update(plainData.getBytes("UTF-8"));
         byte[] signed = signature.sign();
 
         signature.initVerify(keyPair.getPublic());
-        signature.update(plainData.getBytes());
+        signature.update(plainData.getBytes("UTF-8"));
         assertTrue("signature should verify", signature.verify(signed));
     }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSymmetricHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSymmetricHelper.java
@@ -55,11 +55,11 @@ public class AlgorithmParameterSymmetricHelper extends TestHelper<AlgorithmParam
 
         Cipher cipher = Cipher.getInstance(transformation);
         cipher.init(Cipher.ENCRYPT_MODE, key, parameters);
-        byte[] bs = cipher.doFinal(plainData.getBytes());
+        byte[] bs = cipher.doFinal(plainData.getBytes("UTF-8"));
 
         cipher.init(Cipher.DECRYPT_MODE, key, parameters);
         byte[] decrypted = cipher.doFinal(bs);
 
-        assertTrue(Arrays.equals(plainData.getBytes(), decrypted));
+        assertTrue(Arrays.equals(plainData.getBytes("UTF-8"), decrypted));
     }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/CipherAsymmetricCryptHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/CipherAsymmetricCryptHelper.java
@@ -28,6 +28,7 @@ public class CipherAsymmetricCryptHelper extends CipherHelper<KeyPair> {
                 Cipher.DECRYPT_MODE);
     }
 
+    @Override
     public void test(KeyPair keyPair) throws Exception {
         test(keyPair.getPrivate(), keyPair.getPublic());
     }

--- a/testing/src/main/java/org/conscrypt/java/security/CipherHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/CipherHelper.java
@@ -38,11 +38,11 @@ public abstract class CipherHelper<T> extends TestHelper<T> {
     public void test(Key encryptKey, Key decryptKey) throws Exception {
         Cipher cipher = Cipher.getInstance(algorithmName);
         cipher.init(mode1, encryptKey);
-        byte[] encrypted = cipher.doFinal(plainData.getBytes());
+        byte[] encrypted = cipher.doFinal(plainData.getBytes("UTF-8"));
 
         cipher.init(mode2, decryptKey);
         byte[] decrypted = cipher.doFinal(encrypted);
-        String decryptedString = new String(decrypted);
+        String decryptedString = new String(decrypted, "UTF-8");
 
         assertEquals("transformed data does not match", plainData, decryptedString);
     }

--- a/testing/src/main/java/org/conscrypt/java/security/SignatureHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/SignatureHelper.java
@@ -40,11 +40,11 @@ public class SignatureHelper extends TestHelper<KeyPair> {
     public void test(PrivateKey encryptKey, PublicKey decryptKey) throws Exception {
         Signature signature = Signature.getInstance(algorithmName);
         signature.initSign(encryptKey);
-        signature.update(plainData.getBytes());
+        signature.update(plainData.getBytes("UTF-8"));
         byte[] signed = signature.sign();
 
         signature.initVerify(decryptKey);
-        signature.update(plainData.getBytes());
+        signature.update(plainData.getBytes("UTF-8"));
         assertTrue("signature could not be verified", signature.verify(signed));
     }
 }


### PR DESCRIPTION
* Add explicit charset to byte-to-String conversions.
* Add -1 to String.split() calls to make its behavior more intuitive.
* Add a missing @Override.
* Clarify an implicit int-to-byte conversion.
* Switch StringBuffer to StringBuilder.
* Inline an unnecessary function.
* Stop depending on FileDescriptor's toString.