### PR TITLE
Add TLS 1.3 benchmarks

### DIFF
--- a/benchmark-android/src/main/java/org/conscrypt/CaliperAlpnBenchmark.java
+++ b/benchmark-android/src/main/java/org/conscrypt/CaliperAlpnBenchmark.java
@@ -75,7 +75,7 @@ public class CaliperAlpnBenchmark {
 
         @Override
         public BenchmarkProtocol protocol() {
-            return BenchmarkProtocol.TLSv12_ONLY;
+            return BenchmarkProtocol.TLSv12;
         }
 
         @Override

--- a/benchmark-android/src/main/java/org/conscrypt/CaliperAlpnBenchmark.java
+++ b/benchmark-android/src/main/java/org/conscrypt/CaliperAlpnBenchmark.java
@@ -72,5 +72,15 @@ public class CaliperAlpnBenchmark {
         public boolean useAlpn() {
             return true;
         }
+
+        @Override
+        public BenchmarkProtocol protocol() {
+            return BenchmarkProtocol.TLSv12_ONLY;
+        }
+
+        @Override
+        public int rttMillis() {
+            return 0;
+        }
     }
 }

--- a/benchmark-android/src/main/java/org/conscrypt/CaliperClientSocketBenchmark.java
+++ b/benchmark-android/src/main/java/org/conscrypt/CaliperClientSocketBenchmark.java
@@ -40,6 +40,9 @@ public class CaliperClientSocketBenchmark {
   public String cipher;
 
   @Param
+  public BenchmarkProtocol protocol;
+
+  @Param
   public ChannelType channelType;
 
   private ClientSocketBenchmark benchmark;
@@ -84,6 +87,11 @@ public class CaliperClientSocketBenchmark {
     @Override
     public ChannelType channelType() {
       return channelType;
+    }
+
+    @Override
+    public BenchmarkProtocol protocol() {
+      return protocol;
     }
   }
 }

--- a/benchmark-android/src/main/java/org/conscrypt/CaliperEngineHandshakeBenchmark.java
+++ b/benchmark-android/src/main/java/org/conscrypt/CaliperEngineHandshakeBenchmark.java
@@ -53,6 +53,12 @@ public class CaliperEngineHandshakeBenchmark {
     @Param
     public AndroidEngineFactory c_engine;
 
+    @Param
+    public BenchmarkProtocol d_protocol;
+
+    @Param({"100"})
+    public int e_rtt;
+
     private EngineHandshakeBenchmark benchmark;
 
     @BeforeExperiment
@@ -86,6 +92,16 @@ public class CaliperEngineHandshakeBenchmark {
         @Override
         public boolean useAlpn() {
             return false;
+        }
+
+        @Override
+        public BenchmarkProtocol protocol() {
+            return d_protocol;
+        }
+
+        @Override
+        public int rttMillis() {
+            return e_rtt;
         }
     }
 }

--- a/benchmark-base/src/main/java/org/conscrypt/BenchmarkProtocol.java
+++ b/benchmark-base/src/main/java/org/conscrypt/BenchmarkProtocol.java
@@ -1,0 +1,18 @@
+package org.conscrypt;
+
+@SuppressWarnings("ImmutableEnumChecker")
+public enum BenchmarkProtocol {
+
+    TLSv13_ONLY("TLSv1.3"),
+    TLSv12_ONLY("TLSv1.2");
+
+    private final String[] protocols;
+
+    BenchmarkProtocol(String... protocols) {
+        this.protocols = protocols;
+    }
+
+    public String[] getProtocols() {
+        return protocols.clone();
+    }
+}

