### PR TITLE
Provide TrustManagerFactory

### DIFF
--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -82,6 +82,23 @@ public final class Conscrypt {
     }
 
     /**
+     * Constructs a new {@link Provider} with the default name that also provides an implementation
+     * of {@link javax.net.ssl.TrustManagerFactory}.
+     */
+    public static Provider newProviderWithTrustManager() {
+        return newProviderWithTrustManager(Platform.getDefaultProviderName());
+    }
+
+    /**
+     * Constructs a new {@link Provider} with the given name that also provides an implementation
+     * of {@link javax.net.ssl.TrustManagerFactory}.
+     */
+    public static Provider newProviderWithTrustManager(String providerName) {
+        checkAvailability();
+        return new OpenSSLProvider(providerName, true);
+    }
+
+    /**
      * Returns the maximum length (in bytes) of an encrypted packet.
      */
     public static int maxEncryptedPacketLength() {

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -75,27 +75,45 @@ public final class Conscrypt {
 
     /**
      * Constructs a new {@link Provider} with the given name.
+     *
+     * @deprecated Use {@link #newProviderBuilder()} instead.
      */
+    @Deprecated
     public static Provider newProvider(String providerName) {
         checkAvailability();
         return new OpenSSLProvider(providerName);
     }
 
-    /**
-     * Constructs a new {@link Provider} with the default name that also provides an implementation
-     * of {@link javax.net.ssl.TrustManagerFactory}.
-     */
-    public static Provider newProviderWithTrustManager() {
-        return newProviderWithTrustManager(Platform.getDefaultProviderName());
+    public static class ProviderBuilder {
+        private String name;
+        private boolean provideTrustManager = false;
+
+        private ProviderBuilder() {}
+
+        /**
+         * Sets the name of the Provider to be built.
+         */
+        public ProviderBuilder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Causes the returned provider to provide an implementation of
+         * {@link javax.net.ssl.TrustManagerFactory}.
+         */
+        public ProviderBuilder provideTrustManager() {
+            this.provideTrustManager = true;
+            return this;
+        }
+
+        public Provider build() {
+            return new OpenSSLProvider(name, provideTrustManager);
+        }
     }
 
-    /**
-     * Constructs a new {@link Provider} with the given name that also provides an implementation
-     * of {@link javax.net.ssl.TrustManagerFactory}.
-     */
-    public static Provider newProviderWithTrustManager(String providerName) {
-        checkAvailability();
-        return new OpenSSLProvider(providerName, true);
+    public static ProviderBuilder newProviderBuilder() {
+        return new ProviderBuilder();
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -81,12 +81,12 @@ public final class Conscrypt {
     @Deprecated
     public static Provider newProvider(String providerName) {
         checkAvailability();
-        return new OpenSSLProvider(providerName);
+        return new OpenSSLProvider(providerName, false);
     }
 
     public static class ProviderBuilder {
-        private String name;
-        private boolean provideTrustManager = false;
+        private String name = Platform.getDefaultProviderName();
+        private boolean provideTrustManager;
 
         private ProviderBuilder() {}
 

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -50,6 +50,10 @@ public final class OpenSSLProvider extends Provider {
     }
 
     public OpenSSLProvider(String providerName) {
+        this(providerName, false);
+    }
+
+    public OpenSSLProvider(String providerName, boolean includeTrustManager) {
         super(providerName, 1.0, "Android's OpenSSL-backed security provider");
 
         // Ensure that the native library has been loaded.
@@ -68,6 +72,11 @@ public final class OpenSSLProvider extends Provider {
         put("SSLContext.TLSv1.1", classOpenSSLContextImpl + "$TLSv11");
         put("SSLContext.TLSv1.2", tls12SSLContext);
         put("SSLContext.Default", PREFIX + "DefaultSSLContextImpl");
+
+        if (includeTrustManager) {
+            put("TrustManagerFactory.PKIX", TrustManagerFactoryImpl.class.getName());
+            put("Alg.Alias.TrustManagerFactory.X509", "PKIX");
+        }
 
         /* === AlgorithmParameters === */
         put("AlgorithmParameters.AES", PREFIX + "IvParameters$AES");

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -53,7 +53,7 @@ public final class OpenSSLProvider extends Provider {
         this(providerName, false);
     }
 
-    public OpenSSLProvider(String providerName, boolean includeTrustManager) {
+    OpenSSLProvider(String providerName, boolean includeTrustManager) {
         super(providerName, 1.0, "Android's OpenSSL-backed security provider");
 
         // Ensure that the native library has been loaded.

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -181,7 +181,8 @@ public final class TestUtils {
 
     public static Provider getConscryptProvider() {
         try {
-            return (Provider) conscryptClass("OpenSSLProvider").getConstructor().newInstance();
+            return (Provider) conscryptClass("Conscrypt")
+                    .getMethod("newProviderWithTrustManager").invoke(null);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -181,8 +181,13 @@ public final class TestUtils {
 
     public static Provider getConscryptProvider() {
         try {
-            return (Provider) conscryptClass("Conscrypt")
-                    .getMethod("newProviderWithTrustManager").invoke(null);
+            if (isClassAvailable("javax.net.ssl.X509ExtendedTrustManager")) {
+                return (Provider) conscryptClass("Conscrypt")
+                        .getMethod("newProviderWithTrustManager").invoke(null);
+            } else {
+                return (Provider) conscryptClass("Conscrypt")
+                        .getMethod("newProvider").invoke(null);
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -181,12 +181,15 @@ public final class TestUtils {
 
     public static Provider getConscryptProvider() {
         try {
-            if (isClassAvailable("javax.net.ssl.X509ExtendedTrustManager")) {
-                return (Provider) conscryptClass("Conscrypt")
-                        .getMethod("newProviderWithTrustManager").invoke(null);
+            if (!isClassAvailable("javax.net.ssl.X509ExtendedTrustManager")) {
+                return (Provider) conscryptClass("OpenSSLProvider").getConstructor().newInstance();
             } else {
-                return (Provider) conscryptClass("Conscrypt")
-                        .getMethod("newProvider").invoke(null);
+                String defaultName = (String) conscryptClass("Platform")
+                    .getDeclaredMethod("getDefaultProviderName")
+                    .invoke(null);
+                return (Provider) conscryptClass("OpenSSLProvider")
+                    .getDeclaredConstructor(String.class, Boolean.TYPE)
+                    .newInstance(defaultName, true);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -181,15 +182,16 @@ public final class TestUtils {
 
     public static Provider getConscryptProvider() {
         try {
+            String defaultName = (String) conscryptClass("Platform")
+                .getDeclaredMethod("getDefaultProviderName")
+                .invoke(null);
+            Constructor<?> c = conscryptClass("OpenSSLProvider")
+                .getDeclaredConstructor(String.class, Boolean.TYPE);
+
             if (!isClassAvailable("javax.net.ssl.X509ExtendedTrustManager")) {
-                return (Provider) conscryptClass("OpenSSLProvider").getConstructor().newInstance();
+                return (Provider) c.newInstance(defaultName, false);
             } else {
-                String defaultName = (String) conscryptClass("Platform")
-                    .getDeclaredMethod("getDefaultProviderName")
-                    .invoke(null);
-                return (Provider) conscryptClass("OpenSSLProvider")
-                    .getDeclaredConstructor(String.class, Boolean.TYPE)
-                    .newInstance(defaultName, true);
+                return (Provider) c.newInstance(defaultName, true);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/testing/src/main/java/org/conscrypt/javax/net/ssl/TestHostnameVerifier.java
+++ b/testing/src/main/java/org/conscrypt/javax/net/ssl/TestHostnameVerifier.java
@@ -1,0 +1,55 @@
+package org.conscrypt.javax.net.ssl;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
+
+/**
+ * This class implements the simplest possible HostnameVerifier.
+ */
+public class TestHostnameVerifier implements HostnameVerifier {
+    @Override
+    public boolean verify(String hostname, SSLSession sslSession) {
+        try {
+            return verify(hostname, (X509Certificate) sslSession.getPeerCertificates()[0]);
+        } catch (SSLException e) {
+            return false;
+        }
+    }
+
+    private boolean verify(String hostname, X509Certificate cert) {
+        for (String certHost : getHostnames(cert)) {
+            if (certHost.equals(hostname)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static final int DNS_NAME_TYPE = 2;
+
+    private List<String> getHostnames(X509Certificate cert) {
+        List<String> result = new ArrayList<String>();
+        try {
+            Collection<List<?>> altNamePairs = cert.getSubjectAlternativeNames();
+            if (altNamePairs != null) {
+                for (List<?> altNamePair : altNamePairs) {
+                    // altNames are returned as effectively Pair<Integer, String> instances,
+                    // where the first member is the type of altName and the second is the name.
+                    if (altNamePair.get(0).equals(DNS_NAME_TYPE)) {
+                        result.add((String) altNamePair.get(1));
+                    }
+                }
+            }
+            return result;
+        } catch (CertificateParsingException e) {
+            return Collections.emptyList();
+        }
+    }
+}


### PR DESCRIPTION
This is necessary for users who want to enable TLS 1.3, since the
TrustManagerFactory implementation shipped with OpenJDK throws an
exception if it encounters an SSLSocket or SSLEngine that's negotiated
TLS 1.3.  Use our TrustManager in tests.

Also adds a HostnameVerifier in the tests that does the simplest
thing, because our TrustManager verifies hostnames by default, whereas
the OpenJDK one doesn't, and the bundled HostnameVerifier on OpenJDK
just fails to verify anything.