### PR TITLE
General cleanup

### DIFF
--- a/common/src/main/java/org/conscrypt/EvpMdRef.java
+++ b/common/src/main/java/org/conscrypt/EvpMdRef.java
@@ -32,18 +32,20 @@ final class EvpMdRef {
      */
     static String getJcaDigestAlgorithmStandardName(String algorithm) {
         String algorithmUpper = algorithm.toUpperCase(Locale.US);
-        if ((SHA256.JCA_NAME.equals(algorithmUpper)) || (SHA256.OID.equals(algorithmUpper))) {
+        if (SHA256.JCA_NAME.equals(algorithmUpper)
+            || SHA256.OID.equals(algorithmUpper)) {
             return SHA256.JCA_NAME;
-        } else if ((SHA512.JCA_NAME.equals(algorithmUpper))
-                || (SHA512.OID.equals(algorithmUpper))) {
+        } else if (SHA512.JCA_NAME.equals(algorithmUpper)
+                || SHA512.OID.equals(algorithmUpper)) {
             return SHA512.JCA_NAME;
-        } else if ((SHA1.JCA_NAME.equals(algorithmUpper)) || (SHA1.OID.equals(algorithmUpper))) {
+        } else if (SHA1.JCA_NAME.equals(algorithmUpper)
+                || SHA1.OID.equals(algorithmUpper)) {
             return SHA1.JCA_NAME;
-        } else if ((SHA384.JCA_NAME.equals(algorithmUpper))
-                || (SHA384.OID.equals(algorithmUpper))) {
+        } else if (SHA384.JCA_NAME.equals(algorithmUpper)
+                || SHA384.OID.equals(algorithmUpper)) {
             return SHA384.JCA_NAME;
-        } else if ((SHA224.JCA_NAME.equals(algorithmUpper))
-                || (SHA224.OID.equals(algorithmUpper))) {
+        } else if (SHA224.JCA_NAME.equals(algorithmUpper)
+                || SHA224.OID.equals(algorithmUpper)) {
             return SHA224.JCA_NAME;
         } else {
             return null;

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -434,7 +434,7 @@ final class NativeSsl {
         if (pskKeyManager != null) {
             boolean pskEnabled = false;
             for (String enabledCipherSuite : parameters.enabledCipherSuites) {
-                if ((enabledCipherSuite != null) && (enabledCipherSuite.contains("PSK"))) {
+                if ((enabledCipherSuite != null) && enabledCipherSuite.contains("PSK")) {
                     pskEnabled = true;
                     break;
                 }

--- a/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
@@ -177,7 +177,7 @@ public final class OpenSSLECKeyFactory extends KeyFactorySpi {
             } catch (InvalidKeySpecException e) {
                 throw new InvalidKeyException(e);
             }
-        } else if ((key instanceof PrivateKey) && ("PKCS#8".equals(key.getFormat()))) {
+        } else if ((key instanceof PrivateKey) && "PKCS#8".equals(key.getFormat())) {
             byte[] encoded = key.getEncoded();
             if (encoded == null) {
                 throw new InvalidKeyException("Key does not support encoding");
@@ -187,7 +187,7 @@ public final class OpenSSLECKeyFactory extends KeyFactorySpi {
             } catch (InvalidKeySpecException e) {
                 throw new InvalidKeyException(e);
             }
-        } else if ((key instanceof PublicKey) && ("X.509".equals(key.getFormat()))) {
+        } else if ((key instanceof PublicKey) && "X.509".equals(key.getFormat())) {
             byte[] encoded = key.getEncoded();
             if (encoded == null) {
                 throw new InvalidKeyException("Key does not support encoding");

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
@@ -227,7 +227,7 @@ public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             } catch (InvalidKeySpecException e) {
                 throw new InvalidKeyException(e);
             }
-        } else if ((key instanceof PrivateKey) && ("PKCS#8".equals(key.getFormat()))) {
+        } else if ((key instanceof PrivateKey) && "PKCS#8".equals(key.getFormat())) {
             byte[] encoded = key.getEncoded();
             if (encoded == null) {
                 throw new InvalidKeyException("Key does not support encoding");
@@ -237,7 +237,7 @@ public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             } catch (InvalidKeySpecException e) {
                 throw new InvalidKeyException(e);
             }
-        } else if ((key instanceof PublicKey) && ("X.509".equals(key.getFormat()))) {
+        } else if ((key instanceof PublicKey) && "X.509".equals(key.getFormat())) {
             byte[] encoded = key.getEncoded();
             if (encoded == null) {
                 throw new InvalidKeyException("Key does not support encoding");

--- a/common/src/main/java/org/conscrypt/OpenSSLSignature.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignature.java
@@ -391,8 +391,8 @@ public class OpenSSLSignature extends SignatureSpi {
             }
 
             String specMgfAlgorithm = spec.getMGFAlgorithm();
-            if ((!EvpMdRef.MGF1_ALGORITHM_NAME.equalsIgnoreCase(specMgfAlgorithm))
-                    && (!EvpMdRef.MGF1_OID.equals(specMgfAlgorithm))) {
+            if (!EvpMdRef.MGF1_ALGORITHM_NAME.equalsIgnoreCase(specMgfAlgorithm)
+                    && !EvpMdRef.MGF1_OID.equals(specMgfAlgorithm)) {
                 throw new InvalidAlgorithmParameterException(
                         "Unsupported MGF algorithm: " + specMgfAlgorithm + ". Only "
                                 + EvpMdRef.MGF1_ALGORITHM_NAME + " supported");

--- a/libcore-stub/src/main/java/libcore/java/security/StandardNames.java
+++ b/libcore-stub/src/main/java/libcore/java/security/StandardNames.java
@@ -69,13 +69,13 @@ import javax.crypto.spec.DHPublicKeySpec;
 public final class StandardNames {
     public static final boolean IS_RI =
             !"Dalvik Core Library".equals(System.getProperty("java.specification.name"));
-    public static final String JSSE_PROVIDER_NAME = (IS_RI) ? "Conscrypt" : "AndroidOpenSSL";
-    public static final String SECURITY_PROVIDER_NAME = (IS_RI) ? "SUN" : "BC";
+    public static final String JSSE_PROVIDER_NAME = IS_RI ? "Conscrypt" : "AndroidOpenSSL";
+    public static final String SECURITY_PROVIDER_NAME = IS_RI ? "SUN" : "BC";
 
-    public static final String KEY_MANAGER_FACTORY_DEFAULT = (IS_RI) ? "SunX509" : "PKIX";
+    public static final String KEY_MANAGER_FACTORY_DEFAULT = IS_RI ? "SunX509" : "PKIX";
     public static final String TRUST_MANAGER_FACTORY_DEFAULT = "PKIX";
 
-    public static final String KEY_STORE_ALGORITHM = (IS_RI) ? "JKS" : "BKS";
+    public static final String KEY_STORE_ALGORITHM = IS_RI ? "JKS" : "BKS";
 
     /**
      * RFC 5746's Signaling Cipher Suite Value to indicate a request for secure renegotiation

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
@@ -304,7 +304,7 @@ public class KeyPairGeneratorTest {
                 continue;
             }
             if ("EC".equals(algorithm)
-                    && ("SunPKCS11-NSS".equalsIgnoreCase(kpg.getProvider().getName()))
+                    && "SunPKCS11-NSS".equalsIgnoreCase(kpg.getProvider().getName())
                     && keySize == 224) {
                 // TODO(flooey): Remove when we stop supporting Java 6
                 // This Sun provider doesn't support 224-bit EC keys
@@ -323,8 +323,8 @@ public class KeyPairGeneratorTest {
             test_KeyPair(kpg, kpg.generateKeyPair());
         }
 
-        if (("EC".equals(algorithm)) || ("ECDH".equals(algorithm))
-                || ("ECDSA".equals(algorithm))) {
+        if ("EC".equals(algorithm) || "ECDH".equals(algorithm)
+                || "ECDSA".equals(algorithm)) {
             if ("SunPKCS11-NSS".equalsIgnoreCase(kpg.getProvider().getName())) {
                 // SunPKCS11 doesn't support some of the named curves that we expect, so it
                 // fails.  Skip it.

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/SignatureTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/SignatureTest.java
@@ -149,8 +149,8 @@ public class SignatureTest {
             kpAlgorithm = "EC";
         } else if (sigAlgorithmUpperCase.endsWith("DSA")) {
             kpAlgorithm = "DSA";
-        } else if ((sigAlgorithmUpperCase.endsWith("RSA"))
-                || (sigAlgorithmUpperCase.endsWith("RSA/PSS"))) {
+        } else if (sigAlgorithmUpperCase.endsWith("RSA")
+                || sigAlgorithmUpperCase.endsWith("RSA/PSS")) {
             kpAlgorithm = "RSA";
         } else {
             throw new Exception("Unknown KeyPair algorithm for Signature algorithm "

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/crypto/CipherTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/crypto/CipherTest.java
@@ -91,13 +91,13 @@ public final class CipherTest {
     /** GCM tag size used for tests. */
     private static final int GCM_TAG_SIZE_BITS = 96;
 
-    private static final String[] RSA_PROVIDERS = ((StandardNames.IS_RI)
+    private static final String[] RSA_PROVIDERS = StandardNames.IS_RI
         ? new String[] { "SunJCE", StandardNames.JSSE_PROVIDER_NAME }
-        : new String[] { "BC" , StandardNames.JSSE_PROVIDER_NAME });
+        : new String[] { "BC" , StandardNames.JSSE_PROVIDER_NAME };
 
-    private static final String[] AES_PROVIDERS = ((StandardNames.IS_RI)
+    private static final String[] AES_PROVIDERS = StandardNames.IS_RI
         ? new String[] { "SunJCE", StandardNames.JSSE_PROVIDER_NAME }
-        : new String[] { "BC", StandardNames.JSSE_PROVIDER_NAME });
+        : new String[] { "BC", StandardNames.JSSE_PROVIDER_NAME };
 
     private static boolean isSupported(String algorithm, String provider) {
         if (algorithm.equals("RC2")) {
@@ -1372,7 +1372,7 @@ public final class CipherTest {
                     Arrays.toString(
                             ((PSource.PSpecified) expectedOaepSpec.getPSource()).getValue()),
                     Arrays.toString(
-                            (((PSource.PSpecified) actualOaepSpec.getPSource()).getValue())));
+                            ((PSource.PSpecified) actualOaepSpec.getPSource()).getValue()));
         } else {
             fail("Unknown PSource type");
         }
@@ -4570,14 +4570,14 @@ public final class CipherTest {
             if (c.contains("/CBC/")) {
                 cipher.init(Cipher.DECRYPT_MODE,
                         new SecretKeySpec("0123456789012345".getBytes(StandardCharsets.US_ASCII),
-                                (c.startsWith("AES/")) ? "AES" : "DESEDE"),
+                                c.startsWith("AES/") ? "AES" : "DESEDE"),
                         new IvParameterSpec(
-                                ("01234567" + ((c.startsWith("AES/")) ? "89012345" : ""))
+                                ("01234567" + (c.startsWith("AES/") ? "89012345" : ""))
                                         .getBytes(StandardCharsets.US_ASCII)));
             } else {
                 cipher.init(Cipher.DECRYPT_MODE,
                         new SecretKeySpec("0123456789012345".getBytes(StandardCharsets.US_ASCII),
-                                (c.startsWith("AES/")) ? "AES" : "DESEDE"));
+                                c.startsWith("AES/") ? "AES" : "DESEDE"));
             }
 
             byte[] buffer = new byte[0];

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.security.InvalidAlgorithmParameterException;
-import java.security.KeyStore.Builder;
+import java.security.KeyStore;
 import java.security.KeyStore.PasswordProtection;
 import java.security.KeyStore.PrivateKeyEntry;
 import java.security.PrivateKey;
@@ -119,7 +119,7 @@ public class KeyManagerFactoryTest {
 
         // init with KeyStoreBuilderParameters ManagerFactoryParameters
         PasswordProtection pp = new PasswordProtection(getTestKeyStore().storePassword);
-        Builder builder = Builder.newInstance(getTestKeyStore().keyStore, pp);
+        KeyStore.Builder builder = KeyStore.Builder.newInstance(getTestKeyStore().keyStore, pp);
         KeyStoreBuilderParameters ksbp = new KeyStoreBuilderParameters(builder);
         if (supportsManagerFactoryParameters(kmf.getAlgorithm())) {
             kmf.init(ksbp);

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/KeyStoreBuilderParametersTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/KeyStoreBuilderParametersTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
-import java.security.KeyStore.Builder;
+import java.security.KeyStore;
 import java.security.KeyStore.PasswordProtection;
 import java.util.Arrays;
 import java.util.List;
@@ -53,7 +53,7 @@ public class KeyStoreBuilderParametersTest {
         // Objects.requireNonNull was added
         assumeObjectsAvailable();
         try {
-            new KeyStoreBuilderParameters((Builder) null);
+            new KeyStoreBuilderParameters((KeyStore.Builder) null);
             fail();
         } catch (NullPointerException expected) {
         }
@@ -62,7 +62,7 @@ public class KeyStoreBuilderParametersTest {
     @Test
     public void test_init_Builder() {
         TestKeyStore testKeyStore = TestKeyStore.getClient();
-        Builder builder = Builder.newInstance(
+        KeyStore.Builder builder = KeyStore.Builder.newInstance(
                 testKeyStore.keyStore, new PasswordProtection(testKeyStore.storePassword));
         KeyStoreBuilderParameters ksbp = new KeyStoreBuilderParameters(builder);
         assertNotNull(ksbp);
@@ -74,7 +74,7 @@ public class KeyStoreBuilderParametersTest {
     @Test
     public void test_init_List_null() {
         try {
-            new KeyStoreBuilderParameters((List<Builder>) null);
+            new KeyStoreBuilderParameters((List<KeyStore.Builder>) null);
             fail();
         } catch (NullPointerException expected) {
             // Ignored.
@@ -85,12 +85,12 @@ public class KeyStoreBuilderParametersTest {
     public void test_init_List() {
         TestKeyStore testKeyStore1 = TestKeyStore.getClient();
         TestKeyStore testKeyStore2 = TestKeyStore.getServer();
-        Builder builder1 = Builder.newInstance(
+        KeyStore.Builder builder1 = KeyStore.Builder.newInstance(
                 testKeyStore1.keyStore, new PasswordProtection(testKeyStore1.storePassword));
-        Builder builder2 = Builder.newInstance(
+        KeyStore.Builder builder2 = KeyStore.Builder.newInstance(
                 testKeyStore2.keyStore, new PasswordProtection(testKeyStore2.storePassword));
 
-        List<Builder> list = Arrays.asList(builder1, builder2);
+        List<KeyStore.Builder> list = Arrays.asList(builder1, builder2);
         KeyStoreBuilderParameters ksbp = new KeyStoreBuilderParameters(list);
         assertNotNull(ksbp);
         assertNotNull(ksbp.getParameters());

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLContextTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLContextTest.java
@@ -174,10 +174,10 @@ public class SSLContextTest {
             context.init(null, null, null);
 
             StandardNames.assertSSLContextEnabledProtocols(
-                    tlsVersion, ((SSLSocket) (context.getSocketFactory().createSocket()))
+                    tlsVersion, ((SSLSocket) context.getSocketFactory().createSocket())
                                         .getEnabledProtocols());
             StandardNames.assertSSLContextEnabledProtocols(tlsVersion,
-                    ((SSLServerSocket) (context.getServerSocketFactory().createServerSocket()))
+                    ((SSLServerSocket) context.getServerSocketFactory().createServerSocket())
                             .getEnabledProtocols());
             StandardNames.assertSSLContextEnabledProtocols(
                     tlsVersion, context.getDefaultSSLParameters().getProtocols());

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -248,8 +248,8 @@ public class SSLEngineTest {
                 boolean serverAuthenticatedUsingPublicKey = true;
                 if (cipherSuite.contains("_anon_")) {
                     serverAuthenticatedUsingPublicKey = false;
-                } else if ((cipherSuite.startsWith("TLS_PSK_"))
-                        || (cipherSuite.startsWith("TLS_ECDHE_PSK_"))) {
+                } else if (cipherSuite.startsWith("TLS_PSK_")
+                        || cipherSuite.startsWith("TLS_ECDHE_PSK_")) {
                     serverAuthenticatedUsingPublicKey = false;
                 }
                 if (serverAuthenticatedUsingPublicKey) {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSessionContextTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSessionContextTest.java
@@ -329,7 +329,7 @@ public class SSLSessionContextTest {
     }
 
     private int expectedSslSessionCacheTimeout(TestSSLContext c) {
-        return (isConscrypt(c.serverContext.getProvider())) ? 8 * 3600 : 24 * 3600;
+        return isConscrypt(c.serverContext.getProvider()) ? 8 * 3600 : 24 * 3600;
     }
 
     private static int numSessions(SSLSessionContext s) {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
@@ -1581,8 +1581,8 @@ public class SSLSocketVersionCompatibilityTest {
         server.getOutputStream().write(42);
         assertEquals(42, handshakeFuture.get().intValue());
 
-        final Socket toRead = (readUnderlying) ? underlying : clientWrapping;
-        final Socket toClose = (closeUnderlying) ? underlying : clientWrapping;
+        final Socket toRead = readUnderlying ? underlying : clientWrapping;
+        final Socket toClose = closeUnderlying ? underlying : clientWrapping;
 
         // Schedule the socket to be closed in 1 second.
         Future<Void> future = runAsync(new Callable<Void>() {

--- a/openjdk/src/main/java/org/conscrypt/Java8PlatformUtil.java
+++ b/openjdk/src/main/java/org/conscrypt/Java8PlatformUtil.java
@@ -77,7 +77,7 @@ final class Java8PlatformUtil {
         params.setUseCipherSuitesOrder(impl.getUseCipherSuitesOrder());
         if (impl.getUseSni() && AddressUtils.isValidSniHostname(engine.getHostname())) {
             params.setServerNames(Collections.singletonList(
-                    (SNIServerName) new SNIHostName((engine.getHostname()))));
+                    (SNIServerName) new SNIHostName(engine.getHostname())));
         }
     }
 

--- a/test_logging.properties
+++ b/test_logging.properties
@@ -9,3 +9,4 @@ org.conscrypt.handler=java.util.logging.ConsoleHandler
 
 # Avoid nuisance logs in tests.
 org.conscrypt.NativeSslSession.level=SEVERE
+org.conscrypt.TrustManagerImpl.level=INFO

--- a/testing/src/main/java/org/conscrypt/javax/net/ssl/PSKKeyManagerProxy.java
+++ b/testing/src/main/java/org/conscrypt/javax/net/ssl/PSKKeyManagerProxy.java
@@ -70,7 +70,7 @@ class PSKKeyManagerProxy implements InvocationHandler {
         String methodName = method.getName();
         Class<?>[] parameterTypes = method.getParameterTypes();
         boolean sslEngineVariant = (parameterTypes.length > 0)
-                && (SSLEngine.class.equals(parameterTypes[parameterTypes.length - 1]));
+                && SSLEngine.class.equals(parameterTypes[parameterTypes.length - 1]);
         if ("getKey".equals(methodName)) {
             if (sslEngineVariant) {
                 return getKey((String) args[0], (String) args[1], (SSLEngine) args[2]);


### PR DESCRIPTION
Deal with some new ErrorProne warnings: unnecessary parentheses and
importing classes named Builder.

Add new cert failure logging to the test logging file so it doesn't
pollute the test output.