### PR TITLE
Stop using InetAddress.isNumeric()

### DIFF
--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -542,19 +542,6 @@ final class Platform {
         }
     }
 
-    /**
-     * Returns true if the supplied hostname is an literal IP address.
-     */
-    public static boolean isLiteralIpAddress(String hostname) {
-        try {
-            Method m_isNumeric = InetAddress.class.getMethod("isNumeric", String.class);
-            return (Boolean) m_isNumeric.invoke(null, hostname);
-        } catch (Exception ignored) {
-        }
-
-        return AddressUtils.isLiteralIpAddress(hostname);
-    }
-
     static SSLEngine wrapEngine(ConscryptEngine engine) {
         // For now, don't wrap on Android.
         return engine;

--- a/common/src/main/java/org/conscrypt/AddressUtils.java
+++ b/common/src/main/java/org/conscrypt/AddressUtils.java
@@ -43,7 +43,7 @@ final class AddressUtils {
         // Must be a FQDN that does not have a trailing dot.
         return (sniHostname.equalsIgnoreCase("localhost")
                     || sniHostname.indexOf('.') != -1)
-                && !Platform.isLiteralIpAddress(sniHostname)
+                && !isLiteralIpAddress(sniHostname)
                 && !sniHostname.endsWith(".")
                 && sniHostname.indexOf('\0') == -1;
     }

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -317,15 +317,6 @@ final class Platform {
     static void logEvent(@SuppressWarnings("unused") String message) {}
 
     /**
-     * Returns true if the supplied hostname is an literal IP address.
-     */
-    @SuppressWarnings("unused")
-    static boolean isLiteralIpAddress(String hostname) {
-        // TODO: any RI API to make this better?
-        return AddressUtils.isLiteralIpAddress(hostname);
-    }
-
-    /**
      * For unbundled versions, SNI is always enabled by default.
      */
     @SuppressWarnings("unused")

--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -272,13 +272,6 @@ final class Platform {
         }
     }
 
-    /**
-     * Returns true if the supplied hostname is an literal IP address.
-     */
-    static boolean isLiteralIpAddress(String hostname) {
-        return InetAddress.isNumeric(hostname);
-    }
-
     static SSLEngine wrapEngine(ConscryptEngine engine) {
         return new Java8EngineWrapper(engine);
     }


### PR DESCRIPTION
This method is likely to be blacklisted from reflective access on
Android, and we have an implementation that works acceptably.