### PR TITLE
Retype return values

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
@@ -26,6 +26,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContextSpi;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 
@@ -78,8 +79,10 @@ public abstract class OpenSSLContextImpl extends SSLContextSpi {
                 serverSessionContext = new ServerSessionContext();
                 defaultSslContextImpl = (DefaultSSLContextImpl) this;
             } else {
-                clientSessionContext = defaultSslContextImpl.engineGetClientSessionContext();
-                serverSessionContext = defaultSslContextImpl.engineGetServerSessionContext();
+                clientSessionContext =
+                    (ClientSessionContext) defaultSslContextImpl.engineGetClientSessionContext();
+                serverSessionContext =
+                    (ServerSessionContext) defaultSslContextImpl.engineGetServerSessionContext();
             }
             sslParameters = new SSLParametersImpl(defaultSslContextImpl.getKeyManagers(),
                     defaultSslContextImpl.getTrustManagers(), null, clientSessionContext,
@@ -141,12 +144,12 @@ public abstract class OpenSSLContextImpl extends SSLContextSpi {
     }
 
     @Override
-    public ServerSessionContext engineGetServerSessionContext() {
+    public SSLSessionContext engineGetServerSessionContext() {
         return serverSessionContext;
     }
 
     @Override
-    public ClientSessionContext engineGetClientSessionContext() {
+    public SSLSessionContext engineGetClientSessionContext() {
         return clientSessionContext;
     }
 


### PR DESCRIPTION
The return values for
OpenSSLContextImpl.engineGetClientSessionContext() and
.engineGetServerSessionContext() were covariant to make the no-arg
constructor a little easier to write, but it is causing
ClientSessionContext and ServerSessionContext to leak into Android
stubs in a weird way.  Since we don't rely on that typing anywhere
else, we can just put a cast into the constructor instead.