### PR TITLE
Add doc listing Conscrypt capabilities.

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -1,0 +1,201 @@
+Conscrypt's Capabilities
+========================================
+
+Conscrypt is relatively selective in choosing the set of primitives to provide, focusing
+on the most important and widely-used algorithms.  Following is a list of JCA algorithm names
+and other identifiers that are supported by Conscrypt.
+
+## TLS
+
+### Protocol Versions
+
+* SSLv3 (ignored)
+* TLSv1
+* TLSv1.1
+* TLSv1.2
+
+Conscrypt supports TLS v1.0-1.2.  For backwards compatibility it will accept "SSLv3"
+in calls to methods like
+[setEnabledProtocols()](https://docs.oracle.com/javase/9/docs/api/javax/net/ssl/SSLSocket.html#setEnabledProtocols-java.lang.String:A-)
+but will ignore it.
+
+### SSLContext
+
+* Default
+* SSL
+* TLS
+* TLSv1
+* TLSv1.1
+* TLSv1.2
+
+Conscrypt provides the above set of SSLContext algorithm names for JSSE purposes, including
+the special value "Default", which is used to determine the value of
+[SSLContext.getDefault()](https://docs.oracle.com/javase/9/docs/api/javax/net/ssl/SSLContext.html#getDefault--).
+All of these values return a context where TLS v1.0-1.2 are all enabled.
+
+### Cipher Suites
+
+#### Enabled
+* TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+* TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+* TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+* TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+* TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+* TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+* TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+* TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+* TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+* TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+* TLS_RSA_WITH_AES_128_CBC_SHA
+* TLS_RSA_WITH_AES_128_GCM_SHA256
+* TLS_RSA_WITH_AES_256_CBC_SHA
+* TLS_RSA_WITH_AES_256_GCM_SHA384
+
+The above cipher suites are enabled by default.
+
+#### Supported But Not Enabled
+* SSL_RSA_WITH_3DES_EDE_CBC_SHA
+* TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+* TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+* TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256
+* TLS_PSK_WITH_AES_128_CBC_SHA
+* TLS_PSK_WITH_AES_256_CBC_SHA
+
+The above cipher suites are supported, but not enabled by default.
+
+## Cryptography
+
+### Cipher
+
+* `AES/CBC/NoPadding`
+* `AES/CBC/PKCS5Padding`
+* `AES/CTR/NoPadding`
+* `AES/ECB/NoPadding`
+* `AES/ECB/PKCS5Padding`
+
+AES with 128, 192, or 256-bit keys.
+
+* `AES/GCM/NoPadding`
+
+AES/GCM with 128 or 256-bit keys.
+
+* `AES_128/CBC/NoPadding`
+* `AES_128/CBC/PKCS5Padding`
+* `AES_128/ECB/NoPadding`
+* `AES_128/ECB/PKCS5Padding`
+* `AES_128/GCM/NoPadding`
+* `AES_256/CBC/NoPadding`
+* `AES_256/CBC/PKCS5Padding`
+* `AES_256/ECB/NoPadding`
+* `AES_256/ECB/PKCS5Padding`
+* `AES_256/GCM/NoPadding`
+
+Key-restricted versions of the AES ciphers.
+
+* `ARC4`
+
+The RC4 stream cipher.
+
+* `ChaCha20/NONE/NoPadding`
+* `ChaCha20/Poly1305/NoPadding`
+
+ChaCha with 20 rounds, 96-bit nonce, and 32-bit counter as described in
+[RFC 7539](https://tools.ietf.org/html/rfc7539), either with or without a Poly1305 AEAD
+authenticator.
+
+* `DESEDE/CBC/NoPadding`
+* `DESEDE/CBC/PKCS5Padding`
+
+Triple DES with either two or three intermediate keys.
+
+* `RSA/ECB/NoPadding`
+* `RSA/ECB/OAEPPadding`
+* `RSA/ECB/OAEPWithSHA-1AndMGF1Padding`
+* `RSA/ECB/OAEPWithSHA-224AndMGF1Padding`
+* `RSA/ECB/OAEPWithSHA-256AndMGF1Padding`
+* `RSA/ECB/OAEPWithSHA-384AndMGF1Padding`
+* `RSA/ECB/OAEPWithSHA-512AndMGF1Padding`
+* `RSA/ECB/PKCS1Padding`
+
+Conscrypt's OAEP ciphers (eg, `RSA/ECB/OAEPWithSHA-256AndMGF1Padding`) use the named digest for
+both the main digest and the MGF1 digest.  This differs from the behavior of some other
+providers, including the ones bundled with OpenJDK, which always use SHA-1 for the MGF1 digest.
+For maximum compatibility, you should use `RSA/ECB/OAEPPadding` and initialize it with an
+[`OAEPParameterSpec`](https://docs.oracle.com/javase/9/docs/api/javax/crypto/spec/OAEPParameterSpec.html).
+
+### AlgorithmParameters
+* `AES`
+* `ChaCha20`
+* `DESEDE`
+* `EC`
+* `GCM`
+* `OAEP`
+* `PSS`
+
+### CertificateFactory
+* `X509`
+
+### KeyAgreement
+* `ECDH`
+
+### KeyFactory
+* `EC`
+* `RSA`
+
+### KeyGenerator
+* `AES`
+* `ARC4`
+* `ChaCha20`
+* `DESEDE`
+* `HmacMD5`
+* `HmacSHA1`
+* `HmacSHA224`
+* `HmacSHA256`
+* `HmacSHA384`
+* `HmacSHA512`
+
+### KeyPairGenerator
+* `EC`
+* `RSA`
+
+### Mac
+* `HmacMD5`
+* `HmacSHA1`
+* `HmacSHA224`
+* `HmacSHA256`
+* `HmacSHA384`
+* `HmacSHA512`
+
+### MessageDigest
+* `MD5`
+* `SHA-1`
+* `SHA-224`
+* `SHA-256`
+* `SHA-384`
+* `SHA-512`
+
+### SecretKeyFactory
+* `DESEDE`
+
+### SecureRandom
+* `SHA1PRNG`
+
+### Signature
+* `MD5withRSA`
+* `NONEwithECDSA`
+* `NONEwithRSA`
+* `SHA1withRSA`
+* `SHA1withECDSA`
+* `SHA1withRSA/PSS`
+* `SHA224withRSA`
+* `SHA224withECDSA`
+* `SHA224withRSA/PSS`
+* `SHA256withRSA`
+* `SHA256withECDSA`
+* `SHA256withRSA/PSS`
+* `SHA384withRSA`
+* `SHA384withECDSA`
+* `SHA384withRSA/PSS`
+* `SHA512withRSA`
+* `SHA512withECDSA`
+* `SHA512withRSA/PSS`

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -187,59 +187,59 @@ public final class OpenSSLProvider extends Provider {
         putECDHKeyAgreementImplClass("OpenSSLECDHKeyAgreement");
 
         /* == Signatures == */
-        putSignatureImplClass("MD5WithRSA", "OpenSSLSignature$MD5RSA");
-        put("Alg.Alias.Signature.MD5WithRSAEncryption", "MD5WithRSA");
-        put("Alg.Alias.Signature.MD5/RSA", "MD5WithRSA");
-        put("Alg.Alias.Signature.1.2.840.113549.1.1.4", "MD5WithRSA");
-        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.4", "MD5WithRSA");
-        put("Alg.Alias.Signature.1.2.840.113549.2.5with1.2.840.113549.1.1.1", "MD5WithRSA");
+        putSignatureImplClass("MD5withRSA", "OpenSSLSignature$MD5RSA");
+        put("Alg.Alias.Signature.MD5withRSAEncryption", "MD5withRSA");
+        put("Alg.Alias.Signature.MD5/RSA", "MD5withRSA");
+        put("Alg.Alias.Signature.1.2.840.113549.1.1.4", "MD5withRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.4", "MD5withRSA");
+        put("Alg.Alias.Signature.1.2.840.113549.2.5with1.2.840.113549.1.1.1", "MD5withRSA");
 
-        putSignatureImplClass("SHA1WithRSA", "OpenSSLSignature$SHA1RSA");
-        put("Alg.Alias.Signature.SHA1WithRSAEncryption", "SHA1WithRSA");
-        put("Alg.Alias.Signature.SHA1/RSA", "SHA1WithRSA");
-        put("Alg.Alias.Signature.SHA-1/RSA", "SHA1WithRSA");
-        put("Alg.Alias.Signature.1.2.840.113549.1.1.5", "SHA1WithRSA");
-        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.5", "SHA1WithRSA");
-        put("Alg.Alias.Signature.1.3.14.3.2.26with1.2.840.113549.1.1.1", "SHA1WithRSA");
-        put("Alg.Alias.Signature.1.3.14.3.2.26with1.2.840.113549.1.1.5", "SHA1WithRSA");
-        put("Alg.Alias.Signature.1.3.14.3.2.29", "SHA1WithRSA");
-        put("Alg.Alias.Signature.OID.1.3.14.3.2.29", "SHA1WithRSA");
+        putSignatureImplClass("SHA1withRSA", "OpenSSLSignature$SHA1RSA");
+        put("Alg.Alias.Signature.SHA1withRSAEncryption", "SHA1withRSA");
+        put("Alg.Alias.Signature.SHA1/RSA", "SHA1withRSA");
+        put("Alg.Alias.Signature.SHA-1/RSA", "SHA1withRSA");
+        put("Alg.Alias.Signature.1.2.840.113549.1.1.5", "SHA1withRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.5", "SHA1withRSA");
+        put("Alg.Alias.Signature.1.3.14.3.2.26with1.2.840.113549.1.1.1", "SHA1withRSA");
+        put("Alg.Alias.Signature.1.3.14.3.2.26with1.2.840.113549.1.1.5", "SHA1withRSA");
+        put("Alg.Alias.Signature.1.3.14.3.2.29", "SHA1withRSA");
+        put("Alg.Alias.Signature.OID.1.3.14.3.2.29", "SHA1withRSA");
 
-        putSignatureImplClass("SHA224WithRSA", "OpenSSLSignature$SHA224RSA");
-        put("Alg.Alias.Signature.SHA224WithRSAEncryption", "SHA224WithRSA");
-        put("Alg.Alias.Signature.SHA224/RSA", "SHA224WithRSA");
-        put("Alg.Alias.Signature.1.2.840.113549.1.1.14", "SHA224WithRSA");
-        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.14", "SHA224WithRSA");
+        putSignatureImplClass("SHA224withRSA", "OpenSSLSignature$SHA224RSA");
+        put("Alg.Alias.Signature.SHA224withRSAEncryption", "SHA224withRSA");
+        put("Alg.Alias.Signature.SHA224/RSA", "SHA224withRSA");
+        put("Alg.Alias.Signature.1.2.840.113549.1.1.14", "SHA224withRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.14", "SHA224withRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.4with1.2.840.113549.1.1.1",
-                "SHA224WithRSA");
+                "SHA224withRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.4with1.2.840.113549.1.1.14",
-                "SHA224WithRSA");
+                "SHA224withRSA");
 
-        putSignatureImplClass("SHA256WithRSA", "OpenSSLSignature$SHA256RSA");
-        put("Alg.Alias.Signature.SHA256WithRSAEncryption", "SHA256WithRSA");
-        put("Alg.Alias.Signature.SHA256/RSA", "SHA256WithRSA");
-        put("Alg.Alias.Signature.1.2.840.113549.1.1.11", "SHA256WithRSA");
-        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.11", "SHA256WithRSA");
+        putSignatureImplClass("SHA256withRSA", "OpenSSLSignature$SHA256RSA");
+        put("Alg.Alias.Signature.SHA256withRSAEncryption", "SHA256withRSA");
+        put("Alg.Alias.Signature.SHA256/RSA", "SHA256withRSA");
+        put("Alg.Alias.Signature.1.2.840.113549.1.1.11", "SHA256withRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.11", "SHA256withRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.1with1.2.840.113549.1.1.1",
-                "SHA256WithRSA");
+                "SHA256withRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.1with1.2.840.113549.1.1.11",
-                "SHA256WithRSA");
+                "SHA256withRSA");
 
-        putSignatureImplClass("SHA384WithRSA", "OpenSSLSignature$SHA384RSA");
-        put("Alg.Alias.Signature.SHA384WithRSAEncryption", "SHA384WithRSA");
-        put("Alg.Alias.Signature.SHA384/RSA", "SHA384WithRSA");
-        put("Alg.Alias.Signature.1.2.840.113549.1.1.12", "SHA384WithRSA");
-        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.12", "SHA384WithRSA");
+        putSignatureImplClass("SHA384withRSA", "OpenSSLSignature$SHA384RSA");
+        put("Alg.Alias.Signature.SHA384withRSAEncryption", "SHA384withRSA");
+        put("Alg.Alias.Signature.SHA384/RSA", "SHA384withRSA");
+        put("Alg.Alias.Signature.1.2.840.113549.1.1.12", "SHA384withRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.12", "SHA384withRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.2with1.2.840.113549.1.1.1",
-                "SHA384WithRSA");
+                "SHA384withRSA");
 
