### PR TITLE
Revert "Prefer Libcore.os over Os outside of android.* packages. (#358)"

### DIFF
--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -20,6 +20,7 @@ import static android.system.OsConstants.SOL_SOCKET;
 import static android.system.OsConstants.SO_SNDTIMEO;
 
 import android.system.ErrnoException;
+import android.system.Os;
 import android.system.StructTimeval;
 import dalvik.system.BlockGuard;
 import dalvik.system.CloseGuard;
@@ -55,7 +56,6 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.StandardConstants;
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
-import libcore.io.Libcore;
 import libcore.net.NetworkSecurityPolicy;
 import org.conscrypt.ct.CTLogStore;
 import org.conscrypt.ct.CTLogStoreImpl;
@@ -116,7 +116,7 @@ final class Platform {
     static void setSocketWriteTimeout(Socket s, long timeoutMillis) throws SocketException {
         StructTimeval tv = StructTimeval.fromMillis(timeoutMillis);
         try {
-            Libcore.os.setsockoptTimeval(s.getFileDescriptor$(), SOL_SOCKET, SO_SNDTIMEO, tv);
+            Os.setsockoptTimeval(s.getFileDescriptor$(), SOL_SOCKET, SO_SNDTIMEO, tv);
         } catch (ErrnoException errnoException) {
             throw errnoException.rethrowAsSocketException();
         }


### PR DESCRIPTION
The original CL was submitted because it was thought (at the time) that
android.system would become inaccessible to Conscrypt; the opposite is
now the case: We intend to make Libcore.os private within libcore, so
it will become inaccessible to Conscrypt. Therefore this CL reverts back
to the previous use of android.system.Os.

This reverts commit c4b87c4390c480a0b17be9ad99b0f5a1fb7559c1.