### PR TITLE
Create ActiveSession during transitionTo()

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -145,7 +145,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     /**
      * Set during startHandshake.
      */
-    private final ActiveSession activeSession;
+    private ActiveSession activeSession;
 
     /**
      * A snapshot of the active session when the engine was closed.
@@ -184,7 +184,6 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         peerInfoProvider = PeerInfoProvider.nullProvider();
         this.ssl = newSsl(sslParameters, this);
         this.networkBio = ssl.newBio();
-        activeSession = new ActiveSession(ssl, sslParameters.getSessionContext());
     }
 
     ConscryptEngine(String host, int port, SSLParametersImpl sslParameters) {
@@ -192,7 +191,6 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         this.peerInfoProvider = PeerInfoProvider.forHostAndPort(host, port);
         this.ssl = newSsl(sslParameters, this);
         this.networkBio = ssl.newBio();
-        activeSession = new ActiveSession(ssl, sslParameters.getSessionContext());
     }
 
     ConscryptEngine(SSLParametersImpl sslParameters, PeerInfoProvider peerInfoProvider) {
@@ -200,7 +198,6 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         this.peerInfoProvider = checkNotNull(peerInfoProvider, "peerInfoProvider");
         this.ssl = newSsl(sslParameters, this);
         this.networkBio = ssl.newBio();
-        activeSession = new ActiveSession(ssl, sslParameters.getSessionContext());
     }
 
     private static NativeSsl newSsl(SSLParametersImpl sslParameters, ConscryptEngine engine) {
@@ -464,10 +461,15 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
             if (state == STATE_CLOSED || state == STATE_CLOSED_INBOUND) {
                 return;
             }
-            if (isOutboundDone()) {
-                closeAndFreeResources();
+            if (isHandshakeStarted()) {
+                if (isOutboundDone()) {
+                    closeAndFreeResources();
+                } else {
+                    transitionTo(STATE_CLOSED_INBOUND);
+                }
             } else {
-                transitionTo(STATE_CLOSED_INBOUND);
+                // Never started the handshake. Just close now.
+                closeAndFreeResources();
             }
         }
     }
@@ -1819,10 +1821,11 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         switch (newState) {
             case STATE_HANDSHAKE_STARTED: {
                 handshakeFinished = false;
+                activeSession = new ActiveSession(ssl, sslParameters.getSessionContext());
                 break;
             }
             case STATE_CLOSED: {
-                if (!ssl.isClosed() && state >= STATE_HANDSHAKE_STARTED && state < STATE_CLOSED ) {
+                if (!ssl.isClosed() && state >= STATE_HANDSHAKE_STARTED && state < STATE_CLOSED) {
                     closedSession = new SessionSnapshot(activeSession);
                 }
                 break;


### PR DESCRIPTION
The SessionContext we should use in ActiveSession depends on whether
the engine is in client or server mode, which we don't know until the
handshake is started, so wait until handshake start to create it.  As
a bonus, this makes the comment for activeSession correct again.

Also make closeInbound() the same as closeOutbound() where if you
close it before the handshake starts it just closes the engine
entirely.  STATE_CLOSED_INBOUND is assumed to be a post-handshake
state by a bunch of stuff, so we need to skip it.

Fixes #585.