### PR TITLE
Support TLS 1.3 sessions.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -8755,6 +8755,18 @@ static jstring NativeCrypto_SSL_SESSION_cipher(JNIEnv* env, jclass, jlong ssl_se
     return env->NewStringUTF(name);
 }
 
+static jboolean NativeCrypto_SSL_SESSION_should_be_single_use(JNIEnv* env, jclass, jlong ssl_session_address) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    SSL_SESSION* ssl_session = to_SSL_SESSION(env, ssl_session_address, true);
+    JNI_TRACE("ssl_session=%p NativeCrypto_SSL_SESSION_should_be_single_use", ssl_session);
+    if (ssl_session == nullptr) {
+        return JNI_FALSE;
+    }
+    int single_use = SSL_SESSION_should_be_single_use(ssl_session);
+    JNI_TRACE("ssl_session=%p NativeCrypto_SSL_SESSION_should_be_single_use => %d", ssl_session, single_use);
+    return single_use ? JNI_TRUE : JNI_FALSE;
+}
+
 /**
  * Increments the reference count of the session.
  */
@@ -10215,6 +10227,7 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(SSL_session_id, "(J" REF_SSL ")[B"),
         CONSCRYPT_NATIVE_METHOD(SSL_SESSION_get_version, "(J)Ljava/lang/String;"),
         CONSCRYPT_NATIVE_METHOD(SSL_SESSION_cipher, "(J)Ljava/lang/String;"),
+        CONSCRYPT_NATIVE_METHOD(SSL_SESSION_should_be_single_use, "(J)Z"),
         CONSCRYPT_NATIVE_METHOD(SSL_SESSION_up_ref, "(J)V"),
         CONSCRYPT_NATIVE_METHOD(SSL_SESSION_free, "(J)V"),
         CONSCRYPT_NATIVE_METHOD(i2d_SSL_SESSION, "(J)[B"),

--- a/common/src/main/java/org/conscrypt/AbstractSessionContext.java
+++ b/common/src/main/java/org/conscrypt/AbstractSessionContext.java
@@ -255,7 +255,9 @@ abstract class AbstractSessionContext implements SSLSessionContext {
             return session;
         }
 
-        // Not found in-memory - look it up in the persistent cache.
+        // Look in persistent cache.  We don't currently delete sessions from the persistent
+        // cache, so we may find a multi-use (aka TLS 1.2) session after having received and
+        // then used up one or more single-use (aka TLS 1.3) sessions.
         return getSessionFromPersistentCache(sessionId);
     }
 

--- a/common/src/main/java/org/conscrypt/AbstractSessionContext.java
+++ b/common/src/main/java/org/conscrypt/AbstractSessionContext.java
@@ -205,11 +205,14 @@ abstract class AbstractSessionContext implements SSLSessionContext {
             return;
         }
 
-        // Let the subclass know.
-        onBeforeAddSession(session);
-
-        ByteArray key = new ByteArray(id);
         synchronized (sessions) {
+            ByteArray key = new ByteArray(id);
+            if (sessions.containsKey(key)) {
+                removeSession(sessions.get(key));
+            }
+            // Let the subclass know.
+            onBeforeAddSession(session);
+
             sessions.put(key, session);
         }
     }

--- a/common/src/main/java/org/conscrypt/AbstractSessionContext.java
+++ b/common/src/main/java/org/conscrypt/AbstractSessionContext.java
@@ -215,6 +215,23 @@ abstract class AbstractSessionContext implements SSLSessionContext {
     }
 
     /**
+     * Removes the given session from the cache.
+     */
+    final void removeSession(NativeSslSession session) {
+        byte[] id = session.getId();
+        if (id == null || id.length == 0) {
+            return;
+        }
+
+        onBeforeRemoveSession(session);
+
+        ByteArray key = new ByteArray(id);
+        synchronized (sessions) {
+            sessions.remove(key);
+        }
+    }
+
+    /**
      * Called for server sessions only. Retrieves the session by its ID. Overridden by
      * {@link ServerSessionContext} to
      */
@@ -229,6 +246,9 @@ abstract class AbstractSessionContext implements SSLSessionContext {
             session = sessions.get(new ByteArray(sessionId));
         }
         if (session != null && session.isValid()) {
+            if (session.isSingleUse()) {
+                removeSession(session);
+            }
             return session;
         }
 

--- a/common/src/main/java/org/conscrypt/ClientSessionContext.java
+++ b/common/src/main/java/org/conscrypt/ClientSessionContext.java
@@ -133,7 +133,9 @@ public final class ClientSessionContext extends AbstractSessionContext {
             return session;
         }
 
