### PR TITLE
Tag release containers with release name

### DIFF
--- a/release/linux
+++ b/release/linux
@@ -26,8 +26,9 @@ git push upstream "$BRANCH"
 git push upstream "$1"
 
 # Build and start the Docker container
-docker build -t conscrypt-deploy release
-CONTAINER_ID=$(docker run -itd conscrypt-deploy)
+CONTAINER_TAG="conscrypt-deploy-$1"
+docker build -t $CONTAINER_TAG release
+CONTAINER_ID=$(docker run -itd $CONTAINER_TAG)
 
 # Copy the relevant files from the host machine into the container
 docker exec $CONTAINER_ID mkdir /root/.gradle


### PR DESCRIPTION
This makes it easier to build two releases in parallel, for cases
where we need to backport security fixes or otherwise build multiple
releases in short order.