### PR TITLE
Copy testLogging properties

### DIFF
--- a/openjdk-integ-tests/build.gradle
+++ b/openjdk-integ-tests/build.gradle
@@ -1,3 +1,5 @@
+import org.codehaus.groovy.runtime.InvokerHelper
+
 description = 'Conscrypt: OpenJDK Integration Tests'
 
 evaluationDependsOn(':conscrypt-openjdk')
@@ -43,6 +45,8 @@ test {
 task testEngineSocket(type: Test, dependsOn: test) {
     jvmArgs "-Dorg.conscrypt.useEngineSocketByDefault=true"
     include suiteClass
+    InvokerHelper.setProperties(testLogging, test.testLogging.properties)
+    systemProperties = test.systemProperties
 }
 check.dependsOn testEngineSocket
 

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -1,3 +1,5 @@
+import org.codehaus.groovy.runtime.InvokerHelper
+
 description = 'Conscrypt: OpenJdk'
 
 ext {
@@ -260,6 +262,7 @@ def addNativeTest(nativeClassifier) {
             mustRunAfter test
             jvmArgs javaArchFlag
             executable = javaExecutable
+            InvokerHelper.setProperties(testLogging, test.testLogging.properties)
             systemProperties = test.systemProperties
         }
         check.dependsOn "$testTaskName"


### PR DESCRIPTION
test.testLogging is customized by the top-level build file to set up
reasonable logging defaults, but those customizations don't carry over
to other test rules created by projects.

Copy the properties over explicitly so they get the same default
configuration.