### PR TITLE
Make Platform.getDefaultProviderName public on Android.

### DIFF
--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -84,7 +84,8 @@ final class Platform {
      * Default name used in the {@link java.security.Security JCE system} by {@code OpenSSLProvider}
      * if the default constructor is used.
      */
-    static String getDefaultProviderName() {
+    // @VisibleForTesting - used by CTS
+    public static String getDefaultProviderName() {
         return "AndroidOpenSSL";
     }
 


### PR DESCRIPTION
Used in Android CTS.  Already tested in AOSP.