### PR TITLE
fix #491 ConscryptEngine.closeInbound should free resources

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -457,7 +457,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
                 return;
             }
             if (isOutboundDone()) {
-                transitionTo(STATE_CLOSED);
+                closeAndFreeResources();
             } else {
                 transitionTo(STATE_CLOSED_INBOUND);
             }


### PR DESCRIPTION
If closeOutbound is invoked prior to closeInbound, resources should
be freed.