### PR TITLE
Adjust new tests for unusual BC behavior

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
@@ -212,14 +212,18 @@ public class CertificateFactoryTest {
         }
 
         try {
-            cf.generateCertificate(new ByteArrayInputStream(new byte[0]));
-            fail();
+            Certificate c = cf.generateCertificate(new ByteArrayInputStream(new byte[0]));
+            // Bouncy Castle returns null on empty inputs rather than throwing an exception,
+            // which technically doesn't satisfy the method contract, but we'll accept it
+            assertTrue((c == null) && cf.getProvider().getName().equals("BC"));
         } catch (CertificateException expected) {
         }
 
         try {
-            cf.generateCertificate(new ByteArrayInputStream(new byte[] { 0x00 }));
-            fail();
+            Certificate c = cf.generateCertificate(new ByteArrayInputStream(new byte[] { 0x00 }));
+            // Bouncy Castle returns null on short inputs rather than throwing an exception,
+            // which technically doesn't satisfy the method contract, but we'll accept it
+            assertTrue((c == null) && cf.getProvider().getName().equals("BC"));
         } catch (CertificateException expected) {
         }
     }

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
@@ -149,6 +149,11 @@ public class X509CertificateTest {
     public void testExplicitEcParams() throws Exception {
         Provider[] providers = Security.getProviders("CertificateFactory.X509");
         for (Provider p : providers) {
+            if (p.getName().equals("BC")) {
+                // Bouncy Castle allows explicit EC params in certificates, even though they're
+                // barred by RFC 5480
+                continue;
+            }
             try {
                 CertificateFactory cf = CertificateFactory.getInstance("X509", p);
                 Certificate c = cf.generateCertificate(new ByteArrayInputStream(


### PR DESCRIPTION
A couple of the new tests we've added recently fail on Android (which
includes BC as a built-in provider).  BC's behavior is technically
disallowed, but accept it in the tests since we're not going to change
it.