### PR TITLE
Fix typo in assumption

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineVersionCompatibilityTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineVersionCompatibilityTest.java
@@ -664,9 +664,9 @@ public class SSLEngineVersionCompatibilityTest {
                 && !b.isInboundDone() && !a.isOutboundDone() && !b.isOutboundDone());
     }
 
-    // Assumes that the negotiated connection will be
+    // Assumes that the negotiated connection will be TLS 1.2
     private void assumeTlsV1_2Connection() {
-        assumeTrue("TLSv1.2.".equals(negotiatedVersion()));
+        assumeTrue("TLSv1.2".equals(negotiatedVersion()));
     }
 
     /**

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
@@ -2101,6 +2101,12 @@ public class SSLSocketVersionCompatibilityTest {
                     || cipherSuite.equals(StandardNames.CIPHER_SUITE_SECURE_RENEGOTIATION)) {
                 continue;
             }
+            /*
+             * tls_unique only works on 1.2, so skip TLS 1.3 cipher suites.
+             */
+            if (StandardNames.CIPHER_SUITES_TLS13.contains(cipherSuite)) {
+                continue;
+            }
             TestSSLSocketPair pair = TestSSLSocketPair.create(c);
             try {
                 String[] cipherSuites =
@@ -2277,9 +2283,9 @@ public class SSLSocketVersionCompatibilityTest {
         }
     }
 
-    // Assumes that the negotiated connection will be
+    // Assumes that the negotiated connection will be TLS 1.2
     private void assumeTlsV1_2Connection() {
-        assumeTrue("TLSv1.2.".equals(negotiatedVersion()));
+        assumeTrue("TLSv1.2".equals(negotiatedVersion()));
     }
 
     /**


### PR DESCRIPTION
The tests that relied on this were being skipped in all cases, rather
than just when 1.3 would be negotiated.