### PR TITLE
Small cleanups for NativeRef

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -38,7 +38,7 @@ jclass inputStreamClass;
 jclass outputStreamClass;
 jclass stringClass;
 
-jfieldID nativeRef_context;
+jfieldID nativeRef_address;
 
 jmethodID calendar_setMethod;
 jmethodID inputStream_readMethod;
@@ -66,7 +66,7 @@ void init(JavaVM* vm, JNIEnv* env) {
     openSslInputStreamClass = getGlobalRefToClass(
             env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/OpenSSLBIOInputStream");
 
-    nativeRef_context = getFieldRef(env, nativeRefClass, "context", "J");
+    nativeRef_address = getFieldRef(env, nativeRefClass, "address", "J");
 
     calendar_setMethod = getMethodRef(env, calendarClass, "set", "(IIIIII)V");
     inputStream_readMethod = getMethodRef(env, inputStreamClass, "read", "([B)I");

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -126,7 +126,7 @@ static T* fromContextObject(JNIEnv* env, jobject contextObject) {
         return nullptr;
     }
     T* ref = reinterpret_cast<T*>(
-            env->GetLongField(contextObject, conscrypt::jniutil::nativeRef_context));
+            env->GetLongField(contextObject, conscrypt::jniutil::nativeRef_address));
     if (ref == nullptr) {
         JNI_TRACE("ref == null");
         conscrypt::jniutil::throwNullPointerException(env, "ref == null");

--- a/common/src/jni/main/include/conscrypt/jniutil.h
+++ b/common/src/jni/main/include/conscrypt/jniutil.h
@@ -41,7 +41,7 @@ extern jclass inputStreamClass;
 extern jclass outputStreamClass;
 extern jclass stringClass;
 
-extern jfieldID nativeRef_context;
+extern jfieldID nativeRef_address;
 
 extern jmethodID calendar_setMethod;
 extern jmethodID inputStream_readMethod;

--- a/common/src/main/java/org/conscrypt/NativeRef.java
+++ b/common/src/main/java/org/conscrypt/NativeRef.java
@@ -23,12 +23,12 @@ package org.conscrypt;
 abstract class NativeRef {
     final long address;
 
-    NativeRef(long context) {
-        if (context == 0) {
-            throw new NullPointerException("context == 0");
+    NativeRef(long address) {
+        if (address == 0) {
+            throw new NullPointerException("address == 0");
         }
 
-        this.address = context;
+        this.address = address;
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/NativeRef.java
+++ b/common/src/main/java/org/conscrypt/NativeRef.java
@@ -21,14 +21,14 @@ package org.conscrypt;
  * objects. Individual types must subclass this and implement finalizer.
  */
 abstract class NativeRef {
-    final long context;
+    final long address;
 
     NativeRef(long context) {
         if (context == 0) {
             throw new NullPointerException("context == 0");
         }
 
-        this.context = context;
+        this.address = context;
     }
 
     @Override
@@ -37,19 +37,19 @@ abstract class NativeRef {
             return false;
         }
 
-        return ((NativeRef) o).context == context;
+        return ((NativeRef) o).address == address;
     }
 
     @Override
     public int hashCode() {
-        return (int) context;
+        return (int) (address ^ (address >>> 32));
     }
 
     @Override
     protected void finalize() throws Throwable {
         try {
-            if (context != 0) {
-                doFree(context);
+            if (address != 0) {
+                doFree(address);
             }
         } finally {
             super.finalize();

--- a/common/src/main/java/org/conscrypt/NativeSslSession.java
+++ b/common/src/main/java/org/conscrypt/NativeSslSession.java
@@ -236,19 +236,19 @@ abstract class NativeSslSession {
             this.peerCertificates = peerCertificates;
             this.peerOcspStapledResponse = peerOcspStapledResponse;
             this.peerSignedCertificateTimestamp = peerSignedCertificateTimestamp;
-            this.protocol = NativeCrypto.SSL_SESSION_get_version(ref.context);
+            this.protocol = NativeCrypto.SSL_SESSION_get_version(ref.address);
             this.cipherSuite =
-                    NativeCrypto.cipherSuiteToJava(NativeCrypto.SSL_SESSION_cipher(ref.context));
+                    NativeCrypto.cipherSuiteToJava(NativeCrypto.SSL_SESSION_cipher(ref.address));
             this.ref = ref;
         }
 
         @Override
         byte[] getId() {
-            return NativeCrypto.SSL_SESSION_session_id(ref.context);
+            return NativeCrypto.SSL_SESSION_session_id(ref.address);
         }
 
         private long getCreationTime() {
-            return NativeCrypto.SSL_SESSION_get_time(ref.context);
+            return NativeCrypto.SSL_SESSION_get_time(ref.address);
         }
 
         @Override
@@ -257,19 +257,19 @@ abstract class NativeSslSession {
             // Use the minimum of the timeout from the context and the session.
             long timeoutMillis = Math.max(0,
                                          Math.min(context.getSessionTimeout(),
-                                                 NativeCrypto.SSL_SESSION_get_timeout(ref.context)))
+                                                 NativeCrypto.SSL_SESSION_get_timeout(ref.address)))
                     * 1000;
             return (System.currentTimeMillis() - timeoutMillis) < creationTimeMillis;
         }
 
         @Override
         boolean isSingleUse() {
-            return NativeCrypto.SSL_SESSION_should_be_single_use(ref.context);
+            return NativeCrypto.SSL_SESSION_should_be_single_use(ref.address);
         }
 
         @Override
         void offerToResume(NativeSsl ssl) throws SSLException {
-            ssl.offerToResumeSession(ref.context);
+            ssl.offerToResumeSession(ref.address);
         }
 
         @Override
@@ -311,7 +311,7 @@ abstract class NativeSslSession {
                 daos.writeInt(OPEN_SSL_WITH_TLS_SCT.value); // session type ID
 
                 // Session data.
-                byte[] data = NativeCrypto.i2d_SSL_SESSION(ref.context);
+                byte[] data = NativeCrypto.i2d_SSL_SESSION(ref.address);
                 daos.writeInt(data.length);
                 daos.write(data);
 

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -539,11 +539,11 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
             }
 
             NativeCrypto.EVP_PKEY_CTX_set_rsa_padding(
-                    pkeyCtx.context, NativeConstants.RSA_PKCS1_OAEP_PADDING);
-            NativeCrypto.EVP_PKEY_CTX_set_rsa_oaep_md(pkeyCtx.context, oaepMd);
-            NativeCrypto.EVP_PKEY_CTX_set_rsa_mgf1_md(pkeyCtx.context, mgf1Md);
+                    pkeyCtx.address, NativeConstants.RSA_PKCS1_OAEP_PADDING);
+            NativeCrypto.EVP_PKEY_CTX_set_rsa_oaep_md(pkeyCtx.address, oaepMd);
+            NativeCrypto.EVP_PKEY_CTX_set_rsa_mgf1_md(pkeyCtx.address, mgf1Md);
             if (label != null && label.length > 0) {
-                NativeCrypto.EVP_PKEY_CTX_set_rsa_oaep_label(pkeyCtx.context, label);
+                NativeCrypto.EVP_PKEY_CTX_set_rsa_oaep_label(pkeyCtx.address, label);
             }
         }
 


### PR DESCRIPTION
Change context field to address to make it clear it is a native
address.

Update hash code to not just use the lower 32 bits of the address,
which should make it slightly less likely to collide.