### PR TITLE
Switch appveyor.yml from Yasm to NASM.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
   NINJA_URL: "https://github.com/ninja-build/ninja/releases/download/v1.8.2/ninja-win.zip"
   CMAKE_URL: "https://cmake.org/files/v3.11/cmake-3.11.1-win32-x86.zip"
   MSVC_HOME: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community"
-  YASM_URL: "http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win32.exe"
-  YASM_SHA256: "db8ef9348ae858354cee4cc2f99e0f36de8a47a121de4cfeea5a16d45dd5ac1b"
 
 clone_folder: "C:\\projects\\conscrypt"
 shallow_clone: true
@@ -44,11 +42,8 @@ init:
   - set PATH=C:\cmake\bin;%PATH%
   - cmake --version
 
-  # Install yasm
-  - mkdir C:\yasm
-  - appveyor DownloadFile %YASM_URL% -FileName C:\yasm\yasm.exe
-  - ps: if ((Get-FileHash C:\yasm\yasm.exe -Algorithm SHA256).Hash.ToLower() -ne $env:YASM_SHA256) { Throw "Yasm hash mismatch" }
-  - set PATH=C:\yasm;%PATH%
+  # Install NASM
+  - choco install -y --allow-empty-checksums nasm
 
   # Install Go for BoringSSL compile (embedding test data)
   - choco install -y --allow-empty-checksums golang

--- a/release/README.md
+++ b/release/README.md
@@ -22,7 +22,7 @@ The following software is necessary and may not be installed by default:
 <!-- TODO(flooey): Expand and link these, there's probably more -->
 * Linux: [Docker](https://www.docker.com/), [Android SDK](https://developer.android.com/studio/index.html)
 * MacOS: Java SDK
-* Windows: MSVC, git, yasm, Java
+* Windows: MSVC, git, NASM, Java
 
 ### Setup OSSRH and GPG
 


### PR DESCRIPTION
NASM is actively maintained while Yasm appears to be abandoned these
days. Both should work for now, but we've switched to recommending
building BoringSSL with NASM. Chromium is also using NASM to build
BoringSSL now. (Yasm may break in the future if we add assembly that
uses some Intel instructions that aren't in Yasm.)

Happily, chocolatey's NASM package is up-to-date (last update a week
ago), unlike its Yasm package, which is one version behind. So this
means appveyor.yml is simpler now.