### PR TITLE
Expose ClientHello.random and ServerHello.random

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -7874,6 +7874,46 @@ static jobjectArray NativeCrypto_SSL_get0_peer_certificates(JNIEnv* env, jclass,
     return array.release();
 }
 
+static jbyteArray NativeCrypto_SSL_get_client_random(JNIEnv* env, jclass,
+                                                     jlong ssl_address, CONSCRYPT_UNUSED jobject ssl_holder) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_get_client_random", ssl);
+    if (ssl == nullptr) {
+        return nullptr;
+    }
+
+    unsigned char b[SSL3_RANDOM_SIZE];
+    if (SSL_get_client_random(ssl, &b[0], SSL3_RANDOM_SIZE) == SSL3_RANDOM_SIZE) {
+        jbyteArray out = env->NewByteArray(static_cast<jsize>(SSL3_RANDOM_SIZE));
+        if (out != nullptr) {
+            env->SetByteArrayRegion(out, 0, static_cast<jsize>(SSL3_RANDOM_SIZE), reinterpret_cast<const jbyte*>(&b[0]));
+        }
+        return out;
+    }
+    return nullptr;
+}
+
+static jbyteArray NativeCrypto_SSL_get_server_random(JNIEnv* env, jclass,
+                                                     jlong ssl_address, CONSCRYPT_UNUSED jobject ssl_holder) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    SSL* ssl = to_SSL(env, ssl_address, true);
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_get_server_random", ssl);
+    if (ssl == nullptr) {
+        return nullptr;
+    }
+
+    unsigned char b[SSL3_RANDOM_SIZE];
+    if (SSL_get_server_random(ssl, &b[0], SSL3_RANDOM_SIZE) == SSL3_RANDOM_SIZE) {
+        jbyteArray out = env->NewByteArray(static_cast<jsize>(SSL3_RANDOM_SIZE));
+        if (out != nullptr) {
+            env->SetByteArrayRegion(out, 0, static_cast<jsize>(SSL3_RANDOM_SIZE), reinterpret_cast<const jbyte*>(&b[0]));
+        }
+        return out;
+    }
+    return nullptr;
+}
+
 static int sslRead(JNIEnv* env, SSL* ssl, jobject fdObject, jobject shc, char* buf, jint len,
                    SslError* sslError, int read_timeout_millis) {
     JNI_TRACE("ssl=%p sslRead buf=%p len=%d", ssl, buf, len);
@@ -10156,6 +10196,8 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(SSL_get_current_cipher, "(J" REF_SSL ")Ljava/lang/String;"),
         CONSCRYPT_NATIVE_METHOD(SSL_get_version, "(J" REF_SSL ")Ljava/lang/String;"),
         CONSCRYPT_NATIVE_METHOD(SSL_get0_peer_certificates, "(J" REF_SSL ")[[B"),
+        CONSCRYPT_NATIVE_METHOD(SSL_get_client_random, "(J" REF_SSL ")[B"),
+        CONSCRYPT_NATIVE_METHOD(SSL_get_server_random, "(J" REF_SSL ")[B"),
         CONSCRYPT_NATIVE_METHOD(SSL_read, "(J" REF_SSL FILE_DESCRIPTOR SSL_CALLBACKS "[BIII)I"),
         CONSCRYPT_NATIVE_METHOD(SSL_write, "(J" REF_SSL FILE_DESCRIPTOR SSL_CALLBACKS "[BIII)V"),
         CONSCRYPT_NATIVE_METHOD(SSL_interrupt, "(J" REF_SSL ")V"),

--- a/common/src/main/java/org/conscrypt/AbstractConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptEngine.java
@@ -158,6 +158,10 @@ abstract class AbstractConscryptEngine extends SSLEngine {
      */
     abstract void setApplicationProtocolSelector(ApplicationProtocolSelector selector);
 
+    abstract byte[] getClientRandom();
+
+    abstract byte[] getServerRandom();
+
     /**
      * Returns the tls-unique channel binding value for this connection, per RFC 5929.  This
      * will return {@code null} if there is no such value available, such as if the handshake

--- a/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
@@ -731,6 +731,10 @@ abstract class AbstractConscryptSocket extends SSLSocket {
      */
     abstract void setApplicationProtocolSelector(ApplicationProtocolSelector selector);
 
+    abstract byte[] getClientRandom();
+
+    abstract byte[] getServerRandom();
+
     /**
      * Returns the tls-unique channel binding value for this connection, per RFC 5929.  This
      * will return {@code null} if there is no such value available, such as if the handshake

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -435,6 +435,14 @@ public final class Conscrypt {
         return toConscrypt(socket).getApplicationProtocols();
     }
 
+    public static byte[] getClientRandom(SSLSocket socket) {
+        return toConscrypt(socket).getClientRandom();
+    }
+
+    public static byte[] getServerRandom(SSLSocket socket) {
+        return toConscrypt(socket).getServerRandom();
+    }
+
     /**
      * Returns the tls-unique channel binding value for this connection, per RFC 5929.  This
      * will return {@code null} if there is no such value available, such as if the handshake
@@ -677,6 +685,14 @@ public final class Conscrypt {
      */
     public static String getApplicationProtocol(SSLEngine engine) {
         return toConscrypt(engine).getApplicationProtocol();
+    }
+
+    public static byte[] getClientRandom(SSLEngine engine) {
+        return toConscrypt(engine).getClientRandom();
+    }
+
+    public static byte[] getServerRandom(SSLEngine engine) {
+        return toConscrypt(engine).getServerRandom();
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1761,6 +1761,16 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     }
 
     @Override
+    byte[] getClientRandom() {
+        return ssl.getClientRandom();
+    }
+
+    @Override
+    byte[] getServerRandom() {
+        return ssl.getServerRandom();
+    }
+
+    @Override
     byte[] getTlsUnique() {
         return ssl.getTlsUnique();
     }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -328,6 +328,16 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
     }
 
     @Override
+    byte[] getClientRandom() {
+        return engine.getClientRandom();
+    }
+
+    @Override
+    byte[] getServerRandom() {
+        return engine.getServerRandom();
+    }
+
+    @Override
     byte[] getTlsUnique() {
         return engine.getTlsUnique();
     }

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -866,6 +866,16 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     }
 
     @Override
