### PR TITLE
Update Android benchmarks

### DIFF
--- a/benchmark-android/build.gradle
+++ b/benchmark-android/build.gradle
@@ -64,7 +64,7 @@ if (androidSdkInstalled) {
     }
 
     dependencies {
-        depsJarApi project(':conscrypt-android'),
+        depsJarApi project(path: ':conscrypt-android', configuration: 'default'),
                    libraries.bouncycastle_provider,
                    libraries.bouncycastle_apis
 

--- a/benchmark-android/src/main/java/org/conscrypt/AndroidEngineFactory.java
+++ b/benchmark-android/src/main/java/org/conscrypt/AndroidEngineFactory.java
@@ -15,7 +15,6 @@
  */
 package org.conscrypt;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.Security;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;

--- a/benchmark-android/src/main/java/org/conscrypt/AndroidEngineFactory.java
+++ b/benchmark-android/src/main/java/org/conscrypt/AndroidEngineFactory.java
@@ -16,6 +16,7 @@
 package org.conscrypt;
 
 import java.security.NoSuchAlgorithmException;
+import java.security.Security;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
@@ -46,12 +47,33 @@ public enum AndroidEngineFactory implements EngineFactory {
             return engine;
         }
 
-        private SSLContext newContext() {
-            try {
-                return SSLContext.getInstance(TestUtils.getProtocols()[0], new OpenSSLProvider());
-            } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException(e);
+        @Override
+        public void dispose(SSLEngine engine) {
+            engine.closeOutbound();
+        }
+    },
+    PLATFORM {
+        private final SSLContext clientContext = TestUtils.newClientSslContext(
+            Security.getProvider("AndroidOpenSSL"));
+        private final SSLContext serverContext = TestUtils.newServerSslContext(
+            Security.getProvider("AndroidOpenSSL"));
+
+        @Override
+        public SSLEngine newClientEngine(String cipher, boolean useAlpn) {
+            SSLEngine engine = initEngine(clientContext.createSSLEngine(), cipher, true);
+            if (useAlpn) {
+                Conscrypt.setApplicationProtocols(engine, new String[] {"h2"});
             }
+            return engine;
+        }
+
+        @Override
+        public SSLEngine newServerEngine(String cipher, boolean useAlpn) {
+            SSLEngine engine = initEngine(serverContext.createSSLEngine(), cipher, false);
+            if (useAlpn) {
+                Conscrypt.setApplicationProtocols(engine, new String[] {"h2"});
+            }
+            return engine;
         }
 
         @Override

--- a/benchmark-android/src/main/java/org/conscrypt/CaliperAlpnBenchmark.java
+++ b/benchmark-android/src/main/java/org/conscrypt/CaliperAlpnBenchmark.java
@@ -35,7 +35,7 @@ public class CaliperAlpnBenchmark {
     @Param
     public BufferType b_buffer;
 
-    @Param
+    @Param({"CONSCRYPT_UNPOOLED"})
     public AndroidEngineFactory c_engine;
 
     private EngineHandshakeBenchmark benchmark;

--- a/benchmark-android/src/main/java/org/conscrypt/CaliperEngineHandshakeBenchmark.java
+++ b/benchmark-android/src/main/java/org/conscrypt/CaliperEngineHandshakeBenchmark.java
@@ -50,7 +50,7 @@ public class CaliperEngineHandshakeBenchmark {
     @Param
     public BufferType b_buffer;
 
-    @Param
+    @Param({"CONSCRYPT_UNPOOLED"})
     public AndroidEngineFactory c_engine;
 
     @Param

--- a/benchmark-android/src/main/java/org/conscrypt/CaliperEngineWrapBenchmark.java
+++ b/benchmark-android/src/main/java/org/conscrypt/CaliperEngineWrapBenchmark.java
@@ -55,7 +55,7 @@ public class CaliperEngineWrapBenchmark {
     @Param({"64", "512", "4096"})
     public int c_message;
 
-    @Param
+    @Param({"CONSCRYPT_UNPOOLED"})
     public AndroidEngineFactory d_engine;
 
     private EngineWrapBenchmark benchmark;


### PR DESCRIPTION
Update one dep to work with our current version of gradle.

Add platform engine implementation so we can run benchmarks of the
current platform build as well as the unbundled build.