### PR TITLE
Set SSLParameters ALPN protocols in Android platform

### DIFF
--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -140,6 +140,7 @@ final class Platform {
                 }
             }
         }
+        impl.setApplicationProtocols(params.getApplicationProtocols());
     }
 
     static void getSSLParameters(
@@ -150,6 +151,7 @@ final class Platform {
             params.setServerNames(Collections.<SNIServerName>singletonList(
                     new SNIHostName(socket.getHostname())));
         }
+        params.setApplicationProtocols(impl.getApplicationProtocols());
     }
 
     static void setSSLParameters(
@@ -165,6 +167,7 @@ final class Platform {
                 }
             }
         }
+        impl.setApplicationProtocols(params.getApplicationProtocols());
     }
 
     static void getSSLParameters(
@@ -175,6 +178,7 @@ final class Platform {
             params.setServerNames(Collections.<SNIServerName>singletonList(
                     new SNIHostName(engine.getHostname())));
         }
+        params.setApplicationProtocols(impl.getApplicationProtocols());
     }
 
     /**


### PR DESCRIPTION
The Android platform SSLParameters implementation now supports ALPN,
so use it when running there.