### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,9 +45,6 @@ init:
   # Install NASM
   - choco install -y --allow-empty-checksums nasm
 
-  # Install Go for BoringSSL compile (embedding test data)
-  - choco install -y --allow-empty-checksums golang
-
   # Clone BoringSSL
   - git clone --depth 1 https://boringssl.googlesource.com/boringssl.git "%BORINGSSL_HOME%"
 


### PR DESCRIPTION
The release of Go 1.12 is causing some problems because it moved some
symbols between packages and object files compiled for 1.11 or earlier
have them in the wrong package, so when we install golang via choco
(which is 1.12), it causes compilation failures.  Since Go is
preinstalled on AppVeyor Windows images at this point, we can just not
install it ourselves and everything will work with the copy from the
image.