### PR TITLE
Add Conscrypt-specific hostname verifier

### DIFF
--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -22,6 +22,8 @@ import java.security.KeyManagementException;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.util.Properties;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLContextSpi;
 import javax.net.ssl.SSLEngine;
@@ -31,6 +33,7 @@ import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 /**
@@ -705,4 +708,59 @@ public final class Conscrypt {
             int length) throws SSLException {
         return toConscrypt(engine).exportKeyingMaterial(label, context, length);
     }
+
+    /**
+     * Indicates whether the given {@link TrustManager} was created by this distribution of
+     * Conscrypt.
+     */
+    public static boolean isConscrypt(TrustManager trustManager) {
+        return trustManager instanceof TrustManagerImpl;
+    }
+
+    private static TrustManagerImpl toConscrypt(TrustManager trustManager) {
+        if (!isConscrypt(trustManager)) {
+            throw new IllegalArgumentException(
+                "Not a conscrypt trust manager: " + trustManager.getClass().getName());
+        }
+        return (TrustManagerImpl) trustManager;
+    }
+
+    /**
+     * Set the default hostname verifier that will be used for HTTPS endpoint identification by
+     * Conscrypt trust managers.  If {@code null} (the default), endpoint identification will use
+     * the default hostname verifier set in
+     * {@link HttpsURLConnection#setDefaultHostnameVerifier(HostnameVerifier)}.
+     */
+    public synchronized static void setDefaultHostnameVerifier(HostnameVerifier verifier) {
+        TrustManagerImpl.setDefaultHostnameVerifier(verifier);
+    }
+
+    /**
+     * Returns the currently-set default hostname verifier for Conscrypt trust managers.
+     *
+     * @see #setDefaultHostnameVerifier(HostnameVerifier)
+     */
+    public synchronized static HostnameVerifier getDefaultHostnameVerifier(TrustManager trustManager) {
+        return TrustManagerImpl.getDefaultHostnameVerifier();
+    }
+
+    /**
+     * Set the hostname verifier that will be used for HTTPS endpoint identification by the
+     * given trust manager.  If {@code null} (the default), endpoint identification will use the
+     * default hostname verifier set in {@link #setDefaultHostnameVerifier(HostnameVerifier)}.
+     */
+    public static void setHostnameVerifier(TrustManager trustManager, HostnameVerifier verifier) {
+        toConscrypt(trustManager).setHostnameVerifier(verifier);
+    }
+
+    /**
+     * Returns the currently-set hostname verifier for the given trust manager.
+     *
+     * @see #setHostnameVerifier(TrustManager, HostnameVerifier)
+     */
+    public static HostnameVerifier getHostnameVerifier(TrustManager trustManager) {
+        return toConscrypt(trustManager).getHostnameVerifier();
+    }
+
+
 }

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -719,7 +719,7 @@ public final class Conscrypt {
     private static TrustManagerImpl toConscrypt(TrustManager trustManager) {
         if (!isConscrypt(trustManager)) {
             throw new IllegalArgumentException(
-                "Not a conscrypt trust manager: " + trustManager.getClass().getName());
+                "Not a Conscrypt trust manager: " + trustManager.getClass().getName());
         }
         return (TrustManagerImpl) trustManager;
     }
