### PR TITLE
Add Automatic-Module-Name to manifest

### DIFF
--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -65,11 +65,11 @@ if (buildUberJar) {
     }
     sourcesJar.dependsOn copySources
 
-    // Append the BoringSSL-Version to the manifest. Note that this assumes that the
-    // version of BoringSSL for each artifact exactly matches the one on the
-    // current system.
+    // Note that this assumes that the version of BoringSSL for each
+    // artifact exactly matches the one on the current system.
     jar.manifest {
-        attributes 'BoringSSL-Version': boringSslVersion
+        attributes ('BoringSSL-Version': boringSslVersion,
+                    'Automatic-Module-Name': 'org.conscrypt')
     }
 } else {
     // Not building an uber jar - disable all tasks.

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -155,9 +155,9 @@ artifacts {
     platform platformJar
 }
 
-// Append the BoringSSL-Version to the manifest.
 jar.manifest {
-    attributes 'BoringSSL-Version' : boringSslVersion
+    attributes ('BoringSSL-Version' : boringSslVersion,
+                'Automatic-Module-Name' : 'org.conscrypt')
 }
 
 dependencies {


### PR DESCRIPTION
This is necessary for predictable usage in the Java 9 module system.

Fixes #554.