### PR TITLE
Allow d2i_X509_bio and friends to not set an error

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -5073,7 +5073,11 @@ static jlong d2i_ASN1Object_to_jlong(JNIEnv* env, jlong bioRef) {
 
     T* x = d2i_func(bio, nullptr);
     if (x == nullptr) {
-        conscrypt::jniutil::throwExceptionFromBoringSSLError(env, "d2i_ASN1Object_to_jlong");
+        if (ERR_peek_error() != 0) {
+            conscrypt::jniutil::throwExceptionFromBoringSSLError(env, "d2i_ASN1Object_to_jlong");
+        } else {
+            conscrypt::jniutil::throwRuntimeException(env, "d2i_ASN1Object_to_jlong");
+        }
         return 0;
     }
 

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
@@ -210,6 +210,18 @@ public class CertificateFactoryTest {
             fail();
         } catch (CertificateException expected) {
         }
+
+        try {
+            cf.generateCertificate(new ByteArrayInputStream(new byte[0]));
+            fail();
+        } catch (CertificateException expected) {
+        }
+
+        try {
+            cf.generateCertificate(new ByteArrayInputStream(new byte[] { 0x00 }));
+            fail();
+        } catch (CertificateException expected) {
+        }
     }
 
     /*


### PR DESCRIPTION
BoringSSL recently changed so that d2i_X509_bio doesn't set an error
in the error queue when it receives certain garbage inputs.  We don't
actually care what error is set in the queue (we just end up catching
whatever is thrown and throwing CertificateException), so change to
tolerate having no error in the queue.