@@ -728,30 +728,30 @@ public final class Conscrypt {
      * Set the default hostname verifier that will be used for HTTPS endpoint identification by
      * Conscrypt trust managers.  If {@code null} (the default), endpoint identification will use
      * the default hostname verifier set in
-     * {@link HttpsURLConnection#setDefaultHostnameVerifier(HostnameVerifier)}.
+     * {@link HttpsURLConnection#setDefaultHostnameVerifier(javax.net.ssl.HostnameVerifier)}.
      */
-    public synchronized static void setDefaultHostnameVerifier(HostnameVerifier verifier) {
+    public synchronized static void setDefaultHostnameVerifier(ConscryptHostnameVerifier verifier) {
         TrustManagerImpl.setDefaultHostnameVerifier(verifier);
     }
 
     /**
      * Returns the currently-set default hostname verifier for Conscrypt trust managers.
      *
-     * @see #setDefaultHostnameVerifier(HostnameVerifier)
+     * @see #setDefaultHostnameVerifier(ConscryptHostnameVerifier)
      */
-    public synchronized static HostnameVerifier getDefaultHostnameVerifier(TrustManager trustManager) {
+    public synchronized static ConscryptHostnameVerifier getDefaultHostnameVerifier(TrustManager trustManager) {
         return TrustManagerImpl.getDefaultHostnameVerifier();
     }
 
     /**
      * Set the hostname verifier that will be used for HTTPS endpoint identification by the
      * given trust manager.  If {@code null} (the default), endpoint identification will use the
-     * default hostname verifier set in {@link #setDefaultHostnameVerifier(HostnameVerifier)}.
+     * default hostname verifier set in {@link #setDefaultHostnameVerifier(ConscryptHostnameVerifier)}.
      *
      * @throws IllegalArgumentException if the provided trust manager is not a Conscrypt trust
      * manager per {@link #isConscrypt(TrustManager)}
      */
-    public static void setHostnameVerifier(TrustManager trustManager, HostnameVerifier verifier) {
+    public static void setHostnameVerifier(TrustManager trustManager, ConscryptHostnameVerifier verifier) {
         toConscrypt(trustManager).setHostnameVerifier(verifier);
     }
 
@@ -761,9 +761,9 @@ public final class Conscrypt {
      * @throws IllegalArgumentException if the provided trust manager is not a Conscrypt trust
      * manager per {@link #isConscrypt(TrustManager)}
      *
-     * @see #setHostnameVerifier(TrustManager, HostnameVerifier)
+     * @see #setHostnameVerifier(TrustManager, ConscryptHostnameVerifier)
      */
-    public static HostnameVerifier getHostnameVerifier(TrustManager trustManager) {
+    public static ConscryptHostnameVerifier getHostnameVerifier(TrustManager trustManager) {
         return toConscrypt(trustManager).getHostnameVerifier();
     }
 

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -748,6 +748,9 @@ public final class Conscrypt {
      * Set the hostname verifier that will be used for HTTPS endpoint identification by the
      * given trust manager.  If {@code null} (the default), endpoint identification will use the
      * default hostname verifier set in {@link #setDefaultHostnameVerifier(HostnameVerifier)}.
+     *
+     * @throws IllegalArgumentException if the provided trust manager is not a Conscrypt trust
+     * manager per {@link #isConscrypt(TrustManager)}
      */
     public static void setHostnameVerifier(TrustManager trustManager, HostnameVerifier verifier) {
         toConscrypt(trustManager).setHostnameVerifier(verifier);
@@ -755,6 +758,9 @@ public final class Conscrypt {
 
     /**
      * Returns the currently-set hostname verifier for the given trust manager.
+     *
+     * @throws IllegalArgumentException if the provided trust manager is not a Conscrypt trust
+     * manager per {@link #isConscrypt(TrustManager)}
      *
      * @see #setHostnameVerifier(TrustManager, HostnameVerifier)
      */

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -22,7 +22,6 @@ import java.security.KeyManagementException;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.util.Properties;
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLContextSpi;

--- a/common/src/main/java/org/conscrypt/ConscryptHostnameVerifier.java
+++ b/common/src/main/java/org/conscrypt/ConscryptHostnameVerifier.java
@@ -7,7 +7,7 @@ import javax.net.ssl.SSLSession;
  * {@link javax.net.ssl.HostnameVerifier}, the hostname verifier is called whenever hostname
  * verification is needed, without any use of default rules.
  */
-public interface HostnameVerifier {
+public interface ConscryptHostnameVerifier {
 
   /**
    * Returns whether the given hostname is allowable given the peer's authentication information

--- a/common/src/main/java/org/conscrypt/HostnameVerifier.java
+++ b/common/src/main/java/org/conscrypt/HostnameVerifier.java
@@ -1,0 +1,18 @@
+package org.conscrypt;
+
+import javax.net.ssl.SSLSession;
+
+/**
+ * This interface is used to implement hostname verification in Conscrypt.  Unlike with
+ * {@link javax.net.ssl.HostnameVerifier}, the hostname verifier is called whenever hostname
+ * verification is needed, without any use of default rules.
+ */
+public interface HostnameVerifier {
+
+  /**
+   * Returns whether the given hostname is allowable given the peer's authentication information
+   * from the given session.
+   */
+  boolean verify(String hostname, SSLSession session);
+
+}

--- a/common/src/main/java/org/conscrypt/TrustManagerImpl.java
+++ b/common/src/main/java/org/conscrypt/TrustManagerImpl.java
@@ -63,7 +63,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
@@ -969,7 +968,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
     /**
      * Set the default hostname verifier that will be used for HTTPS endpoint identification.  If
      * {@code null} (the default), endpoint identification will use the default hostname verifier
-     * set in {@link HttpsURLConnection#setDefaultHostnameVerifier(HostnameVerifier)}.
+     * set in {@link HttpsURLConnection#setDefaultHostnameVerifier(javax.net.ssl.HostnameVerifier)}.
      */
     synchronized static void setDefaultHostnameVerifier(HostnameVerifier verifier) {
         defaultHostnameVerifier = verifier;
@@ -1010,7 +1009,13 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
         if (defaultVerifier != null) {
             return defaultVerifier;
         }
-        return HttpsURLConnection.getDefaultHostnameVerifier();
+        final javax.net.ssl.HostnameVerifier httpsUrlVerifier =
+            HttpsURLConnection.getDefaultHostnameVerifier();
+        return new HostnameVerifier() {
+            @Override public boolean verify(String hostname, SSLSession session) {
+                return httpsUrlVerifier.verify(hostname, session);
+            }
+        };
     }
 
     public void setCTEnabledOverride(boolean enabled) {

--- a/common/src/test/java/org/conscrypt/TrustManagerImplTest.java
+++ b/common/src/test/java/org/conscrypt/TrustManagerImplTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.security.KeyStore;
 import java.security.Principal;
 import java.security.cert.Certificate;
@@ -27,11 +28,17 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509TrustManager;
 import org.conscrypt.java.security.TestKeyStore;
+import org.conscrypt.javax.net.ssl.TestHostnameVerifier;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -99,7 +106,7 @@ public class TrustManagerImplTest {
         TestUtils.assumeExtendedTrustManagerAvailable();
         // build the trust manager
         KeyStore.PrivateKeyEntry pke = TestKeyStore.getServer().getPrivateKey("RSA", "RSA");
-        X509Certificate[] chain3 = (X509Certificate[])pke.getCertificateChain();
+        X509Certificate[] chain3 = (X509Certificate[]) pke.getCertificateChain();
         X509Certificate root = chain3[2];
         X509TrustManager tm = trustManager(root);
 
@@ -111,13 +118,95 @@ public class TrustManagerImplTest {
 
         assertTrue(tm instanceof TrustManagerImpl);
         TrustManagerImpl tmi = (TrustManagerImpl) tm;
-        List<X509Certificate> certs = tmi.checkServerTrusted(chain2, "RSA", new MySSLSession(
+        List<X509Certificate> certs = tmi.checkServerTrusted(chain2, "RSA", new FakeSSLSession(
                 "purple.com"));
         assertEquals(Arrays.asList(chain3), certs);
-        certs = tmi.checkServerTrusted(chain1, "RSA", new MySSLSession("purple.com"));
+        certs = tmi.checkServerTrusted(chain1, "RSA", new FakeSSLSession("purple.com"));
         assertEquals(Arrays.asList(chain3), certs);
     }
 
+    @Test
+    public void testHttpsEndpointIdentification() throws Exception {
+        TestUtils.assumeExtendedTrustManagerAvailable();
+
+        KeyStore.PrivateKeyEntry pke = TestKeyStore.getServerHostname().getPrivateKey("RSA", "RSA");
+        X509Certificate[] chain = (X509Certificate[]) pke.getCertificateChain();
+        X509Certificate root = chain[2];
+        TrustManagerImpl tmi = (TrustManagerImpl) trustManager(root);
+
+        String goodHostname = TestKeyStore.CERT_HOSTNAME;
+        String badHostname = "definitelywrong.nopenopenope";
+
+        // The default hostname verifier on OpenJDK rejects all hostnames, so use our own
+        HostnameVerifier oldDefault = HttpsURLConnection.getDefaultHostnameVerifier();
+        try {
+            HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());
+
+            SSLParameters params = new SSLParameters();
+
+            // Without endpoint identification this should pass despite the mismatched hostname
+            params.setEndpointIdentificationAlgorithm(null);
+
+            List<X509Certificate> certs = tmi.getTrustedChainForServer(chain, "RSA",
+                new FakeSSLSocket(new FakeSSLSession(badHostname, chain), params));
+            assertEquals(Arrays.asList(chain), certs);
+
+            // Turn on endpoint identification
+            params.setEndpointIdentificationAlgorithm("HTTPS");
+
+            try {
+                tmi.getTrustedChainForServer(chain, "RSA",
+                    new FakeSSLSocket(new FakeSSLSession(badHostname, chain), params));
+            } catch (CertificateException expected) {
+            }
+
+            certs = tmi.getTrustedChainForServer(chain, "RSA",
+                new FakeSSLSocket(new FakeSSLSession(goodHostname, chain), params));
+            assertEquals(Arrays.asList(chain), certs);
+
+            // Override the global default hostname verifier with a Conscrypt-specific one that
+            // always passes.  Both scenarios should pass.
+            Conscrypt.setDefaultHostnameVerifier(new HostnameVerifier() {
+                @Override public boolean verify(String s, SSLSession sslSession) { return true; }
+            });
+
+            certs = tmi.getTrustedChainForServer(chain, "RSA",
+                new FakeSSLSocket(new FakeSSLSession(badHostname, chain), params));
+            assertEquals(Arrays.asList(chain), certs);
+
+            certs = tmi.getTrustedChainForServer(chain, "RSA",
+                new FakeSSLSocket(new FakeSSLSession(goodHostname, chain), params));
+            assertEquals(Arrays.asList(chain), certs);
+
+            // Now set an instance-specific verifier on the trust manager.  The bad hostname should
+            // fail again.
+            Conscrypt.setHostnameVerifier(tmi, new TestHostnameVerifier());
+
+            try {
+                tmi.getTrustedChainForServer(chain, "RSA",
+                    new FakeSSLSocket(new FakeSSLSession(badHostname, chain), params));
+            } catch (CertificateException expected) {
+            }
+
+            certs = tmi.getTrustedChainForServer(chain, "RSA",
+                new FakeSSLSocket(new FakeSSLSession(goodHostname, chain), params));
+            assertEquals(Arrays.asList(chain), certs);
+
+            // Remove the instance-specific verifier, and both should pass again.
+            Conscrypt.setHostnameVerifier(tmi, null);
+
+            certs = tmi.getTrustedChainForServer(chain, "RSA",
+                new FakeSSLSocket(new FakeSSLSession(badHostname, chain), params));
+            assertEquals(Arrays.asList(chain), certs);
+
+            certs = tmi.getTrustedChainForServer(chain, "RSA",
+                new FakeSSLSocket(new FakeSSLSession(goodHostname, chain), params));
+            assertEquals(Arrays.asList(chain), certs);
+        } finally {
+            Conscrypt.setDefaultHostnameVerifier(null);
+            HttpsURLConnection.setDefaultHostnameVerifier(oldDefault);
+        }
+    }
 
     private X509TrustManager trustManager(X509Certificate ca) throws Exception {
         KeyStore keyStore = TestKeyStore.createKeyStore();
@@ -149,11 +238,18 @@ public class TrustManagerImplTest {
         }
     }
 
-    private static class MySSLSession implements SSLSession {
+    private static class FakeSSLSession implements SSLSession {
         private final String hostname;
+        private final X509Certificate[] peerCerts;
 
-        MySSLSession(String hostname) {
+        FakeSSLSession(String hostname) {
             this.hostname = hostname;
+            peerCerts = null;
+        }
+
+        FakeSSLSession(String hostname, X509Certificate[] peerCerts) {
+            this.hostname = hostname;
+            this.peerCerts = peerCerts.clone();
         }
 
         @Override
@@ -204,7 +300,11 @@ public class TrustManagerImplTest {
 
         @Override
         public Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
-            throw new UnsupportedOperationException();
+            if (peerCerts == null) {
+                throw new SSLPeerUnverifiedException("Null peerCerts");
+            } else {
+                return peerCerts.clone();
+            }
         }
 
         @Override
@@ -259,6 +359,119 @@ public class TrustManagerImplTest {
 
         @Override
         public void removeValue(String name) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class FakeSSLSocket extends SSLSocket {
+
+        private final SSLSession session;
+        private final SSLParameters parameters;
+
+        public FakeSSLSocket(SSLSession session, SSLParameters parameters) {
+            this.session = session;
+            this.parameters = parameters;
+        }
+
+        @Override
+        public SSLParameters getSSLParameters() {
+            return parameters;
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String[] getEnabledCipherSuites() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setEnabledCipherSuites(String[] strings) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String[] getSupportedProtocols() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String[] getEnabledProtocols() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setEnabledProtocols(String[] strings) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SSLSession getSession() {
+            return session;
+        }
+
+        @Override
+        public SSLSession getHandshakeSession() {
+            return session;
+        }
+
+        @Override
+        public void addHandshakeCompletedListener(
+            HandshakeCompletedListener handshakeCompletedListener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeHandshakeCompletedListener(
+            HandshakeCompletedListener handshakeCompletedListener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void startHandshake() throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setUseClientMode(boolean b) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean getUseClientMode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setNeedClientAuth(boolean b) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean getNeedClientAuth() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setWantClientAuth(boolean b) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean getWantClientAuth() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setEnableSessionCreation(boolean b) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean getEnableSessionCreation() {
             throw new UnsupportedOperationException();
         }
     }

--- a/common/src/test/java/org/conscrypt/TrustManagerImplTest.java
+++ b/common/src/test/java/org/conscrypt/TrustManagerImplTest.java
@@ -29,7 +29,6 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
 import javax.net.ssl.HandshakeCompletedListener;
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -38,7 +37,6 @@ import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509TrustManager;
 import org.conscrypt.java.security.TestKeyStore;
-import org.conscrypt.javax.net.ssl.TestHostnameVerifier;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -138,7 +136,7 @@ public class TrustManagerImplTest {
         String badHostname = "definitelywrong.nopenopenope";
 
         // The default hostname verifier on OpenJDK rejects all hostnames, so use our own
-        HostnameVerifier oldDefault = HttpsURLConnection.getDefaultHostnameVerifier();
+        javax.net.ssl.HostnameVerifier oldDefault = HttpsURLConnection.getDefaultHostnameVerifier();
         try {
             HttpsURLConnection.setDefaultHostnameVerifier(new TestHostnameVerifier());
 
@@ -475,4 +473,8 @@ public class TrustManagerImplTest {
             throw new UnsupportedOperationException();
         }
     }
+
+    private static class TestHostnameVerifier
+        extends org.conscrypt.javax.net.ssl.TestHostnameVerifier
+        implements HostnameVerifier {}
 }

--- a/common/src/test/java/org/conscrypt/TrustManagerImplTest.java
+++ b/common/src/test/java/org/conscrypt/TrustManagerImplTest.java
@@ -164,7 +164,7 @@ public class TrustManagerImplTest {
 
             // Override the global default hostname verifier with a Conscrypt-specific one that
             // always passes.  Both scenarios should pass.
-            Conscrypt.setDefaultHostnameVerifier(new HostnameVerifier() {
+            Conscrypt.setDefaultHostnameVerifier(new ConscryptHostnameVerifier() {
                 @Override public boolean verify(String s, SSLSession sslSession) { return true; }
             });
 
@@ -476,5 +476,5 @@ public class TrustManagerImplTest {
 
     private static class TestHostnameVerifier
         extends org.conscrypt.javax.net.ssl.TestHostnameVerifier
-        implements HostnameVerifier {}
+        implements ConscryptHostnameVerifier {}
 }

--- a/testing/src/main/java/org/conscrypt/java/security/TestKeyStore.java
+++ b/testing/src/main/java/org/conscrypt/java/security/TestKeyStore.java
@@ -135,6 +135,7 @@ public final class TestKeyStore {
     private static TestKeyStore INTERMEDIATE_CA_EC;
 
     private static TestKeyStore SERVER;
+    private static TestKeyStore SERVER_HOSTNAME;
     private static TestKeyStore CLIENT;
     private static TestKeyStore CLIENT_CERTIFICATE;
     private static TestKeyStore CLIENT_EC_RSA_CERTIFICATE;
@@ -159,6 +160,7 @@ public final class TestKeyStore {
     private static final byte[] LOCAL_HOST_ADDRESS = {127, 0, 0, 1};
     private static final String LOCAL_HOST_NAME = "localhost";
     private static final String LOCAL_HOST_NAME_IPV6 = "ip6-localhost";
+    public static final String CERT_HOSTNAME = "example.com";
 
     public final KeyStore keyStore;
     public final char[] storePassword;
@@ -235,6 +237,13 @@ public final class TestKeyStore {
                          .addSubjectAltNameIpAddress(LOCAL_HOST_ADDRESS)
                          .certificateSerialNumber(BigInteger.valueOf(3))
                          .build();
+        SERVER_HOSTNAME = new Builder()
+            .aliasPrefix("server-hostname")
+            .signer(INTERMEDIATE_CA.getPrivateKey("RSA", "RSA"))
+            .rootCa(INTERMEDIATE_CA.getRootCertificate("RSA"))
+            .addSubjectAltNameDnsName(CERT_HOSTNAME)
+            .certificateSerialNumber(BigInteger.valueOf(4))
+            .build();
         CLIENT = new TestKeyStore(createClient(INTERMEDIATE_CA.keyStore), null, null);
         CLIENT_EC_RSA_CERTIFICATE = new Builder()
                                             .aliasPrefix("client-ec")
@@ -302,6 +311,15 @@ public final class TestKeyStore {
     public static TestKeyStore getServer() {
         initCerts();
         return SERVER;
+    }
+
+    /**
+     * Return a server keystore with a matched RSA certificate with SAN hostname and private key
+     * as well as a CA certificate.
+     */
+    public static TestKeyStore getServerHostname() {
+        initCerts();
+        return SERVER_HOSTNAME;
     }
 
     /**


### PR DESCRIPTION
This allows users to set hostname verifiers either Conscrypt-wide or
on an individual trust manager without polluting the default
HostnameVerifier of HttpsURLConnection.

Fixes #598