### PR TITLE
Revert "Remove CompatibilityCloseMonitor"

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
 add_library(conscrypt_jni
             SHARED
+            ../common/src/jni/main/cpp/conscrypt/compatibility_close_monitor.cc
             ../common/src/jni/main/cpp/conscrypt/jniload.cc
             ../common/src/jni/main/cpp/conscrypt/jniutil.cc
             ../common/src/jni/main/cpp/conscrypt/native_crypto.cc

--- a/common/src/jni/main/cpp/conscrypt/compatibility_close_monitor.cc
+++ b/common/src/jni/main/cpp/conscrypt/compatibility_close_monitor.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <conscrypt/compatibility_close_monitor.h>
+
+#if defined(CONSCRYPT_UNBUNDLED) && !defined(CONSCRYPT_OPENJDK)
+
+#include <dlfcn.h>
+
+namespace conscrypt {
+
+CompatibilityCloseMonitor::acm_ctor_func CompatibilityCloseMonitor::asyncCloseMonitorConstructor =
+        nullptr;
+CompatibilityCloseMonitor::acm_dtor_func CompatibilityCloseMonitor::asyncCloseMonitorDestructor =
+        nullptr;
+
+void CompatibilityCloseMonitor::init() {
+    void *lib = dlopen("libjavacore.so", RTLD_NOW);
+    if (lib != nullptr) {
+        asyncCloseMonitorConstructor =
+                (acm_ctor_func)dlsym(lib, "_ZN24AsynchronousCloseMonitorC1Ei");
+        asyncCloseMonitorDestructor =
+                (acm_dtor_func)dlsym(lib, "_ZN24AsynchronousCloseMonitorD1Ev");
+    }
+}
+
+}  // namespace conscrypt
+
+#endif  // CONSCRYPT_UNBUNDLED && !CONSCRYPT_OPENJDK

--- a/common/src/jni/main/cpp/conscrypt/jniload.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniload.cc
@@ -16,6 +16,7 @@
 
 #include <jni.h>
 
+#include <conscrypt/compatibility_close_monitor.h>
 #include <conscrypt/jniutil.h>
 #include <conscrypt/logging.h>
 #include <conscrypt/native_crypto.h>
@@ -24,6 +25,7 @@
 #define CONSCRYPT_JNI_VERSION JNI_VERSION_1_6
 #endif  // !CONSCRYPT_JNI_VERSION
 
+using conscrypt::CompatibilityCloseMonitor;
 using conscrypt::NativeCrypto;
 
 // Give client libs everything they need to initialize our JNI
@@ -40,6 +42,8 @@ jint libconscrypt_JNI_OnLoad(JavaVM* vm, void*) {
     // Register all of the native JNI methods.
     NativeCrypto::registerNativeMethods(env);
 
+    // Perform static initialization of the close monitor (if required on this platform).
+    CompatibilityCloseMonitor::init();
     return CONSCRYPT_JNI_VERSION;
 }
 

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -20,6 +20,7 @@
 #include <conscrypt/bio_output_stream.h>
 #include <conscrypt/bio_stream.h>
 #include <conscrypt/compat.h>
+#include <conscrypt/compatibility_close_monitor.h>
 #include <conscrypt/jniutil.h>
 #include <conscrypt/logging.h>
 #include <conscrypt/macros.h>
@@ -53,6 +54,7 @@ using conscrypt::AppData;
 using conscrypt::BioInputStream;
 using conscrypt::BioOutputStream;
 using conscrypt::BioStream;
+using conscrypt::CompatibilityCloseMonitor;
 using conscrypt::NativeCrypto;
 using conscrypt::SslError;
 
@@ -5998,6 +6000,8 @@ static int sslSelect(JNIEnv* env, int type, jobject fdObject, AppData* appData,
         if (timeout_millis <= 0) {
             timeout_millis = -1;
         }
+
+        CompatibilityCloseMonitor monitor(intFd);
 
         result = poll(fds, sizeof(fds) / sizeof(fds[0]), timeout_millis);
         JNI_TRACE("sslSelect %s fd=%d appData=%p timeout_millis=%d => %d",

--- a/common/src/jni/main/include/conscrypt/compatibility_close_monitor.h
+++ b/common/src/jni/main/include/conscrypt/compatibility_close_monitor.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CONSCRYPT_COMPATIBILITY_CLOSE_MONITOR_H_
+#define CONSCRYPT_COMPATIBILITY_CLOSE_MONITOR_H_
+
+#include <conscrypt/macros.h>
+
+#ifndef CONSCRYPT_UNBUNDLED
+
+/* If we're compiled unbundled from Android system image, we use the
+ * CompatibilityCloseMonitor
+ */
+#include <nativehelper/AsynchronousCloseMonitor.h>
+
+namespace conscrypt {
+
+/**
+ * When bundled with Android, this just wraps around AsynchronousCloseMonitor.
+ */
+class CompatibilityCloseMonitor {
+ private:
+    AsynchronousCloseMonitor monitor;
+
+ public:
+    explicit CompatibilityCloseMonitor(int fd) : monitor(fd) {}
+
+    ~CompatibilityCloseMonitor() {}
+
+    static void init() {}
+};
+
+}  // namespace conscrypt
+
+#elif !defined(CONSCRYPT_OPENJDK)  // && CONSCRYPT_UNBUNDLED
+
+namespace conscrypt {
+
+/*
+ * This is a big hack; don't learn from this. Basically what happened is we do
+ * not have an API way to insert ourselves into the AsynchronousCloseMonitor
+ * that's compiled into the native libraries for libcore when we're unbundled.
+ * So we try to look up the symbol from the main library to find it.
+ */
+class CompatibilityCloseMonitor {
+ public:
+    explicit CompatibilityCloseMonitor(int fd) {
+        if (asyncCloseMonitorConstructor != nullptr) {
+            asyncCloseMonitorConstructor(objBuffer, fd);
+        }
+    }
+
+    ~CompatibilityCloseMonitor() {
+        if (asyncCloseMonitorDestructor != nullptr) {
+            asyncCloseMonitorDestructor(objBuffer);
+        }
+    }
+
+    static void init();
+
+ private:
+    typedef void (*acm_ctor_func)(void*, int);
+    typedef void (*acm_dtor_func)(void*);
+
+    static acm_ctor_func asyncCloseMonitorConstructor;
+    static acm_dtor_func asyncCloseMonitorDestructor;
+
+    char objBuffer[256];
+#if 0
+    static_assert(sizeof(objBuffer) > 2*sizeof(AsynchronousCloseMonitor),
+                  "CompatibilityCloseMonitor must be larger than the actual object");
+#endif
+};
+
+}  // namespace conscrypt
+
+#else  // CONSCRYPT_UNBUNDLED && CONSCRYPT_OPENJDK
+
+namespace conscrypt {
+
+/**
+ * For OpenJDK, do nothing.
+ */
+class CompatibilityCloseMonitor {
+ public:
+    explicit CompatibilityCloseMonitor(int) {}
+
+    ~CompatibilityCloseMonitor() {}
+
+    static void init() {}
+};
+
+}  // namespace conscrypt
+
+#endif  // CONSCRYPT_UNBUNDLED && CONSCRYPT_OPENJDK
+
+#endif  // CONSCRYPT_COMPATIBILITY_CLOSE_MONITOR_H_


### PR DESCRIPTION
Reverts google/conscrypt#613 "Remove CompatibilityCloseMonitor" as it breaks behaviour.

NB Automated revert contains a commit for 'Revert "Update Android benchmarks (#614)"' too, but contains no content so it seems fine.