### PR TITLE
Synchronize OpenSSLRSAPublicKey.ensureReadParams.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPublicKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPublicKey.java
@@ -99,7 +99,7 @@ public class OpenSSLRSAPublicKey implements RSAPublicKey, OpenSSLKeyHolder {
         return NativeCrypto.EVP_marshal_public_key(key.getNativeRef());
     }
 
-    private void ensureReadParams() {
+    private synchronized void ensureReadParams() {
         if (fetchedParams) {
             return;
         }


### PR DESCRIPTION
This matches OpenSSLRSAPrivateKey. Callers call getters on this object
on multiple threads, expecting it to work as they are both logically
immutable. This means the cache of fetched parameters must be
thread-safe.