### PR TITLE
Reduce warning spam

### DIFF
--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -201,9 +201,6 @@ final class Platform {
         // This doesn't appear to be needed.
     }
 
-    /*
-     * Call Os.setsockoptTimeval via reflection.
-     */
     @SuppressWarnings("unused")
     static void setSocketWriteTimeout(@SuppressWarnings("unused") Socket s,
             @SuppressWarnings("unused") long timeoutMillis) throws SocketException {


### PR DESCRIPTION
A significant number of log statements from this Platform method were
due to bad file descriptors, so check for those and throw
SocketException, which mirrors what sockets do when they have a bad
file descriptor in other situations.