### PR TITLE
Add buffer allocators to ConscryptEngineSocket

### DIFF
--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -469,10 +469,26 @@ public final class Conscrypt {
 
     /**
      * Provides the given engine with the provided bufferAllocator.
+     * @throws IllegalArgumentException if the provided engine is not a Conscrypt engine.
+     * @throws IllegalStateException if the provided engine has already begun its handshake.
      */
     @ExperimentalApi
     public static void setBufferAllocator(SSLEngine engine, BufferAllocator bufferAllocator) {
         toConscrypt(engine).setBufferAllocator(bufferAllocator);
+    }
+
+    /**
+     * Provides the given socket with the provided bufferAllocator.  If the given socket is a
+     * Conscrypt socket but does not use buffer allocators, this method does nothing.
+     * @throws IllegalArgumentException if the provided socket is not a Conscrypt socket.
+     * @throws IllegalStateException if the provided socket has already begun its handshake.
+     */
+    @ExperimentalApi
+    public static void setBufferAllocator(SSLSocket socket, BufferAllocator bufferAllocator) {
+        AbstractConscryptSocket s = toConscrypt(socket);
+        if (s instanceof ConscryptEngineSocket) {
+            ((ConscryptEngineSocket) s).setBufferAllocator(bufferAllocator);
+        }
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -213,10 +213,18 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
 
     /**
      * Configures the default {@link BufferAllocator} to be used by all future
-     * {@link SSLEngine} instances from this provider.
+     * {@link SSLEngine} and {@link ConscryptEngineSocket} instances from this provider.
      */
     static void setDefaultBufferAllocator(BufferAllocator bufferAllocator) {
         defaultBufferAllocator = bufferAllocator;
+    }
+
+    /**
+     * Returns the default {@link BufferAllocator}, which may be {@code null} if no default
+     * has been explicitly set.
+     */
+    static BufferAllocator getDefaultBufferAllocator() {
+        return defaultBufferAllocator;
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -403,11 +403,11 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
         try {
             // Close the underlying socket.
             super.close();
-
+        } finally {
             // Close the engine.
             engine.closeInbound();
             engine.closeOutbound();
-        } finally {
+            
             // Release any resources we're holding
             if (in != null) {
                 in.release();

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -52,6 +52,8 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
     private SSLOutputStream out;
     private SSLInputStream in;
 
+    private BufferAllocator bufferAllocator = ConscryptEngine.getDefaultBufferAllocator();
+
     // @GuardedBy("stateLock");
     private int state = STATE_NEW;
 
@@ -404,6 +406,11 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
         // Close the engine.
         engine.closeInbound();
         engine.closeOutbound();
+
+        // Release any resources we're holding
+        if (in != null) {
+            in.release();
+        }
     }
 
     @Override
@@ -435,6 +442,11 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
     @Override
     final void setApplicationProtocolSelector(ApplicationProtocolSelectorAdapter selector) {
         engine.setApplicationProtocolSelector(selector);
+    }
+
+    void setBufferAllocator(BufferAllocator bufferAllocator) {
+        engine.setBufferAllocator(bufferAllocator);
+        this.bufferAllocator = bufferAllocator;
     }
 
     private void onHandshakeFinished() {
@@ -600,10 +612,18 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
         private final ByteBuffer fromEngine;
         private final ByteBuffer fromSocket;
         private final int fromSocketArrayOffset;
+        private final AllocatedBuffer allocatedBuffer;
         private InputStream socketInputStream;
 
         SSLInputStream() {
-            fromEngine = ByteBuffer.allocateDirect(engine.getSession().getApplicationBufferSize());
+            if (bufferAllocator != null) {
+                allocatedBuffer = bufferAllocator.allocateDirectBuffer(
+                        engine.getSession().getApplicationBufferSize());
+                fromEngine = allocatedBuffer.nioBuffer();
+            } else {
+                allocatedBuffer = null;
+                fromEngine = ByteBuffer.allocateDirect(engine.getSession().getApplicationBufferSize());
+            }
             // Initially fromEngine.remaining() == 0.
             fromEngine.flip();
             fromSocket = ByteBuffer.allocate(engine.getSession().getPacketBufferSize());
@@ -613,6 +633,14 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
         @Override
         public void close() throws IOException {
             ConscryptEngineSocket.this.close();
+        }
+
+        void release() {
+            synchronized (readLock) {
+                if (allocatedBuffer != null) {
+                    allocatedBuffer.release();
+                }
+            }
         }
 
         @Override

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -400,16 +400,18 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
             stateLock.notifyAll();
         }
 
-        // Close the underlying socket.
-        super.close();
+        try {
+            // Close the underlying socket.
+            super.close();
 
-        // Close the engine.
-        engine.closeInbound();
-        engine.closeOutbound();
-
-        // Release any resources we're holding
-        if (in != null) {
-            in.release();
+            // Close the engine.
+            engine.closeInbound();
+            engine.closeOutbound();
+        } finally {
+            // Release any resources we're holding
+            if (in != null) {
+                in.release();
+            }
         }
     }
 


### PR DESCRIPTION
This allows users to set a buffer allocator for both the buffers used
by ConscryptEngineSocket directly and the ones use by the enclosed
ConscryptEngine.

Fixes #549.