-        // Look in persistent cache.
+        // Look in persistent cache.  We don't currently delete sessions from the persistent
+        // cache, so we may find a multi-use (aka TLS 1.2) session after having received and
+        // then used up one or more single-use (aka TLS 1.3) sessions.
         if (persistentCache != null) {
             byte[] data = persistentCache.getSessionData(host, port);
             if (data != null) {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1125,6 +1125,8 @@ public final class NativeCrypto {
 
     static native String SSL_SESSION_cipher(long sslSessionNativePointer);
 
+    static native boolean SSL_SESSION_should_be_single_use(long sslSessionNativePointer);
+
     static native void SSL_SESSION_up_ref(long sslSessionNativePointer);
 
     static native void SSL_SESSION_free(long sslSessionNativePointer);

--- a/common/src/main/java/org/conscrypt/NativeSslSession.java
+++ b/common/src/main/java/org/conscrypt/NativeSslSession.java
@@ -166,6 +166,11 @@ abstract class NativeSslSession {
 
     abstract boolean isValid();
 
+    /**
+     * Returns whether this session should only ever be used for resumption once.
+     */
+    abstract boolean isSingleUse();
+
     abstract void offerToResume(NativeSsl ssl) throws SSLException;
 
     abstract String getCipherSuite();
@@ -255,6 +260,11 @@ abstract class NativeSslSession {
                                                  NativeCrypto.SSL_SESSION_get_timeout(ref.context)))
                     * 1000;
             return (System.currentTimeMillis() - timeoutMillis) < creationTimeMillis;
+        }
+
+        @Override
+        boolean isSingleUse() {
+            return NativeCrypto.SSL_SESSION_should_be_single_use(ref.context);
         }
 
         @Override

--- a/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
+++ b/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
@@ -98,24 +98,24 @@ public abstract class AbstractSessionContextTest<T extends AbstractSessionContex
 
     @Test
     public void testRemoveIfSingleUse() {
-        NativeSslSession a = new MockSessionBuilder().host("a").singleUse(false).build();
-        NativeSslSession b = new MockSessionBuilder().host("b").singleUse(true).build();
+        NativeSslSession multi = new MockSessionBuilder().host("multi").singleUse(false).build();
+        NativeSslSession single = new MockSessionBuilder().host("single").singleUse(true).build();
 
-        context.cacheSession(a);
+        context.cacheSession(multi);
         assertEquals(1, size(context));
 
-        context.cacheSession(b);
+        context.cacheSession(single);
         assertEquals(2, size(context));
 
-        NativeSslSession out = getCachedSession(context, a);
-        assertEquals(a, out);
+        NativeSslSession out = getCachedSession(context, multi);
+        assertEquals(multi, out);
         assertEquals(2, size(context));
 
-        out = getCachedSession(context, b);
-        assertEquals(b, out);
+        out = getCachedSession(context, single);
+        assertEquals(single, out);
         assertEquals(1, size(context));
 
-        assertNull(getCachedSession(context, b));
+        assertNull(getCachedSession(context, single));
     }
 
     @Test

--- a/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
+++ b/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
@@ -98,7 +98,6 @@ public abstract class AbstractSessionContextTest<T extends AbstractSessionContex
 
     @Test
     public void testRemoveIfSingleUse() {
-        context.setSessionCacheSize(10);
         NativeSslSession a = new MockSessionBuilder().host("a").singleUse(false).build();
         NativeSslSession b = new MockSessionBuilder().host("b").singleUse(true).build();
 

--- a/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
+++ b/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
@@ -97,6 +97,29 @@ public abstract class AbstractSessionContextTest<T extends AbstractSessionContex
     }
 
     @Test
+    public void testRemoveIfSingleUse() {
+        context.setSessionCacheSize(10);
+        NativeSslSession a = new MockSessionBuilder().host("a").singleUse(false).build();
+        NativeSslSession b = new MockSessionBuilder().host("b").singleUse(true).build();
+
+        context.cacheSession(a);
+        assertEquals(1, size(context));
+
+        context.cacheSession(b);
+        assertEquals(2, size(context));
+
+        NativeSslSession out = getCachedSession(context, a);
+        assertEquals(a, out);
+        assertEquals(2, size(context));
+
+        out = getCachedSession(context, b);
+        assertEquals(b, out);
+        assertEquals(1, size(context));
+
+        assertNull(getCachedSession(context, b));
+    }
+
+    @Test
     public void testSerializeSession() throws Exception {
         Certificate mockCert = mock(Certificate.class);
         when(mockCert.getEncoded()).thenReturn(new byte[] {0x05, 0x06, 0x07, 0x10});

--- a/openjdk/src/test/java/org/conscrypt/ClientSessionContextTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ClientSessionContextTest.java
@@ -19,6 +19,7 @@ package org.conscrypt;
 import static org.conscrypt.MockSessionBuilder.DEFAULT_PORT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import java.security.KeyManagementException;
 import org.junit.Test;
@@ -88,5 +89,28 @@ public class ClientSessionContextTest extends AbstractSessionContextTest<ClientS
 
         out = context.getCachedSession("b", DEFAULT_PORT, getDefaultSSLParameters());
         assertNull(out);
+    }
+
+    @Test
+    public void testCanRetrieveMultipleSingleUseSessions() {
+        ClientSessionContext context = newContext();
+
+        NativeSslSession single1 = new MockSessionBuilder()
+                .id(new byte[] {1}).host("host").singleUse(true).build();
+        NativeSslSession single2 = new MockSessionBuilder()
+                .id(new byte[] {2}).host("host").singleUse(true).build();
+
+        context.cacheSession(single1);
+        assertEquals(1, size(context));
+
+        context.cacheSession(single2);
+        assertEquals(2, size(context));
+
+        assertSame(single1,
+                context.getCachedSession("host", DEFAULT_PORT, getDefaultSSLParameters()));
+        assertEquals(1, size(context));
+        assertSame(single2,
+                context.getCachedSession("host", DEFAULT_PORT, getDefaultSSLParameters()));
+        assertEquals(0, size(context));
     }
 }

--- a/openjdk/src/test/java/org/conscrypt/ClientSessionContextTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ClientSessionContextTest.java
@@ -17,8 +17,11 @@
 package org.conscrypt;
 
 import static org.conscrypt.MockSessionBuilder.DEFAULT_PORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.security.KeyManagementException;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -47,5 +50,43 @@ public class ClientSessionContextTest extends AbstractSessionContextTest<ClientS
         } catch (KeyManagementException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void testNoMixingOfSingleAndMultiUseSessions() {
+        ClientSessionContext context = newContext();
+
+        NativeSslSession a = new MockSessionBuilder().host("a").singleUse(false).build();
+        NativeSslSession bSingle1 = new MockSessionBuilder()
+                .id(new byte[] {1}).host("b").singleUse(true).build();
+        NativeSslSession bSingle2 = new MockSessionBuilder()
+                .id(new byte[] {2}).host("b").singleUse(true).build();
+        NativeSslSession bMulti = new MockSessionBuilder()
+                .id(new byte[] {3}).host("b").singleUse(false).build();
+
+        context.cacheSession(a);
+        assertEquals(1, size(context));
+
+        context.cacheSession(bSingle1);
+        assertEquals(2, size(context));
+
+        context.cacheSession(bSingle2);
+        assertEquals(3, size(context));
+
+        context.cacheSession(bMulti);
+        assertEquals(2, size(context));
+
+        NativeSslSession out = context.getCachedSession(
+                "b", DEFAULT_PORT, getDefaultSSLParameters());
+        assertEquals(bMulti, out);
+
+        context.cacheSession(bSingle2);
+        assertEquals(2, size(context));
+
+        out = context.getCachedSession("b", DEFAULT_PORT, getDefaultSSLParameters());
+        assertEquals(bSingle2, out);
+
+        out = context.getCachedSession("b", DEFAULT_PORT, getDefaultSSLParameters());
+        assertNull(out);
     }
 }

