### PR TITLE
Filter out ConscryptJava6Suite.java.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -57,7 +57,7 @@ local_javac_flags:=-Xmaxwarns 9999999
 #
 
 bundled_test_java_files := $(call all-java-files-under,platform/src/test/java)
-bundled_test_java_files += $(filter-out %/ConscryptSuite.java,\
+bundled_test_java_files += $(filter-out %/ConscryptSuite.java %/ConscryptJava6Suite.java,\
     $(call all-java-files-under,openjdk-integ-tests/src/test/java))
 bundled_test_java_files += $(call all-java-files-under,testing/src/main/java)
 bundled_test_java_files := $(foreach j,$(bundled_test_java_files),\


### PR DESCRIPTION
Including it causes problems in Android CTS because it results in
tests being added twice, which CTS doesn't handle well.