### PR TITLE
Update handling of empty error queue

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -342,7 +342,7 @@ void throwExceptionFromBoringSSLError(JNIEnv* env, CONSCRYPT_UNUSED const char* 
     unsigned long error = ERR_get_error_line_data(&file, &line, &data, &flags);
 
     if (error == 0) {
-        throwAssertionError(env, "throwExceptionFromBoringSSLError called with no error");
+        defaultThrow(env, "Unknown BoringSSL error");
         return;
     }
 
@@ -353,7 +353,7 @@ void throwExceptionFromBoringSSLError(JNIEnv* env, CONSCRYPT_UNUSED const char* 
         ERR_error_string_n(error, message, sizeof(message));
         int library = ERR_GET_LIB(error);
         int reason = ERR_GET_REASON(error);
-        JNI_TRACE("OpenSSL error in %s error=%lx library=%x reason=%x (%s:%d): %s %s", location,
+        JNI_TRACE("BoringSSL error in %s error=%lx library=%x reason=%x (%s:%d): %s %s", location,
                   error, library, reason, file, line, message,
                   (flags & ERR_TXT_STRING) ? data : "(no data)");
         switch (library) {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1391,7 +1391,6 @@ public final class NativeCrypto {
     static native int BIO_read(long bioRef, byte[] buffer) throws IOException;
     static native void BIO_write(long bioRef, byte[] buffer, int offset, int length)
             throws IOException, IndexOutOfBoundsException;
-    static native long ERR_peek_last_error();
     static native long SSL_clear_mode(long ssl, NativeSsl ssl_holder, long mode);
     static native long SSL_get_mode(long ssl, NativeSsl ssl_holder);
     static native long SSL_get_options(long ssl, NativeSsl ssl_holder);

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -82,7 +82,6 @@ import libcore.java.security.StandardNames;
 import org.conscrypt.NativeCrypto.SSLHandshakeCallbacks;
 import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 import org.conscrypt.java.security.TestKeyStore;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -118,11 +117,6 @@ public class NativeCryptoTest {
         m_Platform_getFileDescriptor =
                 c_Platform.getDeclaredMethod("getFileDescriptor", Socket.class);
         m_Platform_getFileDescriptor.setAccessible(true);
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        assertEquals(0, NativeCrypto.ERR_peek_last_error());
     }
 
     private static OpenSSLKey getServerPrivateKey() {

--- a/openjdk/src/test/java/org/conscrypt/NativeSslSessionTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeSslSessionTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -383,11 +382,6 @@ public class NativeSslSessionTest {
     private static final byte[] DUMMY_OCSP_DATA = new byte[1];
 
     private static final byte[] DUMMY_TLS_SCT_DATA = new byte[1];
-
-    @After
-    public void tearDown() throws Exception {
-        assertEquals(0, NativeCrypto.ERR_peek_last_error());
-    }
 
     private static TestSessionBuilder getType1() {
         return new TestSessionBuilder()


### PR DESCRIPTION
Some BoringSSL functions don't make any guarantees about the state of
the error queue if they return an error, and in most cases we don't
actually care what error occurred.  Instead of throwing AssertionError
when we encounter an error with no entry in the error queue, throw the
default exception type (which is usually RuntimeException).

Also removes NativeCrypto.ERR_peek_last_error(), which was only used
in tests.  We now have the CHECK_ERROR_QUEUE_ON_RETURN macro that
serves the same purpose but does it more comprehensively.

Fixes #553.