### PR TITLE
Remove @hide annotations

### DIFF
--- a/api-doclet/src/main/java/org/conscrypt/doclet/FilterDoclet.java
+++ b/api-doclet/src/main/java/org/conscrypt/doclet/FilterDoclet.java
@@ -33,8 +33,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This Doclet filters out all classes, methods, fields, etc. that have the {@code @hide} annotation
- * on them.
+ * This Doclet filters out all classes, methods, fields, etc. that have the {@code @Internal}
+ * annotation on them.
  */
 public class FilterDoclet extends com.sun.tools.doclets.standard.Standard {
     public static void main(String[] args) throws FileNotFoundException {
@@ -47,11 +47,15 @@ public class FilterDoclet extends com.sun.tools.doclets.standard.Standard {
     }
 
     /**
-     * Returns true if the given element has an @hide annotation.
+     * Returns true if the given element has an @Internal annotation.
      */
-    private static boolean hasHideAnnotation(Doc doc) {
-        String comment = doc.getRawCommentText();
-        return comment.contains("@hide");
+    private static boolean hasHideAnnotation(ProgramElementDoc doc) {
+        for (AnnotationDesc ann : doc.annotations()) {
+            if (ann.annotationType().qualifiedTypeName().equals("org.conscrypt.Internal")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -60,18 +64,13 @@ public class FilterDoclet extends com.sun.tools.doclets.standard.Standard {
     private static boolean isHidden(Doc doc) {
         // Methods, fields, constructors.
         if (doc instanceof MemberDoc) {
-            return hasHideAnnotation(doc);
+            return hasHideAnnotation((MemberDoc) doc);
         }
         // Classes, interfaces, enums, annotation types.
         if (doc instanceof ClassDoc) {
-            ClassDoc classDoc = (ClassDoc) doc;
-            // Check the containing package.
-            if (hasHideAnnotation(classDoc.containingPackage())) {
-                return true;
-            }
             // Check the class doc and containing class docs if this is a
             // nested class.
-            ClassDoc current = classDoc;
+            ClassDoc current = (ClassDoc) doc;
             do {
                 if (hasHideAnnotation(current)) {
                     return true;

--- a/common/src/main/java/org/conscrypt/CertPinManager.java
+++ b/common/src/main/java/org/conscrypt/CertPinManager.java
@@ -22,8 +22,6 @@ import java.util.List;
 
 /**
  * Interface for classes that implement certificate pinning for use in {@link TrustManagerImpl}.
- *
- * @hide
  */
 @Internal
 public interface CertPinManager {

--- a/common/src/main/java/org/conscrypt/ChainStrengthAnalyzer.java
+++ b/common/src/main/java/org/conscrypt/ChainStrengthAnalyzer.java
@@ -25,8 +25,6 @@ import java.util.List;
 
 /**
  * Analyzes the cryptographic strength of a chain of X.509 certificates.
- *
- * @hide
  */
 @Internal
 public final class ChainStrengthAnalyzer {

--- a/common/src/main/java/org/conscrypt/ClientSessionContext.java
+++ b/common/src/main/java/org/conscrypt/ClientSessionContext.java
@@ -25,8 +25,6 @@ import javax.net.ssl.SSLContext;
 /**
  * Caches client sessions. Indexes by host and port. Users are typically
  * looking to reuse any session for a given host and port.
- *
- * @hide
  */
 @Internal
 public final class ClientSessionContext extends AbstractSessionContext {

--- a/common/src/main/java/org/conscrypt/DESEDESecretKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/DESEDESecretKeyFactory.java
@@ -27,8 +27,6 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * An implementation of {@link javax.crypto.SecretKeyFactory} for use with DESEDE keys.  This
  * class supports {@link SecretKeySpec} and {@link DESedeKeySpec} for key specs.
- *
- * @hide
  */
 @Internal
 public class DESEDESecretKeyFactory extends SecretKeyFactorySpi {

--- a/common/src/main/java/org/conscrypt/DefaultSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/DefaultSSLContextImpl.java
@@ -32,8 +32,6 @@ import javax.net.ssl.TrustManagerFactory;
 
 /**
  * Support class for this package.
- *
- * @hide
  */
 @Internal
 public final class DefaultSSLContextImpl extends OpenSSLContextImpl {

--- a/common/src/main/java/org/conscrypt/ECParameters.java
+++ b/common/src/main/java/org/conscrypt/ECParameters.java
@@ -27,8 +27,6 @@ import java.security.spec.InvalidParameterSpecException;
 /**
  * AlgorithmParameters implementation for elliptic curves.  The only supported encoding format is
  * ASN.1, as specified in RFC 3279, section 2.3.5.  However, only named curves are supported.
- *
- * @hide
  */
 @Internal
 public class ECParameters extends AlgorithmParametersSpi {

--- a/common/src/main/java/org/conscrypt/FileClientSessionCache.java
+++ b/common/src/main/java/org/conscrypt/FileClientSessionCache.java
@@ -36,8 +36,6 @@ import javax.net.ssl.SSLSession;
 /**
  * File-based cache implementation. Only one process should access the
  * underlying directory at a time.
- *
- * @hide
  */
 @Internal
 public final class FileClientSessionCache {

--- a/common/src/main/java/org/conscrypt/GCMParameters.java
+++ b/common/src/main/java/org/conscrypt/GCMParameters.java
@@ -28,8 +28,6 @@ import java.security.spec.InvalidParameterSpecException;
  * implementation of the GCM AlgorithmParameters implementation.
  * <p>
  * The only supported encoding format is ASN.1, as specified in RFC 5084 section 3.2.
- *
- * @hide
  */
 @Internal
 public final class GCMParameters extends AlgorithmParametersSpi {

--- a/common/src/main/java/org/conscrypt/IvParameters.java
+++ b/common/src/main/java/org/conscrypt/IvParameters.java
@@ -25,8 +25,6 @@ import javax.crypto.spec.IvParameterSpec;
 /**
  * An implementation of {@link java.security.AlgorithmParameters} that contains only an IV.  The
  * supported encoding formats are ASN.1 (primary) and RAW.
- *
- * @hide
  */
 @Internal
 public class IvParameters extends AlgorithmParametersSpi {

--- a/common/src/main/java/org/conscrypt/KeyGeneratorImpl.java
+++ b/common/src/main/java/org/conscrypt/KeyGeneratorImpl.java
@@ -27,8 +27,6 @@ import javax.crypto.spec.SecretKeySpec;
 /**
  * An implementation of {@link javax.crypto.KeyGenerator} suitable for use with other Conscrypt
  * algorithms.
- *
- * @hide
  */
 @Internal
 public abstract class KeyGeneratorImpl extends KeyGeneratorSpi {

--- a/common/src/main/java/org/conscrypt/KeyManagerFactoryImpl.java
+++ b/common/src/main/java/org/conscrypt/KeyManagerFactoryImpl.java
@@ -33,7 +33,6 @@ import javax.net.ssl.ManagerFactoryParameters;
 /**
  * KeyManagerFactory implementation.
  * @see KeyManagerFactorySpi
- * @hide
  */
 @Internal
 public class KeyManagerFactoryImpl extends KeyManagerFactorySpi {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -52,8 +52,6 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
  * from becoming eligible for GC while the native method is executing.  See
  * <a href="https://github.com/google/error-prone/blob/master/docs/bugpattern/UnsafeFinalization.md">this</a>
  * for more details.
- *
- * @hide
  */
 @Internal
 public final class NativeCrypto {

--- a/common/src/main/java/org/conscrypt/OAEPParameters.java
+++ b/common/src/main/java/org/conscrypt/OAEPParameters.java
@@ -29,8 +29,6 @@ import javax.crypto.spec.PSource;
 /**
  * AlgorithmParameters implementation for OAEP.  The only supported encoding format is ASN.1,
  * as specified in RFC 4055 section 4.1.
- *
- * @hide
  */
 @Internal
 public class OAEPParameters extends AlgorithmParametersSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipher.java
@@ -46,8 +46,6 @@ import org.conscrypt.NativeRef.EVP_CIPHER_CTX;
 
 /**
  * An implementation of {@link Cipher} using BoringSSL as the backing library.
- *
- * @hide
  */
 @Internal
 public abstract class OpenSSLCipher extends CipherSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherChaCha20.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherChaCha20.java
@@ -29,8 +29,6 @@ import javax.crypto.spec.IvParameterSpec;
 
 /**
  * Implementation of the ChaCha20 stream cipher.
- *
- * @hide
  */
 @Internal
 public class OpenSSLCipherChaCha20 extends OpenSSLCipher {

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -48,9 +48,6 @@ import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
 
-/**
- * @hide
- */
 @Internal
 abstract class OpenSSLCipherRSA extends CipherSpi {
     /**

--- a/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
@@ -34,8 +34,6 @@ import javax.net.ssl.TrustManager;
  * OpenSSL-backed SSLContext service provider interface.
  *
  * <p>Public to allow contruction via the provider framework.
- *
- * @hide
  */
 @Internal
 public abstract class OpenSSLContextImpl extends SSLContextSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLECDHKeyAgreement.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECDHKeyAgreement.java
@@ -30,8 +30,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 /**
  * Elliptic Curve Diffie-Hellman key agreement backed by the OpenSSL engine.
- *
- * @hide
  */
 @Internal
 public final class OpenSSLECDHKeyAgreement extends KeyAgreementSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
@@ -35,8 +35,6 @@ import java.security.spec.X509EncodedKeySpec;
 
 /**
  * An implementation of a {@link KeyFactorySpi} for EC keys based on BoringSSL.
- *
- * @hide
  */
 @Internal
 public final class OpenSSLECKeyFactory extends KeyFactorySpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLECKeyPairGenerator.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECKeyPairGenerator.java
@@ -32,8 +32,6 @@ import java.util.Map;
 /**
  * An implementation of {@link KeyPairGenerator} for EC keys which uses BoringSSL to perform all the
  * operations.
- *
- * @hide
  */
 @Internal
 public final class OpenSSLECKeyPairGenerator extends KeyPairGenerator {

--- a/common/src/main/java/org/conscrypt/OpenSSLKeyHolder.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLKeyHolder.java
@@ -18,8 +18,6 @@ package org.conscrypt;
 
 /**
  * Marker interface for classes that hold an {@link OpenSSLKey}.
- *
- * @hide
  */
 @Internal
 public interface OpenSSLKeyHolder {

--- a/common/src/main/java/org/conscrypt/OpenSSLMac.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLMac.java
@@ -27,8 +27,6 @@ import javax.crypto.SecretKey;
 
 /**
  * An implementation of {@link javax.crypto.Mac} which uses BoringSSL to perform all the operations.
- *
- * @hide
  */
 @Internal
 public abstract class OpenSSLMac extends MacSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLMessageDigestJDK.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLMessageDigestJDK.java
@@ -22,8 +22,6 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * Implements the JDK MessageDigest interface using OpenSSL's EVP API.
- *
- * @hide
  */
 @Internal
 public class OpenSSLMessageDigestJDK extends MessageDigestSpi implements Cloneable {

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -29,8 +29,6 @@ import java.security.Provider;
  * href="http://csrc.nist.gov/groups/ST/crypto_apps_infra/csor/algorithms.html">NIST cryptographic
  * algorithms</a></li>
  * </ul>
- *
- * @hide
  */
 @Internal
 public final class OpenSSLProvider extends Provider {

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
@@ -36,8 +36,6 @@ import java.security.spec.X509EncodedKeySpec;
 /**
  * An implementation of {@link java.security.KeyFactory} which uses BoringSSL to perform all the
  * operations.
- *
- * @hide
  */
 @Internal
 public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAKeyPairGenerator.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAKeyPairGenerator.java
@@ -29,8 +29,6 @@ import java.security.spec.RSAKeyGenParameterSpec;
 /**
  * An implementation of {@link java.security.KeyPairGenerator} which uses BoringSSL to perform all
  * the operations.
- *
- * @hide
  */
 @Internal
 public final class OpenSSLRSAKeyPairGenerator extends KeyPairGeneratorSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateKey.java
@@ -31,8 +31,6 @@ import java.security.spec.RSAPrivateKeySpec;
 /**
  * An implementation of {@link java.security.PrivateKey} for RSA keys which uses BoringSSL to
  * perform all the operations.
- *
- * @hide
  */
 class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
     private static final long serialVersionUID = 4872170254439578735L;

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPublicKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPublicKey.java
@@ -28,8 +28,6 @@ import java.security.spec.RSAPublicKeySpec;
 /**
  * An implementation of {@link java.security.PublicKey} for RSA keys which uses BoringSSL to
  * perform all the operations.
- *
- * @hide
  */
 @Internal
 public class OpenSSLRSAPublicKey implements RSAPublicKey, OpenSSLKeyHolder {

--- a/common/src/main/java/org/conscrypt/OpenSSLRandom.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRandom.java
@@ -21,8 +21,6 @@ import java.security.SecureRandomSpi;
 
 /**
  * Implements {@link java.security.SecureRandom} using BoringSSL's RAND interface.
- *
- * @hide
  */
 @Internal
 public final class OpenSSLRandom extends SecureRandomSpi implements Serializable {

--- a/common/src/main/java/org/conscrypt/OpenSSLSignature.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignature.java
@@ -35,8 +35,6 @@ import java.security.spec.PSSParameterSpec;
 /**
  * Implements the subset of the JDK Signature interface needed for
  * signature verification using OpenSSL.
- *
- * @hide
  */
 @Internal
 public class OpenSSLSignature extends SignatureSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLSignatureRawECDSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignatureRawECDSA.java
@@ -26,8 +26,6 @@ import java.security.SignatureSpi;
 /**
  * Implements the JDK Signature interface needed for RAW ECDSA signature
  * generation and verification using BoringSSL.
- *
- * @hide
  */
 @Internal
 public class OpenSSLSignatureRawECDSA extends SignatureSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLSignatureRawRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignatureRawRSA.java
@@ -29,8 +29,6 @@ import java.security.interfaces.RSAPublicKey;
 /**
  * Implements the JDK Signature interface needed for RAW RSA signature
  * generation and verification using BoringSSL.
- *
- * @hide
  */
 @Internal
 public final class OpenSSLSignatureRawRSA extends SignatureSpi {

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -28,8 +28,6 @@ import javax.net.ssl.SSLSession;
 /**
  * Public shim allowing us to stay backward-compatible with legacy applications which were using
  * Conscrypt's extended socket API before the introduction of the {@link Conscrypt} class.
- *
- * @hide
  */
 @Internal
 public abstract class OpenSSLSocketImpl extends AbstractConscryptSocket {

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -53,8 +53,6 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
 /**
  * An implementation of {@link X509Certificate} based on BoringSSL.
- *
- * @hide
  */
 @Internal
 public final class OpenSSLX509Certificate extends X509Certificate {

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
@@ -35,8 +35,6 @@ import java.util.List;
 
 /**
  * An implementation of {@link java.security.cert.CertificateFactory} based on BoringSSL.
- *
- * @hide
  */
 @Internal
 public class OpenSSLX509CertificateFactory extends CertificateFactorySpi {

--- a/common/src/main/java/org/conscrypt/PSKKeyManager.java
+++ b/common/src/main/java/org/conscrypt/PSKKeyManager.java
@@ -95,7 +95,6 @@ import javax.net.ssl.SSLEngine;
  * }</pre>
  *
  * @deprecated This abstraction is deprecated because it does not work with TLS 1.3.
- * @hide
  */
 @Deprecated
 @Internal

--- a/common/src/main/java/org/conscrypt/PSSParameters.java
+++ b/common/src/main/java/org/conscrypt/PSSParameters.java
@@ -26,8 +26,6 @@ import java.security.spec.PSSParameterSpec;
 /**
  * AlgorithmParameters implementation for PSS.  The only supported encoding format is ASN.1
  * (with X.509 accepted as an alias), as specified in RFC 4055 section 3.1.
- *
- * @hide
  */
 @Internal
 public class PSSParameters extends AlgorithmParametersSpi {

--- a/common/src/main/java/org/conscrypt/SSLClientSessionCache.java
+++ b/common/src/main/java/org/conscrypt/SSLClientSessionCache.java
@@ -28,8 +28,6 @@ import javax.net.ssl.SSLSession;
  * {@code SSLSession}s into raw bytes and vice versa. The exact makeup of the
  * session data is dependent upon the caller's implementation and is opaque to
  * the {@code SSLClientSessionCache} implementation.
- *
- * @hide
  */
 @Internal
 public interface SSLClientSessionCache {

--- a/common/src/main/java/org/conscrypt/ServerSessionContext.java
+++ b/common/src/main/java/org/conscrypt/ServerSessionContext.java
@@ -21,8 +21,6 @@ import javax.net.ssl.SSLContext;
 /**
  * Caches server sessions. Indexes by session ID. Users typically look up
  * sessions using the ID provided by an SSL client.
- *
- * @hide
  */
 @Internal
 public final class ServerSessionContext extends AbstractSessionContext {

--- a/common/src/main/java/org/conscrypt/TrustManagerFactoryImpl.java
+++ b/common/src/main/java/org/conscrypt/TrustManagerFactoryImpl.java
@@ -46,7 +46,6 @@ import javax.net.ssl.TrustManagerFactorySpi;
  * TrustManagerFactory service provider interface implementation.
  *
  * @see javax.net.ssl.TrustManagerFactorySpi
- * @hide
  */
 @Internal
 public class TrustManagerFactoryImpl extends TrustManagerFactorySpi {

--- a/common/src/main/java/org/conscrypt/TrustManagerImpl.java
+++ b/common/src/main/java/org/conscrypt/TrustManagerImpl.java
@@ -82,7 +82,6 @@ import org.conscrypt.ct.CTVerifier;
  * be provided by some certification provider.
  *
  * @see javax.net.ssl.X509ExtendedTrustManager
- * @hide
  */
 @Internal
 public final class TrustManagerImpl extends X509ExtendedTrustManager {

--- a/common/src/main/java/org/conscrypt/TrustedCertificateIndex.java
+++ b/common/src/main/java/org/conscrypt/TrustedCertificateIndex.java
@@ -33,8 +33,6 @@ import javax.security.auth.x500.X500Principal;
 /**
  * Indexes {@code TrustAnchor} instances so they can be found in O(1)
  * time instead of O(N).
- *
- * @hide
  */
 @Internal
 public final class TrustedCertificateIndex {

--- a/common/src/main/java/org/conscrypt/ct/CTConstants.java
+++ b/common/src/main/java/org/conscrypt/ct/CTConstants.java
@@ -18,9 +18,6 @@ package org.conscrypt.ct;
 
 import org.conscrypt.Internal;
 
-/**
- * @hide
- */
 @Internal
 public class CTConstants {
     public static final String X509_SCT_LIST_OID = "1.3.6.1.4.1.11129.2.4.2";

--- a/common/src/main/java/org/conscrypt/ct/CTLogInfo.java
+++ b/common/src/main/java/org/conscrypt/ct/CTLogInfo.java
@@ -29,8 +29,6 @@ import org.conscrypt.Internal;
  * Properties about a Certificate Transparency Log.
  * This object stores information about a CT log, its public key, description and URL.
  * It allows verification of SCTs against the log's public key.
- *
- * @hide
  */
 @Internal
 public class CTLogInfo {

--- a/common/src/main/java/org/conscrypt/ct/CTLogStore.java
+++ b/common/src/main/java/org/conscrypt/ct/CTLogStore.java
@@ -18,9 +18,6 @@ package org.conscrypt.ct;
 
 import org.conscrypt.Internal;
 
-/**
- * @hide
- */
 @Internal
 public interface CTLogStore {
     CTLogInfo getKnownLog(byte[] logId);

--- a/common/src/main/java/org/conscrypt/ct/CTVerificationResult.java
+++ b/common/src/main/java/org/conscrypt/ct/CTVerificationResult.java
@@ -21,9 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import org.conscrypt.Internal;
 
-/**
- * @hide
- */
 @Internal
 public class CTVerificationResult {
     private final ArrayList<VerifiedSCT> validSCTs = new ArrayList<VerifiedSCT>();

--- a/common/src/main/java/org/conscrypt/ct/CTVerifier.java
+++ b/common/src/main/java/org/conscrypt/ct/CTVerifier.java
@@ -26,9 +26,6 @@ import org.conscrypt.Internal;
 import org.conscrypt.NativeCrypto;
 import org.conscrypt.OpenSSLX509Certificate;
 
-/**
- * @hide
- */
 @Internal
 public class CTVerifier {
     private final CTLogStore store;

--- a/common/src/main/java/org/conscrypt/ct/CertificateEntry.java
+++ b/common/src/main/java/org/conscrypt/ct/CertificateEntry.java
@@ -38,8 +38,6 @@ import org.conscrypt.OpenSSLX509Certificate;
  *         case precert_entry: PreCert;
  *     } signed_entry;
  * } CertificateEntry;
- *
- * @hide
  */
 @Internal
 public class CertificateEntry {

--- a/common/src/main/java/org/conscrypt/ct/DigitallySigned.java
+++ b/common/src/main/java/org/conscrypt/ct/DigitallySigned.java
@@ -22,8 +22,6 @@ import org.conscrypt.Internal;
 
 /**
  * DigitallySigned structure, as defined by RFC5246 Section 4.7.
- *
- * @hide
  */
 @Internal
 public class DigitallySigned {

--- a/common/src/main/java/org/conscrypt/ct/Serialization.java
+++ b/common/src/main/java/org/conscrypt/ct/Serialization.java
@@ -23,9 +23,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import org.conscrypt.Internal;
 
-/**
- * @hide
- */
 @Internal
 public class Serialization {
     private Serialization() {}

--- a/common/src/main/java/org/conscrypt/ct/SerializationException.java
+++ b/common/src/main/java/org/conscrypt/ct/SerializationException.java
@@ -18,9 +18,6 @@ package org.conscrypt.ct;
 
 import org.conscrypt.Internal;
 
-/**
- * @hide
- */
 @Internal
 public class SerializationException extends Exception {
     public SerializationException() {

--- a/common/src/main/java/org/conscrypt/ct/SignedCertificateTimestamp.java
+++ b/common/src/main/java/org/conscrypt/ct/SignedCertificateTimestamp.java
@@ -24,8 +24,6 @@ import org.conscrypt.Internal;
 
 /**
  * SignedCertificateTimestamp structure, as defined by RFC6962 Section 3.2.
- *
- * @hide
  */
 @Internal
 public class SignedCertificateTimestamp {

--- a/common/src/main/java/org/conscrypt/ct/VerifiedSCT.java
+++ b/common/src/main/java/org/conscrypt/ct/VerifiedSCT.java
@@ -20,8 +20,6 @@ import org.conscrypt.Internal;
 
 /**
  * Verification result for a single SCT.
- *
- * @hide
  */
 @Internal
 public final class VerifiedSCT {

--- a/common/src/main/java/org/conscrypt/io/IoUtils.java
+++ b/common/src/main/java/org/conscrypt/io/IoUtils.java
@@ -19,7 +19,9 @@ package org.conscrypt.io;
 import java.io.Closeable;
 import java.io.InterruptedIOException;
 import java.net.Socket;
+import org.conscrypt.Internal;
 
+@Internal
 public final class IoUtils {
     private IoUtils() {}
 

--- a/libcore-stub/build.gradle
+++ b/libcore-stub/build.gradle
@@ -5,7 +5,7 @@ configurations {
 }
 
 dependencies {
-    // This is used for the @hide annotation processing in JavaDoc
+    // This is used for the @Internal annotation processing in JavaDoc
     publicApiDocs project(':conscrypt-api-doclet')
 
     // Only compile against this. Other modules will embed the generated code directly.

--- a/libcore-stub/src/main/java/android/system/StructTimeval.java
+++ b/libcore-stub/src/main/java/android/system/StructTimeval.java
@@ -21,8 +21,6 @@ import libcore.util.Objects;
 /**
  * Corresponds to C's {@code struct timeval} from
  * <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_time.h.html">&lt;sys/time.h&gt;</a>
- *
- * @hide
  */
 public final class StructTimeval {
     /** Seconds. */

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -161,7 +161,7 @@ jar.manifest {
 }
 
 dependencies {
-    // This is used for the @hide annotation processing in JavaDoc
+    // This is used for the @Internal annotation processing in JavaDoc
     publicApiDocs project(':conscrypt-api-doclet')
 
     compileOnly project(':conscrypt-constants'),

--- a/openjdk/src/main/java/org/conscrypt/HostProperties.java
+++ b/openjdk/src/main/java/org/conscrypt/HostProperties.java
@@ -40,7 +40,8 @@ import java.util.logging.Logger;
 /**
  * Utilities for interacting with properties of the host being run on.
  */
-public class HostProperties {
+@Internal
+class HostProperties {
     private static final Logger logger = Logger.getLogger(HostProperties.class.getName());
 
     private static final String TEMP_DIR_PROPERTY_NAME = "org.conscrypt.tmpdir";

--- a/platform/src/main/java/org/conscrypt/CertBlacklistImpl.java
+++ b/platform/src/main/java/org/conscrypt/CertBlacklistImpl.java
@@ -34,9 +34,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * @hide
- */
 @Internal
 public final class CertBlacklistImpl implements CertBlacklist {
     private static final Logger logger = Logger.getLogger(CertBlacklistImpl.class.getName());

--- a/platform/src/main/java/org/conscrypt/Hex.java
+++ b/platform/src/main/java/org/conscrypt/Hex.java
@@ -17,10 +17,7 @@
 package org.conscrypt;
 
 /**
- *
  * Helper class for dealing with hexadecimal strings.
- *
- * @hide
  */
 @Internal
 // public for testing by TrustedCertificateStoreTest

--- a/platform/src/main/java/org/conscrypt/InternalUtil.java
+++ b/platform/src/main/java/org/conscrypt/InternalUtil.java
@@ -25,8 +25,6 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 /**
  * Helper to initialize the JNI libraries. This version runs when compiled
  * as part of the platform.
- *
- * @hide
  */
 @Internal
 public final class InternalUtil {

--- a/platform/src/main/java/org/conscrypt/JSSEProvider.java
+++ b/platform/src/main/java/org/conscrypt/JSSEProvider.java
@@ -35,8 +35,6 @@ import java.security.Provider;
  * Trust manager implementation requires:
  *     CertPathValidator    PKIX
  *     CertificateFactory    X509
- *
- * @hide
  */
 @Internal
 public final class JSSEProvider extends Provider {

--- a/platform/src/main/java/org/conscrypt/TrustedCertificateKeyStoreSpi.java
+++ b/platform/src/main/java/org/conscrypt/TrustedCertificateKeyStoreSpi.java
@@ -27,8 +27,6 @@ import java.util.Enumeration;
 
 /**
  * A KeyStoreSpi wrapper for the TrustedCertificateStore.
- *
- * @hide
  */
 @Internal
 public final class TrustedCertificateKeyStoreSpi extends KeyStoreSpi {

--- a/platform/src/main/java/org/conscrypt/TrustedCertificateStore.java
+++ b/platform/src/main/java/org/conscrypt/TrustedCertificateStore.java
@@ -79,8 +79,6 @@ import org.conscrypt.io.IoUtils;
  * ensures that its owner and group are the system uid and system
  * gid and that it is world readable but only writable by the system
  * user.
- *
- * @hide
  */
 @Internal
 public class TrustedCertificateStore implements ConscryptCertStore {

--- a/platform/src/main/java/org/conscrypt/ct/CTLogStoreImpl.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTLogStoreImpl.java
@@ -35,9 +35,6 @@ import java.util.Set;
 import org.conscrypt.Internal;
 import org.conscrypt.InternalUtil;
 
-/**
- * @hide
- */
 @Internal
 public class CTLogStoreImpl implements CTLogStore {
     private static final Charset US_ASCII = Charset.forName("US-ASCII");

--- a/platform/src/main/java/org/conscrypt/ct/CTPolicyImpl.java
+++ b/platform/src/main/java/org/conscrypt/ct/CTPolicyImpl.java
@@ -21,9 +21,6 @@ import java.util.HashSet;
 import java.util.Set;
 import org.conscrypt.Internal;
 
-/**
- * @hide
- */
 @Internal
 public class CTPolicyImpl implements CTPolicy {
     private final CTLogStore logStore;

--- a/platform/src/main/java/org/conscrypt/ct/KnownLogs.java
+++ b/platform/src/main/java/org/conscrypt/ct/KnownLogs.java
@@ -21,9 +21,6 @@ package org.conscrypt.ct;
 
 import org.conscrypt.Internal;
 
-/**
- * @hide
- */
 @Internal
 public final class KnownLogs {
     public static final int LOG_COUNT = 8;


### PR DESCRIPTION
We no longer need to have these annotations for Android use, since the
repackaging tools add them automatically.

Switch the Javadoc doclet to check for @Internal instead.