### PR TITLE
Make TestUtils.readPublicKeyPemFile Windows-compatible

### DIFF
--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -225,6 +225,7 @@ public final class TestUtils {
         String keyData = new String(readTestFile(name), "US-ASCII");
         keyData = keyData.replace("-----BEGIN PUBLIC KEY-----", "");
         keyData = keyData.replace("-----END PUBLIC KEY-----", "");
+        keyData = keyData.replace("\r", "");
         keyData = keyData.replace("\n", "");
         return KeyFactory.getInstance("EC").generatePublic(
                 new X509EncodedKeySpec(decodeBase64(keyData)));


### PR DESCRIPTION
When line ending conversion occurs, the PEM files can end up with CR
characters in them, so we need to strip those as well to make the
tests pass on Windows.