+    byte[] getClientRandom() {
+        return ssl.getClientRandom();
+    }
+
+    @Override
+    byte[] getServerRandom() {
+        return ssl.getServerRandom();
+    }
+
+    @Override
     byte[] getTlsUnique() {
         return ssl.getTlsUnique();
     }

--- a/common/src/main/java/org/conscrypt/Java8EngineWrapper.java
+++ b/common/src/main/java/org/conscrypt/Java8EngineWrapper.java
@@ -296,6 +296,16 @@ final class Java8EngineWrapper extends AbstractConscryptEngine {
     }
 
     @Override
+    byte[] getClientRandom() {
+        return delegate.getClientRandom();
+    }
+
+    @Override
+    byte[] getServerRandom() {
+        return delegate.getServerRandom();
+    }
+
+    @Override
     byte[] getTlsUnique() {
         return delegate.getTlsUnique();
     }

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1118,6 +1118,10 @@ public final class NativeCrypto {
      */
     static native byte[][] SSL_get0_peer_certificates(long ssl, NativeSsl ssl_holder);
 
+    static native byte[] SSL_get_client_random(long ssl, NativeSsl ssl_holder);
+
+    static native byte[] SSL_get_server_random(long ssl, NativeSsl ssl_holder);
+
     /**
      * Reads with the native SSL_read function from the encrypted data stream
      * @return -1 if error or the end of the stream is reached.

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -125,6 +125,14 @@ final class NativeSsl {
         return NativeCrypto.SSL_get_ocsp_response(ssl, this);
     }
 
+    byte[] getClientRandom() {
+        return NativeCrypto.SSL_get_client_random(ssl, this);
+    }
+
+    byte[] getServerRandom() {
+        return NativeCrypto.SSL_get_server_random(ssl, this);
+    }
+
     byte[] getTlsUnique() {
         return NativeCrypto.SSL_get_tls_unique(ssl, this);
     }

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
@@ -2036,6 +2036,27 @@ public class SSLSocketVersionCompatibilityTest {
     }
 
     @Test
+    public void test_SSLSocket_HelloRandom() throws Exception {
+        TestSSLContext context = new TestSSLContext.Builder()
+                .clientProtocol(clientVersion)
+                .serverProtocol(serverVersion)
+                .build();
+        TestSSLSocketPair pair = TestSSLSocketPair.create(context);
+        try {
+            byte[] clientRandom = Conscrypt.getClientRandom(pair.client);
+            byte[] serverRandom = Conscrypt.getServerRandom(pair.client);
+            byte[] clientRandom2 = Conscrypt.getClientRandom(pair.server);
+            byte[] serverRandom2 = Conscrypt.getServerRandom(pair.server);
+            assertEquals(32, clientRandom.length);
+            assertEquals(32, serverRandom.length);
+            assertArrayEquals(clientRandom, clientRandom2);
+            assertArrayEquals(serverRandom, serverRandom2);
+        } finally {
+            pair.close();
+        }
+    }
+
+    @Test
     public void test_SSLSocket_TlsUnique() throws Exception {
         // tls_unique isn't supported in TLS 1.3
         assumeTlsV1_2Connection();


### PR DESCRIPTION
I used it to build a [tlsdate](https://github.com/ioerror/tlsdate)-like tool.

    val okHttpClient = OkHttpClient.Builder()
        .addNetworkInterceptor { chain ->
            val response = chain.proceed(chain.request())
            val connection = chain.connection()
                ?.takeIf { it.handshake()?.tlsVersion() != TlsVersion.TLS_1_3 }
                ?: return@addNetworkInterceptor response
            val socket = (connection.socket() as? SSLSocket)
                ?.takeIf { Conscrypt.isConscrypt(it) }
                ?: return@addNetworkInterceptor response
            val serverRandom = Conscrypt.getServerRandom(socket)?.asUByteArray()
                ?: return@addNetworkInterceptor response
            val serverTime = serverRandom.take(4).fold(0L) { k, b -> k shl 8 or b.toLong() }
            return@addNetworkInterceptor response.newBuilder()
                .addHeader(
                    "x-tls-date",
                    Instant.ofEpochSecond(serverTime).atOffset(ZoneOffset.UTC)
                        .format(DateTimeFormatter.RFC_1123_DATE_TIME)
                )
                .build()
        }
        .build()
    val request = Request.Builder().url("https://clients3.google.com/generate_204").build()
    val response = okHttpClient.newCall(request).execute()
    println(response)
    println("tlsdate: ${response.headers().getDate("x-tls-date")}")
    println("htpdate: ${response.headers().getDate("date")}")
