### PR TITLE
Add explicit no-arg constructors

### DIFF
--- a/common/src/main/java/org/conscrypt/DESEDESecretKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/DESEDESecretKeyFactory.java
@@ -32,6 +32,9 @@ import javax.crypto.spec.SecretKeySpec;
  */
 @Internal
 public class DESEDESecretKeyFactory extends SecretKeyFactorySpi {
+
+    public DESEDESecretKeyFactory() {}
+
     @Override
     protected SecretKey engineGenerateSecret(KeySpec keySpec) throws InvalidKeySpecException {
         if (keySpec == null) {

--- a/common/src/main/java/org/conscrypt/ECParameters.java
+++ b/common/src/main/java/org/conscrypt/ECParameters.java
@@ -35,6 +35,8 @@ public class ECParameters extends AlgorithmParametersSpi {
 
     private OpenSSLECGroupContext curve;
 
+    public ECParameters() {}
+
     @Override
     protected void engineInit(AlgorithmParameterSpec algorithmParameterSpec)
             throws InvalidParameterSpecException {

--- a/common/src/main/java/org/conscrypt/IvParameters.java
+++ b/common/src/main/java/org/conscrypt/IvParameters.java
@@ -109,7 +109,13 @@ public class IvParameters extends AlgorithmParametersSpi {
         return "Conscrypt IV AlgorithmParameters";
     }
 
-    public static class AES extends IvParameters {}
-    public static class DESEDE extends IvParameters {}
-    public static class ChaCha20 extends IvParameters {}
+    public static class AES extends IvParameters {
+        public AES() {}
+    }
+    public static class DESEDE extends IvParameters {
+        public DESEDE() {}
+    }
+    public static class ChaCha20 extends IvParameters {
+        public ChaCha20() {}
+    }
 }

--- a/common/src/main/java/org/conscrypt/OAEPParameters.java
+++ b/common/src/main/java/org/conscrypt/OAEPParameters.java
@@ -52,6 +52,8 @@ public class OAEPParameters extends AlgorithmParametersSpi {
 
     private OAEPParameterSpec spec = OAEPParameterSpec.DEFAULT;
 
+    public OAEPParameters() {}
+
     @Override
     protected void engineInit(AlgorithmParameterSpec algorithmParameterSpec)
             throws InvalidParameterSpecException {

--- a/common/src/main/java/org/conscrypt/OpenSSLCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipher.java
@@ -1398,6 +1398,8 @@ public abstract class OpenSSLCipher extends CipherSpi {
                 }
 
                 public static class AES_128 extends GCM {
+                    public AES_128() {}
+
                     @Override
                     void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
                         if (keyLength != 16) { // 128 bits
@@ -1408,6 +1410,8 @@ public abstract class OpenSSLCipher extends CipherSpi {
                 }
 
                 public static class AES_256 extends GCM {
+                    public AES_256() {}
+
                     @Override
                     void checkSupportedKeySize(int keyLength) throws InvalidKeyException {
                         if (keyLength != 32) { // 256 bits

--- a/common/src/main/java/org/conscrypt/OpenSSLECDHKeyAgreement.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECDHKeyAgreement.java
@@ -48,6 +48,8 @@ public final class OpenSSLECDHKeyAgreement extends KeyAgreementSpi {
     /** Agreed key. Only available after {@link #engineDoPhase(Key, boolean)} completes. */
     private byte[] mResult;
 
+    public OpenSSLECDHKeyAgreement() {}
+
     @Override
     public Key engineDoPhase(Key key, boolean lastPhase) throws InvalidKeyException {
         if (mOpenSslPrivateKey == null) {

--- a/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
@@ -41,6 +41,8 @@ import java.security.spec.X509EncodedKeySpec;
 @Internal
 public final class OpenSSLECKeyFactory extends KeyFactorySpi {
 
+    public OpenSSLECKeyFactory() {}
+
     @Override
     protected PublicKey engineGeneratePublic(KeySpec keySpec) throws InvalidKeySpecException {
         if (keySpec == null) {

--- a/common/src/main/java/org/conscrypt/OpenSSLRandom.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRandom.java
@@ -28,6 +28,8 @@ import java.security.SecureRandomSpi;
 public final class OpenSSLRandom extends SecureRandomSpi implements Serializable {
     private static final long serialVersionUID = 8506210602917522861L;
 
+    public OpenSSLRandom() {}
+
     @Override
     protected void engineSetSeed(byte[] seed) {
         if (seed == null) {

--- a/common/src/main/java/org/conscrypt/OpenSSLSignatureRawECDSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignatureRawECDSA.java
@@ -41,6 +41,8 @@ public class OpenSSLSignatureRawECDSA extends SignatureSpi {
      */
     private ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
+    public OpenSSLSignatureRawECDSA() {}
+
     @Override
     protected void engineUpdate(byte input) {
         buffer.write(input);

--- a/common/src/main/java/org/conscrypt/OpenSSLSignatureRawRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignatureRawRSA.java
@@ -54,6 +54,8 @@ public final class OpenSSLSignatureRawRSA extends SignatureSpi {
      */
     private boolean inputIsTooLong;
 
+    public OpenSSLSignatureRawRSA() {}
+
     @Override
     protected void engineUpdate(byte input) {
         final int oldOffset = inputOffset++;

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
@@ -272,6 +272,8 @@ public class OpenSSLX509CertificateFactory extends CertificateFactorySpi {
                 }
             };
 
+    public OpenSSLX509CertificateFactory() {}
+
     @Override
     public Certificate engineGenerateCertificate(InputStream inStream) throws CertificateException {
         try {

--- a/common/src/main/java/org/conscrypt/PSSParameters.java
+++ b/common/src/main/java/org/conscrypt/PSSParameters.java
@@ -34,6 +34,8 @@ public class PSSParameters extends AlgorithmParametersSpi {
 
     private PSSParameterSpec spec = PSSParameterSpec.DEFAULT;
 
+    public PSSParameters() {}
+
     @Override
     protected void engineInit(AlgorithmParameterSpec algorithmParameterSpec)
             throws InvalidParameterSpecException {


### PR DESCRIPTION
We're somewhat inconsistent on whether we include these or not, but we
now want these to be present so we can add annotations to them to
support Android features.  This also makes it more obvious that these
classes are publicly constructible.