--- a/benchmark-base/src/main/java/org/conscrypt/BenchmarkProtocol.java
+++ b/benchmark-base/src/main/java/org/conscrypt/BenchmarkProtocol.java
@@ -3,8 +3,8 @@ package org.conscrypt;
 @SuppressWarnings("ImmutableEnumChecker")
 public enum BenchmarkProtocol {
 
-    TLSv13_ONLY("TLSv1.3"),
-    TLSv12_ONLY("TLSv1.2");
+    TLSv13("TLSv1.3"),
+    TLSv12("TLSv1.2");
 
     private final String[] protocols;
 

--- a/benchmark-base/src/main/java/org/conscrypt/ClientSocketBenchmark.java
+++ b/benchmark-base/src/main/java/org/conscrypt/ClientSocketBenchmark.java
@@ -16,7 +16,6 @@
 
 package org.conscrypt;
 
-import static org.conscrypt.TestUtils.getProtocols;
 import static org.conscrypt.TestUtils.newTextMessage;
 
 import java.io.OutputStream;
@@ -40,6 +39,7 @@ public final class ClientSocketBenchmark {
         int messageSize();
         String cipher();
         ChannelType channelType();
+        BenchmarkProtocol protocol();
     }
 
     private ClientEndpoint client;
@@ -59,7 +59,8 @@ public final class ClientSocketBenchmark {
 
         // Always use the same server for consistency across the benchmarks.
         server = config.serverFactory().newServer(
-                ChannelType.CHANNEL, config.messageSize(), getProtocols(), ciphers(config));
+                ChannelType.CHANNEL, config.messageSize(), config.protocol().getProtocols(),
+                ciphers(config));
 
         server.setMessageProcessor(new ServerEndpoint.MessageProcessor() {
             @Override
@@ -73,7 +74,7 @@ public final class ClientSocketBenchmark {
         Future<?> connectedFuture = server.start();
 
         client = config.clientFactory().newClient(
-            config.channelType(), server.port(), getProtocols(), ciphers(config));
+            config.channelType(), server.port(), config.protocol().getProtocols(), ciphers(config));
         client.start();
 
         // Wait for the initial connection to complete.

--- a/benchmark-jmh/build.gradle
+++ b/benchmark-jmh/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'me.champeau.gradle.jmh' version '0.3.1'
+    id 'me.champeau.gradle.jmh' version '0.4.7'
 }
 
 apply plugin: 'idea'
@@ -14,6 +14,7 @@ ext {
 
     genDir = "${buildDir}/jmh-generated-classes"
     jmhInclude = System.getProperty('jmh.include')
+    jmhParams = System.getProperty('jmh.parameters')
     jmhWarmupIterations = System.getProperty('jmh.wi', '10')
     jmhIterations = System.getProperty('jmh.i', '10')
     jmhFork = System.getProperty('jmh.f', '1')
@@ -29,6 +30,9 @@ jmh {
     jmhVersion = "$jmhVersion"
     if (jmhInclude != null) {
         setInclude(jmhInclude.toString())
+    }
+    if (jmhParams != null) {
+        setBenchmarkParameters(parseParams(jmhParams))
     }
     warmupIterations = "$jmhWarmupIterations".toInteger()
     iterations = "$jmhIterations".toInteger();
@@ -85,6 +89,19 @@ dependencies {
 // See https://github.com/melix/jmh-gradle-plugin/issues/39
 idea.module {
     scopes.PROVIDED.plus += [ configurations.compile, configurations.jmh ]
+}
+
+// Param strings are in the form "param:VAL1,VAL2;param2:VAL3,VAL4"
+def parseParams(s) {
+    // It's really easy to type jmh.parameters=foo=bar instead of jmh.parameters=foo:bar,
+    // so check for that.
+    if (s.contains("=")) {
+        throw new IllegalArgumentException("jmh.parameters value shouldn't include '='.  (Did you mean ':'?)")
+    }
+    return s.split(";").collectEntries { entry ->
+        def pair = entry.split(":")
+        [ (pair.first().trim()) : pair.last().split(",").collect { it.trim() } ]
+    }
 }
 
 // Don't include this artifact in the distribution.

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhAlpnBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhAlpnBenchmark.java
@@ -79,6 +79,16 @@ public class JmhAlpnBenchmark {
     public boolean useAlpn() {
       return true;
     }
+
+    @Override
+    public int rttMillis() {
+      return 0;
+    }
+
+    @Override
+    public BenchmarkProtocol protocol() {
+      return BenchmarkProtocol.TLSv12_ONLY;
+    }
   }
 }
 

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhAlpnBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhAlpnBenchmark.java
@@ -87,7 +87,7 @@ public class JmhAlpnBenchmark {
 
     @Override
     public BenchmarkProtocol protocol() {
-      return BenchmarkProtocol.TLSv12_ONLY;
+      return BenchmarkProtocol.TLSv12;
     }
   }
 }

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhClientSocketBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhClientSocketBenchmark.java
@@ -36,6 +36,11 @@ import org.openjdk.jmh.annotations.Threads;
 @Fork(1)
 @Threads(1)
 public class JmhClientSocketBenchmark {
+
+    static {
+        TestUtils.installConscryptAsDefaultProvider();
+    }
+
     /**
      * Use an AuxCounter so we can measure that bytes per second as they accumulate without
      * consuming CPU in the benchmark method.
@@ -64,6 +69,9 @@ public class JmhClientSocketBenchmark {
 
     @Param({TestUtils.TEST_CIPHER})
     public String cipher;
+
+    @Param
+    public BenchmarkProtocol protocol;
 
     @Param
     public ChannelType channelType;
@@ -111,6 +119,11 @@ public class JmhClientSocketBenchmark {
         @Override
         public ChannelType channelType() {
             return channelType;
+        }
+
+        @Override
+        public BenchmarkProtocol protocol() {
+            return protocol;
         }
     }
 }

--- a/benchmark-jmh/src/jmh/java/org/conscrypt/JmhEngineHandshakeBenchmark.java
+++ b/benchmark-jmh/src/jmh/java/org/conscrypt/JmhEngineHandshakeBenchmark.java
@@ -50,6 +50,11 @@ import org.openjdk.jmh.annotations.Threads;
 @Fork(1)
 @Threads(1)
 public class JmhEngineHandshakeBenchmark {
+
+    static {
+        TestUtils.installConscryptAsDefaultProvider();
+    }
+
     private final JmhConfig config = new JmhConfig();
 
     @Param({TestUtils.TEST_CIPHER})
@@ -60,6 +65,12 @@ public class JmhEngineHandshakeBenchmark {
 
     @Param
     public OpenJdkEngineFactory c_engine;
+
+    @Param
+    public BenchmarkProtocol d_protocol;
+
+    @Param({"100"})
+    public int e_rtt;
 
     private EngineHandshakeBenchmark benchmark;
 
@@ -93,6 +104,16 @@ public class JmhEngineHandshakeBenchmark {
         @Override
         public boolean useAlpn() {
             return false;
+        }
+
+        @Override
+        public int rttMillis() {
+            return e_rtt;
+        }
+
+        @Override
+        public BenchmarkProtocol protocol() {
+            return d_protocol;
         }
     }
 }


### PR DESCRIPTION
Adds a BenchmarkProtocol parameter to ClientSocketBenchmark and
EngineHandshakeBenchmark to determine which protocol to use.

Switched EngineHandshakeBenchmark off TestUtils.doEngineHandshake and
onto its own implementation.  This lets us simulate network transit
time as well as eliminating all the test assertions and generally
operating closer to the typical usage of an SSLEngine.

Also adds the ability to specify JMH params on the command line.