-        putSignatureImplClass("SHA512WithRSA", "OpenSSLSignature$SHA512RSA");
-        put("Alg.Alias.Signature.SHA512WithRSAEncryption", "SHA512WithRSA");
-        put("Alg.Alias.Signature.SHA512/RSA", "SHA512WithRSA");
-        put("Alg.Alias.Signature.1.2.840.113549.1.1.13", "SHA512WithRSA");
-        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.13", "SHA512WithRSA");
+        putSignatureImplClass("SHA512withRSA", "OpenSSLSignature$SHA512RSA");
+        put("Alg.Alias.Signature.SHA512withRSAEncryption", "SHA512withRSA");
+        put("Alg.Alias.Signature.SHA512/RSA", "SHA512withRSA");
+        put("Alg.Alias.Signature.1.2.840.113549.1.1.13", "SHA512withRSA");
+        put("Alg.Alias.Signature.OID.1.2.840.113549.1.1.13", "SHA512withRSA");
         put("Alg.Alias.Signature.2.16.840.1.101.3.4.2.3with1.2.840.113549.1.1.1",
-                "SHA512WithRSA");
+                "SHA512withRSA");
 
         putRAWRSASignatureImplClass("OpenSSLSignatureRawRSA");
 


### PR DESCRIPTION
This will be useful to indicate what we do and don't support, as well
as a place to indicate our implementation-specific choices (like MGF1
digest or TLS 1.3 choices).

Also standardize on lowercase "with" in Signature algorithm IDs.  The
RSA ones used "With" and the ECDSA and PSS ones used "with", so it's
2:1 in favor of lowercase.  JCA algorithm identifiers are matched
case-insensitively, so this is just for display purposes.