### PR TITLE
Update Provider installation in tests

### DIFF
--- a/common/src/test/java/org/conscrypt/CertPinManagerTest.java
+++ b/common/src/test/java/org/conscrypt/CertPinManagerTest.java
@@ -36,17 +36,21 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class CertPinManagerTest {
+    private static boolean installedProvider;
     private List<X509Certificate> expectedFullChain;
     private X509Certificate[] chain;
 
     @BeforeClass
     public static void installConscrypt() {
-        TestUtils.installConscryptAsDefaultProvider();
+        installedProvider = TestUtils.installConscryptIfNotPresent();
     }
 
     @AfterClass
     public static void removeConscrypt() {
-        Security.removeProvider(TestUtils.getConscryptProvider().getName());
+        if (installedProvider) {
+            Security.removeProvider(TestUtils.getConscryptProvider().getName());
+            installedProvider = false;
+        }
     }
 
     @Before

--- a/common/src/test/java/org/conscrypt/ct/CTVerifierTest.java
+++ b/common/src/test/java/org/conscrypt/ct/CTVerifierTest.java
@@ -34,6 +34,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class CTVerifierTest {
+    private static boolean installedProvider;
     private OpenSSLX509Certificate ca;
     private OpenSSLX509Certificate cert;
     private OpenSSLX509Certificate certEmbedded;
@@ -41,12 +42,15 @@ public class CTVerifierTest {
 
     @BeforeClass
     public static void installConscrypt() {
-        TestUtils.installConscryptAsDefaultProvider();
+        installedProvider = TestUtils.installConscryptIfNotPresent();
     }
 
     @AfterClass
     public static void removeConscrypt() {
-        Security.removeProvider(TestUtils.getConscryptProvider().getName());
+        if (installedProvider) {
+            Security.removeProvider(TestUtils.getConscryptProvider().getName());
+            installedProvider = false;
+        }
     }
 
     @Before

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -201,6 +201,15 @@ public final class TestUtils {
         }
     }
 
+    public static synchronized boolean installConscryptIfNotPresent() {
+        Provider conscryptProvider = getConscryptProvider();
+        if (Security.getProvider(conscryptProvider.getName()) == null) {
+            Security.insertProviderAt(conscryptProvider, 1);
+            return true;
+        }
+        return false;
+    }
+
     public static synchronized void installConscryptAsDefaultProvider() {
         final Provider conscryptProvider = getConscryptProvider();
         Provider[] providers = Security.getProviders();


### PR DESCRIPTION
Change CertPinManagerTest and CTVerifierTest to only install the
provider if it's not installed already and check if the provider was
installed before uninstalling.  Otherwise, when running on the Android
platform they will uninstall the platform copy of Conscrypt and break
every following test.