### PR TITLE
Fix NPE from closed SSLEngine.

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -992,6 +992,20 @@ public class SSLEngineTest {
     }
 
     @Test
+    public void test_SSLEngine_Closed() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create();
+        pair.close();
+        ByteBuffer out = ByteBuffer.allocate(pair.client.getSession().getPacketBufferSize());
+        SSLEngineResult res = pair.client.wrap(ByteBuffer.wrap(new byte[] { 0x01 }), out);
+        assertEquals(Status.CLOSED, res.getStatus());
+        assertEquals(0, res.bytesProduced());
+
+        res = pair.client.unwrap(ByteBuffer.wrap(new byte[] { 0x01} ), out);
+        assertEquals(Status.CLOSED, res.getStatus());
+        assertEquals(0, res.bytesConsumed());
+    }
+
+    @Test
     public void test_SSLEngine_TlsUnique() throws Exception {
         TestSSLEnginePair pair = TestSSLEnginePair.create(new TestSSLEnginePair.Hooks() {
             @Override


### PR DESCRIPTION
When calling wrap() on a closed SSLEngine instance, we check to see if
anything is already pending to be written, but the native BIO will
already have been freed, so the native code threw
NullPointerException.  Check for it being already freed when looking
for pending data and just return zero in that case.

Also sets the bio pointer to 0 before freeing it and and marks it as
volatile to reduce the chances of any weird race conditions, though
the locking in ConscryptEngine should already make these impossible.

Fixes netty/netty#7988.