### PR TITLE
Support opaque keys with RSA-PSS signatures.

### DIFF
--- a/common/src/main/java/org/conscrypt/CryptoUpcalls.java
+++ b/common/src/main/java/org/conscrypt/CryptoUpcalls.java
@@ -127,19 +127,7 @@ final class CryptoUpcalls {
 
     static byte[] rsaSignDigestWithPrivateKey(PrivateKey javaKey, int openSSLPadding,
             byte[] message) {
-        if (!"RSA".equals(javaKey.getAlgorithm())) {
-            throw new RuntimeException("Unexpected key type: " + javaKey.toString());
-        }
-        switch (openSSLPadding) {
-            case NativeConstants.RSA_PKCS1_PADDING:
-                return signDigestWithPrivateKey(javaKey, message, "NONEwithRSA");
-            case NativeConstants.RSA_NO_PADDING:
-            case NativeConstants.RSA_PKCS1_OAEP_PADDING:
-                return rsaOpWithPrivateKey(javaKey, openSSLPadding, Cipher.ENCRYPT_MODE, message);
-            default:
-                logger.warning("Unsupported OpenSSL/BoringSSL padding: " + openSSLPadding);
-                return null;
-        }
+        return rsaOpWithPrivateKey(javaKey, openSSLPadding, Cipher.ENCRYPT_MODE, message);
     }
 
     static byte[] rsaDecryptWithPrivateKey(PrivateKey javaKey, int openSSLPadding, byte[] input) {

--- a/common/src/main/java/org/conscrypt/CryptoUpcalls.java
+++ b/common/src/main/java/org/conscrypt/CryptoUpcalls.java
@@ -127,6 +127,7 @@ final class CryptoUpcalls {
 
     static byte[] rsaSignDigestWithPrivateKey(PrivateKey javaKey, int openSSLPadding,
             byte[] message) {
+        // An RSA cipher + ENCRYPT_MODE produces a standard RSA signature
         return rsaOpWithPrivateKey(javaKey, openSSLPadding, Cipher.ENCRYPT_MODE, message);
     }
 
@@ -145,6 +146,8 @@ final class CryptoUpcalls {
         String jcaPadding;
         switch (openSSLPadding) {
             case NativeConstants.RSA_PKCS1_PADDING:
+                // Since we're using this with a private key, this will produce RSASSA-PKCS1-v1_5
+                // (signature) padding rather than RSAES-PKCS1-v1_5 (encryption) padding
                 jcaPadding = "PKCS1Padding";
                 break;
             case NativeConstants.RSA_NO_PADDING:

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -1040,6 +1040,9 @@ public class SSLSocketTest {
         run_SSLSocket_clientAuth_OpaqueKey(TestKeyStore.getClientEcEcCertificate());
     }
     private void run_SSLSocket_clientAuth_OpaqueKey(TestKeyStore keyStore) throws Exception {
+        // OpaqueProvider will not be allowed to operate if the VM we're running on
+        // requires Oracle signatures for provider jars, since we don't sign the test jar.
+        TestUtils.assumeAllowsUnsignedCrypto();
         try {
             Security.insertProviderAt(new OpaqueProvider(), 1);
             final TestSSLContext c = TestSSLContext.create(keyStore, TestKeyStore.getServer());

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -53,6 +53,7 @@ import java.security.InvalidParameterException;
 import java.security.Key;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.Provider;
@@ -188,6 +189,7 @@ public class SSLSocketTest {
                     + "test_SSLSocket_getSupportedCipherSuites_connect:\n" + error);
         }
     }
+
     private void test_SSLSocket_getSupportedCipherSuites_connect(
             TestKeyStore testKeyStore, StringBuilder error) throws Exception {
         String clientToServerString = "this is sent from the client to the server...";
@@ -1109,9 +1111,9 @@ public class SSLSocketTest {
         static final String NAME = "OpaqueProvider";
         public OpaqueProvider() {
             super(NAME, 1.0, "test provider");
-            put("Signature.NONEwithRSA", OpaqueSignatureSpi.RSA.class.getName());
             put("Signature.NONEwithECDSA", OpaqueSignatureSpi.ECDSA.class.getName());
-            put("Cipher.RSA/ECB/NoPadding", OpaqueCipherSpi.class.getName());
+            put("Cipher.RSA/ECB/NoPadding", OpaqueCipherSpi.NoPadding.class.getName());
+            put("Cipher.RSA/ECB/PKCS1Padding", OpaqueCipherSpi.PKCS1Padding.class.getName());
         }
     }
     protected static class OpaqueSignatureSpi extends SignatureSpi {
@@ -1119,11 +1121,6 @@ public class SSLSocketTest {
         private Signature delegate;
         OpaqueSignatureSpi(String algorithm) {
             this.algorithm = algorithm;
-        }
-        public final static class RSA extends OpaqueSignatureSpi {
-            public RSA() {
-                super("NONEwithRSA");
-            }
         }
         public final static class ECDSA extends OpaqueSignatureSpi {
             public ECDSA() {
@@ -1172,9 +1169,22 @@ public class SSLSocketTest {
             return delegate.getParameter(param);
         }
     }
-    public static class OpaqueCipherSpi extends CipherSpi {
+    protected static class OpaqueCipherSpi extends CipherSpi {
         private Cipher delegate;
-        public OpaqueCipherSpi() {}
+        private final String algorithm;
+        public OpaqueCipherSpi(String algorithm) {
+            this.algorithm = algorithm;
+        }
+        public static final class NoPadding extends OpaqueCipherSpi {
+            public NoPadding() {
+                super("RSA/ECB/NoPadding");
+            }
+        }
+        public static final class PKCS1Padding extends OpaqueCipherSpi {
+            public PKCS1Padding() {
+                super("RSA/ECB/PKCS1Padding");
+            }
+        }
         @Override
         protected void engineSetMode(String mode) throws NoSuchAlgorithmException {
             fail();
@@ -1203,14 +1213,16 @@ public class SSLSocketTest {
         protected void engineInit(int opmode, Key key, SecureRandom random)
                 throws InvalidKeyException {
             getCipher();
-            delegate.init(opmode, key, random);
+            delegate.init(opmode, ((OpaqueDelegatingRSAPrivateKey) key).getDelegate(), random);
         }
         void getCipher() throws InvalidKeyException {
             try {
-                delegate = Cipher.getInstance("RSA/ECB/NoPadding");
+                delegate = Cipher.getInstance(algorithm, StandardNames.JSSE_PROVIDER_NAME);
             } catch (NoSuchAlgorithmException e) {
                 throw new InvalidKeyException(e);
             } catch (NoSuchPaddingException e) {
+                throw new InvalidKeyException(e);
+            } catch (NoSuchProviderException e) {
                 throw new InvalidKeyException(e);
             }
         }
@@ -1219,14 +1231,16 @@ public class SSLSocketTest {
                 int opmode, Key key, AlgorithmParameterSpec params, SecureRandom random)
                 throws InvalidKeyException, InvalidAlgorithmParameterException {
             getCipher();
-            delegate.init(opmode, key, params, random);
+            delegate.init(opmode, ((OpaqueDelegatingRSAPrivateKey) key).getDelegate(), params,
+                    random);
         }
         @Override
         protected void engineInit(
                 int opmode, Key key, AlgorithmParameters params, SecureRandom random)
                 throws InvalidKeyException, InvalidAlgorithmParameterException {
             getCipher();
-            delegate.init(opmode, key, params, random);
+            delegate.init(opmode, ((OpaqueDelegatingRSAPrivateKey) key).getDelegate(), params,
+                    random);
         }
         @Override
         protected byte[] engineUpdate(byte[] input, int inputOffset, int inputLen) {
@@ -1240,7 +1254,7 @@ public class SSLSocketTest {
         @Override
         protected byte[] engineDoFinal(byte[] input, int inputOffset, int inputLen)
                 throws IllegalBlockSizeException, BadPaddingException {
-            return delegate.update(input, inputOffset, inputLen);
+            return delegate.doFinal(input, inputOffset, inputLen);
         }
         @Override
         protected int engineDoFinal(


### PR DESCRIPTION
TLS 1.3 only uses RSA-PSS signatures (rather than RSA-PKCS#1), so we
need to support these.  Implement it by switching to
Cipher.RSA/ECB/NoPadding instead of using Signature.RSA.  Fix the
opaque key tests so they actually work properly.