### PR TITLE
Add API to get Conscrypt version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,10 +76,12 @@ if (androidSdkInstalled) {
             java {
                 srcDirs = [
                         "${rootDir}/common/src/main/java",
-                        "src/main/java"
+                        "src/main/java",
+                        "build/modified"
                 ]
                 // Requires evaluationDependsOn(':conscrypt-constants') above.
                 srcDirs += project(':conscrypt-constants').sourceSets.main.java.srcDirs
+                excludes = [ "org/conscrypt/Conscrypt.java" ]
             }
         }
         externalNativeBuild {
@@ -94,6 +96,22 @@ if (androidSdkInstalled) {
 
     configurations {
         publicApiDocs
+    }
+
+    task addVersionToConscryptClass(type: Copy) {
+        ext {
+            parsedVersion = VersionNumber.parse(version)
+        }
+        from "${rootDir}/common/src/main/java/org/conscrypt/Conscrypt.java"
+        into 'build/modified'
+        filter {
+            line -> line.replace("new Version(-1, -1, -1)",
+                    "new Version(${parsedVersion.getMajor()}, ${parsedVersion.getMinor()}, ${parsedVersion.getMicro()})")
+        }
+    }
+
+    build {
+        dependsOn addVersionToConscryptClass
     }
 
     dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,12 +76,13 @@ if (androidSdkInstalled) {
             java {
                 srcDirs = [
                         "${rootDir}/common/src/main/java",
-                        "src/main/java",
-                        "build/modified"
+                        "src/main/java"
                 ]
                 // Requires evaluationDependsOn(':conscrypt-constants') above.
                 srcDirs += project(':conscrypt-constants').sourceSets.main.java.srcDirs
-                excludes = [ "org/conscrypt/Conscrypt.java" ]
+            }
+            resources {
+                srcDirs += "build/generated/resources"
             }
         }
         externalNativeBuild {
@@ -98,20 +99,8 @@ if (androidSdkInstalled) {
         publicApiDocs
     }
 
-    task addVersionToConscryptClass(type: Copy) {
-        ext {
-            parsedVersion = VersionNumber.parse(version)
-        }
-        from "${rootDir}/common/src/main/java/org/conscrypt/Conscrypt.java"
-        into 'build/modified'
-        filter {
-            line -> line.replace("new Version(-1, -1, -1)",
-                    "new Version(${parsedVersion.getMajor()}, ${parsedVersion.getMinor()}, ${parsedVersion.getMicro()})")
-        }
-    }
-
-    build {
-        dependsOn addVersionToConscryptClass
+    preBuild {
+        dependsOn generateProperties
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ subprojects {
         property("version.major", parsedVersion.getMajor())
         property("version.minor", parsedVersion.getMinor())
         property("version.patch", parsedVersion.getMicro())
+        property("version.boringssl", boringSslVersion)
         outputFile "build/generated/resources/org/conscrypt/conscrypt.properties"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -158,10 +158,10 @@ subprojects {
         ext {
             parsedVersion = VersionNumber.parse(version)
         }
-        property("version.major", parsedVersion.getMajor())
-        property("version.minor", parsedVersion.getMinor())
-        property("version.patch", parsedVersion.getMicro())
-        property("version.boringssl", boringSslVersion)
+        property("org.conscrypt.version.major", parsedVersion.getMajor())
+        property("org.conscrypt.version.minor", parsedVersion.getMinor())
+        property("org.conscrypt.version.patch", parsedVersion.getMicro())
+        property("org.conscrypt.boringssl.version", boringSslVersion)
         outputFile "build/generated/resources/org/conscrypt/conscrypt.properties"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,16 @@ subprojects {
         }
     }
 
+    task generateProperties(type: WriteProperties) {
+        ext {
+            parsedVersion = VersionNumber.parse(version)
+        }
+        property("version.major", parsedVersion.getMajor())
+        property("version.minor", parsedVersion.getMinor())
+        property("version.patch", parsedVersion.getMicro())
+        outputFile "build/generated/resources/org/conscrypt/conscrypt.properties"
+    }
+
     if (!androidProject) {
         sourceCompatibility = JavaVersion.VERSION_1_6
         targetCompatibility = JavaVersion.VERSION_1_6

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -15,10 +15,13 @@
  */
 package org.conscrypt;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.KeyManagementException;
 import java.security.PrivateKey;
 import java.security.Provider;
+import java.util.Properties;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLContextSpi;
 import javax.net.ssl.SSLEngine;
@@ -65,9 +68,34 @@ public final class Conscrypt {
         public int patch() { return patch; }
     }
 
-    // NOTE: This constant definition is replaced by the addVersionToConscryptClass Gradle task
-    private static final Version VERSION = new Version(-1, -1, -1);
+    private static final Version VERSION;
 
+    static {
+        int major = -1;
+        int minor = -1;
+        int patch = -1;
+        try {
+            InputStream stream = Conscrypt.class.getResourceAsStream("conscrypt.properties");
+            if (stream != null) {
+                Properties props = new Properties();
+                props.load(stream);
+                major = Integer.parseInt(props.getProperty("version.major", "-1"));
+                minor = Integer.parseInt(props.getProperty("version.minor", "-1"));
+                patch = Integer.parseInt(props.getProperty("version.patch", "-1"));
+            }
+        } catch (IOException e) {
+        }
+        if ((major >= 0) && (minor >= 0) && (patch >= 0)) {
+            VERSION = new Version(major, minor, patch);
+        } else {
+            VERSION = null;
+        }
+    }
+
+    /**
+     * Returns the version of this distribution of Conscrypt.  If version information is
+     * unavailable, returns {@code null}.
+     */
     public static Version version() {
         return VERSION;
     }

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -49,6 +49,29 @@ public final class Conscrypt {
         }
     }
 
+    public static class Version {
+        private final int major;
+        private final int minor;
+        private final int patch;
+
+        private Version(int major, int minor, int patch) {
+            this.major = major;
+            this.minor = minor;
+            this.patch = patch;
+        }
+
+        public int major() { return major; }
+        public int minor() { return minor; }
+        public int patch() { return patch; }
+    }
+
+    // NOTE: This constant definition is replaced by the addVersionToConscryptClass Gradle task
+    private static final Version VERSION = new Version(-1, -1, -1);
+
+    public static Version version() {
+        return VERSION;
+    }
+
     /**
      * Checks that the Conscrypt support is available for the system.
      *

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -79,9 +79,9 @@ public final class Conscrypt {
             if (stream != null) {
                 Properties props = new Properties();
                 props.load(stream);
-                major = Integer.parseInt(props.getProperty("version.major", "-1"));
-                minor = Integer.parseInt(props.getProperty("version.minor", "-1"));
-                patch = Integer.parseInt(props.getProperty("version.patch", "-1"));
+                major = Integer.parseInt(props.getProperty("org.conscrypt.version.major", "-1"));
+                minor = Integer.parseInt(props.getProperty("org.conscrypt.version.minor", "-1"));
+                patch = Integer.parseInt(props.getProperty("org.conscrypt.version.patch", "-1"));
             }
         } catch (IOException e) {
         }

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -38,8 +38,9 @@ sourceSets {
         java {
             srcDirs += "${rootDir}/common/src/main/java"
             srcDirs += project(':conscrypt-constants').sourceSets.main.java.srcDirs
-            srcDirs += "build/modified"
-            excludes = [ "org/conscrypt/Conscrypt.java" ]
+        }
+        resources {
+            srcDirs += "build/generated/resources"
         }
     }
 
@@ -84,20 +85,8 @@ sourceSets {
     }
 }
 
-task addVersionToConscryptClass(type: Copy) {
-    ext {
-        parsedVersion = VersionNumber.parse(version)
-    }
-    from "${rootDir}/common/src/main/java/org/conscrypt/Conscrypt.java"
-    into 'build/modified'
-    filter {
-        line -> line.replace("new Version(-1, -1, -1)",
-                "new Version(${parsedVersion.getMajor()}, ${parsedVersion.getMinor()}, ${parsedVersion.getMicro()})")
-    }
-}
-
 compileJava {
-    dependsOn addVersionToConscryptClass
+    dependsOn generateProperties
 }
 
 task platformJar(type: Jar) {

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -38,6 +38,8 @@ sourceSets {
         java {
             srcDirs += "${rootDir}/common/src/main/java"
             srcDirs += project(':conscrypt-constants').sourceSets.main.java.srcDirs
+            srcDirs += "build/modified"
+            excludes = [ "org/conscrypt/Conscrypt.java" ]
         }
     }
 
@@ -80,6 +82,22 @@ sourceSets {
             output.dir(nativeResourcesDir(nativeClassifier), builtBy: "copyNativeLib${sourceSetName}")
         }
     }
+}
+
+task addVersionToConscryptClass(type: Copy) {
+    ext {
+        parsedVersion = VersionNumber.parse(version)
+    }
+    from "${rootDir}/common/src/main/java/org/conscrypt/Conscrypt.java"
+    into 'build/modified'
+    filter {
+        line -> line.replace("new Version(-1, -1, -1)",
+                "new Version(${parsedVersion.getMajor()}, ${parsedVersion.getMinor()}, ${parsedVersion.getMicro()})")
+    }
+}
+
+compileJava {
+    dependsOn addVersionToConscryptClass
 }
 
 task platformJar(type: Jar) {

--- a/openjdk/src/test/java/org/conscrypt/ConscryptTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptTest.java
@@ -1,6 +1,7 @@
 package org.conscrypt;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -17,6 +18,7 @@ public class ConscryptTest {
     @Test
     public void testVersionIsSensible() {
         Conscrypt.Version version = Conscrypt.version();
+        assertNotNull(version);
         // The version object should be a singleton
         assertSame(version, Conscrypt.version());
 

--- a/openjdk/src/test/java/org/conscrypt/ConscryptTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptTest.java
@@ -1,0 +1,27 @@
+package org.conscrypt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ConscryptTest {
+
+    /**
+     * This confirms that the version machinery is working.
+     */
+    @Test
+    public void testVersionIsSensible() {
+        Conscrypt.Version version = Conscrypt.version();
+        // The version object should be a singleton
+        assertSame(version, Conscrypt.version());
+
+        assertEquals("Major version: " + version.major(), 1, version.major());
+        assertTrue("Minor version: " + version.minor(), 0 <= version.minor());
+        assertTrue("Patch version: " + version.patch(), 0 <= version.patch());
+    }
+}


### PR DESCRIPTION
Libraries like OkHttp want to be able to check what version of
Conscrypt is available before attempting to enable new features (like
TLS 1.3).  Add a simple API to check what version of Conscrypt is
being used.

Fixes #538.