### PR TITLE
Some minor build optimizations

### DIFF
--- a/constants/build.gradle
+++ b/constants/build.gradle
@@ -57,6 +57,7 @@ model {
             def gen = $.binaries.get("genExecutable")
 
             dependsOn gen
+            outputs.dir genDir
             File genDir = new File("${genDir}/org/conscrypt")
 
             executable gen.executable.file

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -260,6 +260,7 @@ def addNativeTest(nativeClassifier) {
             mustRunAfter test
             jvmArgs javaArchFlag
             executable = javaExecutable
+            systemProperties = test.systemProperties
         }
         check.dependsOn "$testTaskName"
     }

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -89,7 +89,6 @@ if (androidSdkInstalled) {
     }
 
     dependencies {
-        implementation fileTree(dir: 'libs', include: ['*.jar'])
         implementation project(path: ':conscrypt-openjdk', configuration: 'platform')
         publicApiDocs project(':conscrypt-api-doclet')
         androidTestImplementation('androidx.test.espresso:espresso-core:3.1.1', {


### PR DESCRIPTION
Add output dir declaration to constant gen so results can be cached.

Add generic test system properties to native tests so the logging
filter is applied.

Remove a dependency that doesn't exist.