--- a/openjdk/src/test/java/org/conscrypt/MockSessionBuilder.java
+++ b/openjdk/src/test/java/org/conscrypt/MockSessionBuilder.java
@@ -28,6 +28,7 @@ final class MockSessionBuilder {
 
     private byte[] id;
     private boolean valid = true;
+    private boolean singleUse = false;
     private String host;
     private int port = DEFAULT_PORT;
     private String cipherSuite = DEFAULT_CIPHER_SUITE;
@@ -63,11 +64,17 @@ final class MockSessionBuilder {
         return this;
     }
 
+    MockSessionBuilder singleUse(boolean singleUse) {
+        this.singleUse = singleUse;
+        return this;
+    }
+
     NativeSslSession build() {
         NativeSslSession session = mock(NativeSslSession.class);
         byte[] id = this.id == null ? host.getBytes(UTF_8) : this.id;
         when(session.getId()).thenReturn(id);
         when(session.isValid()).thenReturn(valid);
+        when(session.isSingleUse()).thenReturn(singleUse);
         when(session.getProtocol()).thenReturn(TestUtils.getProtocols()[0]);
         when(session.getPeerHost()).thenReturn(host);
         when(session.getPeerPort()).thenReturn(port);


### PR DESCRIPTION
TLS 1.3 sessions are designed to only be used once, preventing correlation
across connections.  This implements support for those sessions by
removing such sessions from the cache whenever they're retrieved from
the session cache and not sending them to the persistent
(filesystem-based) cache, which we currently cannot delete individual
items from.

Also switch our per-host-port caches to support a list of cached
sessions rather than a single one, so that if we get multiple sessions
from the peer we can cache them all and use them when establishing
multiple connections in parallel or such things.