### PR TITLE
Fix X509_verify exceptions

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -195,6 +195,12 @@ int throwIOException(JNIEnv* env, const char* message) {
     return conscrypt::jniutil::throwException(env, "java/io/IOException", message);
 }
 
+int throwCertificateException(JNIEnv* env, const char* message) {
+    JNI_TRACE("throwCertificateException %s", message);
+    return conscrypt::jniutil::throwException(
+            env, "java/security/cert/CertificateException", message);
+}
+
 int throwParsingException(JNIEnv* env, const char* message) {
     return conscrypt::jniutil::throwException(env, TO_STRING(JNI_JARJAR_PREFIX)
                             "org/conscrypt/OpenSSLX509CertificateFactory$ParsingException",

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4137,8 +4137,16 @@ static void NativeCrypto_X509_verify(JNIEnv* env, jclass, jlong x509Ref, CONSCRY
         return;
     }
 
+    if (X509_ALGOR_cmp(x509->sig_alg, X509_CINF_get_signature(X509_get_cert_info(x509)))) {
+        conscrypt::jniutil::throwCertificateException(env,
+                "Certificate signature algorithms do not match");
+        JNI_TRACE("X509_verify(%p, %p) => signature alg mismatch", x509, pkey);
+        return;
+    }
+
     if (X509_verify(x509, pkey) != 1) {
-        conscrypt::jniutil::throwExceptionFromBoringSSLError(env, "X509_verify");
+        conscrypt::jniutil::throwExceptionFromBoringSSLError(
+                env, "X509_verify", conscrypt::jniutil::throwCertificateException);
         JNI_TRACE("X509_verify(%p, %p) => verify failure", x509, pkey);
         return;
     }

--- a/common/src/jni/main/include/conscrypt/jniutil.h
+++ b/common/src/jni/main/include/conscrypt/jniutil.h
@@ -201,6 +201,11 @@ extern int throwNoSuchAlgorithmException(JNIEnv* env, const char* message);
 extern int throwIOException(JNIEnv* env, const char* message);
 
 /**
+ * Throws a CertificateException with the given string as a message.
+ */
+extern int throwCertificateException(JNIEnv* env, const char* message);
+
+/**
  * Throws a ParsingException with the given string as a message.
  */
 extern int throwParsingException(JNIEnv* env, const char* message);

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptJava6Suite.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptJava6Suite.java
@@ -36,6 +36,7 @@ import org.conscrypt.java.security.KeyPairGeneratorTestRSA;
 import org.conscrypt.java.security.MessageDigestTest;
 import org.conscrypt.java.security.SignatureTest;
 import org.conscrypt.java.security.cert.CertificateFactoryTest;
+import org.conscrypt.java.security.cert.X509CertificateTest;
 import org.conscrypt.javax.crypto.CipherBasicsTest;
 import org.conscrypt.javax.crypto.ECDHKeyAgreementTest;
 import org.conscrypt.javax.crypto.KeyGeneratorTest;
@@ -64,6 +65,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
         // java.security tests
         CertificateFactoryTest.class,
+        X509CertificateTest.class,
         AlgorithmParameterGeneratorTestDH.class,
         AlgorithmParameterGeneratorTestDSA.class,
         AlgorithmParametersPSSTest.class,

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
@@ -38,6 +38,7 @@ import org.conscrypt.java.security.KeyPairGeneratorTestRSA;
 import org.conscrypt.java.security.MessageDigestTest;
 import org.conscrypt.java.security.SignatureTest;
 import org.conscrypt.java.security.cert.CertificateFactoryTest;
+import org.conscrypt.java.security.cert.X509CertificateTest;
 import org.conscrypt.javax.crypto.CipherBasicsTest;
 import org.conscrypt.javax.crypto.CipherTest;
 import org.conscrypt.javax.crypto.ECDHKeyAgreementTest;
@@ -67,6 +68,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
         // java.security tests
         CertificateFactoryTest.class,
+        X509CertificateTest.class,
         AlgorithmParameterGeneratorTestDH.class,
         AlgorithmParameterGeneratorTestDSA.class,
         AlgorithmParametersPSSTest.class,

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt.java.security.cert;
+
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class X509CertificateTest {
+
+    /*
+     This certificate is a modified version of the following self-signed cert:
+
+     -----BEGIN CERTIFICATE-----
+     MIIFMjCCAxqgAwIBAgIJAL0mG5fOeJ7xMA0GCSqGSIb3DQEBCwUAMC0xCzAJBgNV
+     BAYTAkdCMQ8wDQYDVQQHDAZMb25kb24xDTALBgNVBAoMBFRlc3QwIBcNMTgwOTE3
+     MTIxNzU3WhgPMjExODA4MjQxMjE3NTdaMC0xCzAJBgNVBAYTAkdCMQ8wDQYDVQQH
+     DAZMb25kb24xDTALBgNVBAoMBFRlc3QwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw
+     ggIKAoICAQDCMhBrRAGGw+n2GdctBr/cEK4FZA6ajiHjihgpCHoSBdyL4R2jGKLS
+     g0WgaMXa1HpkKN7LcIySosEBPlmcRkr1RqbEvQStOSvoFCXYvtx3alM6HTbXMcDR
+     mqoKoABP6LXsPSoMWIgqMtP2X9EOppzHVIK1yFYFfbIlvYUV2Ka+MuMe0Vh5wvD1
+     4GanPb+cWSKgdRSVQovCCMY3yWtZKVEaxRpCsk/mYYIFWz0tcgMjIKwDx1XXgiAV
+     nU6NK43xbaw3XhtnaD/pv9lhTTbNrlcln9LjTD097BaK4R+1AEPHnpfxA9Ui3upn
+     kbsNUdGdOB0ksZi/vd7lh833YgquQUIAhYrbfvq/HFCpVV1gljzlS3sqULYpLE//
+     i3OsuL2mE+CYIJGpIi2GeJJWXciNMTJDOqTn+fRDtVb4RPp4Y70DJirp7XzaBi3q
+     H0edANCzPSRCDbZsOhzIXhXshldiXVRX666DDlbMQgLTEnNKrkwv6DmU8o15XQsb
+     8k1Os2YwXmkEOxUQ7AJZXVTZSf6UK9Znmdq1ZrHjybMfRUkHVxJcnKvrxfryralv
+     gzfvu+D6HuxrCo3Ojqa+nDgIbxKEBtdrcsMhq1jWPFhjwo1fSadAkKOfdCAuXJRD
+     THg3b4Sf+W7Cpc570YHrIpBf7WFl2XsPcEM0mJZ5+yATASCubNozQwIDAQABo1Mw
+     UTAdBgNVHQ4EFgQUES0hupZSqY21JOba10QyZuxm91EwHwYDVR0jBBgwFoAUES0h
+     upZSqY21JOba10QyZuxm91EwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsF
+     AAOCAgEABTN5S30ng/RMpBweDm2N561PdpaCdiRXtAFCRVWR2mkDYC/Xj9Vqe6be
+     PyM7L/5OKYVjzF1yJu67z/dx+ja5o+41g17jdqla7hyPx+9B4uRyDh+1KJTa+duj
+     mw/aA1LCr6O6W4WizDOsChJ6FaB2Y1+GlFnKWb5nUdhVJqXQE1WOX9dZnw8Y4Npd
+     VmAsjWot0BZorJrt3fwfcv3QfA896twkbo7Llv/8qzg4sXZXZ4ZtgAOqnPngiSn+
+     JT/vYCXZ406VvAFpFqMcVz2dO/VGuL8lGIMHRKNyafrsV81EzH1W/XmRWOgvgj6r
+     yQI63ln/AMY72HQ97xLkE1xKunGz6bK5Ug5+O43Uftc4Mb6MUgzo+ZqEQ3Ob+cAV
+     cvjmtwDaPO/O39O5Xq0tLTlkn2/cKf4OQ6S++GDxzyRVHh5JXgP4j9+jfZY57Woy
+     R1bE7N50JjY4cDermBJKdlBIjL7UPhqmLyaG7V0hBitFlgGBUCcJtJOV0xYd5aF3
+     pxNkvMXhBmh95fjxJ0cJjpO7tN1RAwtMMNgsl7OUbuVRQCHOPW5DgP5qY21jDeRn
+     BY82382l+9QzykmJLI5MZnmj4BA9uIDCwMtoTTvP++SsvhUAbuvh7MOOUQL0EY4m
+     KStYq7X9PKseN+PvmfeoffIKc5R/Ha39oi7cGMVHCr8aiEhsf94=
+     -----END CERTIFICATE-----
+
+     The cert has been modified to change the certificate data's signature algorithm
+     declaration from sha256withRSAEncryption to sha512withRSAEncryption.  This causes
+     the signature block's algorithm (which is unmodified) to not match the cert info.
+     */
+    private static final String MISMATCHED_ALGORITHM_CERT =
+            "-----BEGIN CERTIFICATE-----\n"
+            + "MIIFMjCCAxqgAwIBAgIJAL0mG5fOeJ7xMA0GCSqGSIb3DQEBDQUAMC0xCzAJBgNV\n"
+            + "BAYTAkdCMQ8wDQYDVQQHDAZMb25kb24xDTALBgNVBAoMBFRlc3QwIBcNMTgwOTE3\n"
+            + "MTIxNzU3WhgPMjExODA4MjQxMjE3NTdaMC0xCzAJBgNVBAYTAkdCMQ8wDQYDVQQH\n"
+            + "DAZMb25kb24xDTALBgNVBAoMBFRlc3QwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAw\n"
+            + "ggIKAoICAQDCMhBrRAGGw+n2GdctBr/cEK4FZA6ajiHjihgpCHoSBdyL4R2jGKLS\n"
+            + "g0WgaMXa1HpkKN7LcIySosEBPlmcRkr1RqbEvQStOSvoFCXYvtx3alM6HTbXMcDR\n"
+            + "mqoKoABP6LXsPSoMWIgqMtP2X9EOppzHVIK1yFYFfbIlvYUV2Ka+MuMe0Vh5wvD1\n"
+            + "4GanPb+cWSKgdRSVQovCCMY3yWtZKVEaxRpCsk/mYYIFWz0tcgMjIKwDx1XXgiAV\n"
+            + "nU6NK43xbaw3XhtnaD/pv9lhTTbNrlcln9LjTD097BaK4R+1AEPHnpfxA9Ui3upn\n"
+            + "kbsNUdGdOB0ksZi/vd7lh833YgquQUIAhYrbfvq/HFCpVV1gljzlS3sqULYpLE//\n"
+            + "i3OsuL2mE+CYIJGpIi2GeJJWXciNMTJDOqTn+fRDtVb4RPp4Y70DJirp7XzaBi3q\n"
+            + "H0edANCzPSRCDbZsOhzIXhXshldiXVRX666DDlbMQgLTEnNKrkwv6DmU8o15XQsb\n"
+            + "8k1Os2YwXmkEOxUQ7AJZXVTZSf6UK9Znmdq1ZrHjybMfRUkHVxJcnKvrxfryralv\n"
+            + "gzfvu+D6HuxrCo3Ojqa+nDgIbxKEBtdrcsMhq1jWPFhjwo1fSadAkKOfdCAuXJRD\n"
+            + "THg3b4Sf+W7Cpc570YHrIpBf7WFl2XsPcEM0mJZ5+yATASCubNozQwIDAQABo1Mw\n"
+            + "UTAdBgNVHQ4EFgQUES0hupZSqY21JOba10QyZuxm91EwHwYDVR0jBBgwFoAUES0h\n"
+            + "upZSqY21JOba10QyZuxm91EwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsF\n"
+            + "AAOCAgEABTN5S30ng/RMpBweDm2N561PdpaCdiRXtAFCRVWR2mkDYC/Xj9Vqe6be\n"
+            + "PyM7L/5OKYVjzF1yJu67z/dx+ja5o+41g17jdqla7hyPx+9B4uRyDh+1KJTa+duj\n"
+            + "mw/aA1LCr6O6W4WizDOsChJ6FaB2Y1+GlFnKWb5nUdhVJqXQE1WOX9dZnw8Y4Npd\n"
+            + "VmAsjWot0BZorJrt3fwfcv3QfA896twkbo7Llv/8qzg4sXZXZ4ZtgAOqnPngiSn+\n"
+            + "JT/vYCXZ406VvAFpFqMcVz2dO/VGuL8lGIMHRKNyafrsV81EzH1W/XmRWOgvgj6r\n"
+            + "yQI63ln/AMY72HQ97xLkE1xKunGz6bK5Ug5+O43Uftc4Mb6MUgzo+ZqEQ3Ob+cAV\n"
+            + "cvjmtwDaPO/O39O5Xq0tLTlkn2/cKf4OQ6S++GDxzyRVHh5JXgP4j9+jfZY57Woy\n"
+            + "R1bE7N50JjY4cDermBJKdlBIjL7UPhqmLyaG7V0hBitFlgGBUCcJtJOV0xYd5aF3\n"
+            + "pxNkvMXhBmh95fjxJ0cJjpO7tN1RAwtMMNgsl7OUbuVRQCHOPW5DgP5qY21jDeRn\n"
+            + "BY82382l+9QzykmJLI5MZnmj4BA9uIDCwMtoTTvP++SsvhUAbuvh7MOOUQL0EY4m\n"
+            + "KStYq7X9PKseN+PvmfeoffIKc5R/Ha39oi7cGMVHCr8aiEhsf94=\n"
+            + "-----END CERTIFICATE-----\n";
+
+
+    // See b/113174702
+    @Test
+    public void testMismatchedAlgorithm() throws Exception {
+        Provider[] providers = Security.getProviders("CertificateFactory.X509");
+        for (Provider p : providers) {
+            CertificateFactory cf = CertificateFactory.getInstance("X509", p);
+            try {
+                try {
+                    Certificate c = cf.generateCertificate(new ByteArrayInputStream(
+                            MISMATCHED_ALGORITHM_CERT.getBytes(Charset.forName("US-ASCII"))));
+                    c.verify(c.getPublicKey());
+                    fail();
+                } catch (CertificateException expected) {
+                }
+            } catch (Throwable e) {
+                throw new Exception("Failed testing " + p.getName(), e);
+            }
+        }
+    }
+}

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
@@ -25,7 +25,6 @@ import java.security.Security;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -104,7 +103,7 @@ public class X509CertificateTest {
             + "-----END CERTIFICATE-----\n";
 
 
-    // See b/113174702
+    // See issue #539.
     @Test
     public void testMismatchedAlgorithm() throws Exception {
         Provider[] providers = Security.getProviders("CertificateFactory.X509");


### PR DESCRIPTION
Unexpectedly, X509_verify does not set an entry in the error queue
when the signature algorithm in a certificate's info doesn't match the
algorithm in the signature block, it just returns 0.  This trips an
AssertionError in throwExceptionFromBoringSSLError, so check for that
condition explicitly.

Also default to throwing CertificateException instead of
RuntimeException when X509_verify encounters an error that we haven't
explicitly handled.  I don't know if there are any such errors in
practice, but it'll be more correct if there are.

Fixes #539.