### PR TITLE
Make ConscryptEngineSocket call correct methods

### DIFF
--- a/android/lint.xml
+++ b/android/lint.xml
@@ -7,6 +7,8 @@
         <ignore path="**/org/conscrypt/Java8EngineWrapper.java" />
         <ignore path="**/org/conscrypt/Java8EngineSocket.java" />
         <ignore path="**/org/conscrypt/Java8FileDescriptorSocket.java" />
+        <!-- ConscryptEngineSocket uses X509ExtendedTrustManager in an API-guarded method -->
+        <ignore path="**/org/conscrypt/ConscryptEngineSocket.java" />
         <!-- We don't provide the trust manager in the Android build -->
         <ignore path="**/org/conscrypt/TrustManagerImpl.java" />
     </issue>

--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -905,6 +905,11 @@ final class Platform {
         return null;
     }
 
+    // X509ExtendedTrustManager was added in API 24
+    static boolean supportsX509ExtendedTrustManager() {
+        return Build.VERSION.SDK_INT > 23;
+    }
+
     /**
      * Check if SCT verification is required for a given hostname.
      *

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -150,6 +150,43 @@ final class SSLParametersImpl implements Cloneable {
         // directly accesses /dev/urandom, which makes it irrelevant.
     }
 
+    // Copy constructor for the purposes of changing the final fields
+    private SSLParametersImpl(ClientSessionContext clientSessionContext,
+        ServerSessionContext serverSessionContext,
+        X509KeyManager x509KeyManager,
+        PSKKeyManager pskKeyManager,
+        X509TrustManager x509TrustManager,
+        SSLParametersImpl sslParams) {
+        this.clientSessionContext = clientSessionContext;
+        this.serverSessionContext = serverSessionContext;
+        this.x509KeyManager = x509KeyManager;
+        this.pskKeyManager = pskKeyManager;
+        this.x509TrustManager = x509TrustManager;
+
+        this.enabledProtocols =
+            (sslParams.enabledProtocols == null) ? null : sslParams.enabledProtocols.clone();
+        this.isEnabledProtocolsFiltered = sslParams.isEnabledProtocolsFiltered;
+        this.enabledCipherSuites =
+            (sslParams.enabledCipherSuites == null) ? null : sslParams.enabledCipherSuites.clone();
+        this.client_mode = sslParams.client_mode;
+        this.need_client_auth = sslParams.need_client_auth;
+        this.want_client_auth = sslParams.want_client_auth;
+        this.enable_session_creation = sslParams.enable_session_creation;
+        this.endpointIdentificationAlgorithm = sslParams.endpointIdentificationAlgorithm;
+        this.useCipherSuitesOrder = sslParams.useCipherSuitesOrder;
+        this.ctVerificationEnabled = sslParams.ctVerificationEnabled;
+        this.sctExtension =
+            (sslParams.sctExtension == null) ? null : sslParams.sctExtension.clone();
+        this.ocspResponse =
+            (sslParams.ocspResponse == null) ? null : sslParams.ocspResponse.clone();
+        this.applicationProtocols =
+            (sslParams.applicationProtocols == null) ? null : sslParams.applicationProtocols.clone();
+        this.applicationProtocolSelector = sslParams.applicationProtocolSelector;
+        this.useSessionTickets = sslParams.useSessionTickets;
+        this.useSni = sslParams.useSni;
+        this.channelIdEnabled = sslParams.channelIdEnabled;
+    }
+
     static SSLParametersImpl getDefault() throws KeyManagementException {
         SSLParametersImpl result = defaultParameters;
         if (result == null) {
@@ -464,6 +501,11 @@ final class SSLParametersImpl implements Cloneable {
         } catch (CloneNotSupportedException e) {
             throw new AssertionError(e);
         }
+    }
+
+    SSLParametersImpl cloneWithTrustManager(X509TrustManager newTrustManager) {
+        return new SSLParametersImpl(clientSessionContext, serverSessionContext,
+            x509KeyManager, pskKeyManager, newTrustManager, this);
     }
 
     private static X509KeyManager getDefaultX509KeyManager() throws KeyManagementException {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -28,13 +28,13 @@ import static org.junit.Assert.fail;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,6 +57,7 @@ import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509ExtendedTrustManager;
 import org.conscrypt.TestUtils;
 import org.conscrypt.java.security.StandardNames;
 import org.conscrypt.java.security.TestKeyStore;
@@ -453,11 +454,94 @@ public class SSLSocketTest {
     }
 
     @Test
-    public void test_SSLSocket_getHandshakeSession() throws Exception {
+    public void test_SSLSocket_getHandshakeSession_unconnected() throws Exception {
         SSLSocketFactory sf = (SSLSocketFactory) SSLSocketFactory.getDefault();
         SSLSocket socket = (SSLSocket) sf.createSocket();
-        SSLSession session = getHandshakeSession(socket);
+        SSLSession session = socket.getHandshakeSession();
         assertNull(session);
+    }
+
+    @Test
+    public void test_SSLSocket_getHandshakeSession_duringHandshake() throws Exception {
+        // We can't reference the actual context we're using, since we need to pass
+        // the test trust manager in to construct it, so create reference objects that
+        // we can test against.
+        final TestSSLContext referenceContext = TestSSLContext.create();
+        final SSLSocket referenceClientSocket =
+            (SSLSocket) referenceContext.clientContext.getSocketFactory().createSocket();
+
+        TestSSLContext c = TestSSLContext.newBuilder()
+            .clientTrustManager(new X509ExtendedTrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s,
+                    Socket socket) throws CertificateException {
+                    throw new CertificateException("Shouldn't be called");
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s,
+                    Socket socket) throws CertificateException {
+                    try {
+                        SSLSocket sslSocket = (SSLSocket) socket;
+                        SSLSession session = sslSocket.getHandshakeSession();
+                        assertNotNull(session);
+                        // By the point of the handshake where we're validating certificates,
+                        // the hostname is known and the cipher suite should be agreed
+                        assertEquals(referenceContext.host.getHostName(), session.getPeerHost());
+                        assertEquals(referenceClientSocket.getEnabledCipherSuites()[0],
+                            session.getCipherSuite());
+                    } catch (Exception e) {
+                        throw new CertificateException("Something broke", e);
+                    }
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s,
+                    SSLEngine sslEngine) throws CertificateException {
+                    throw new CertificateException("Shouldn't be called");
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s,
+                    SSLEngine sslEngine) throws CertificateException {
+                    throw new CertificateException("Shouldn't be called");
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
+                    throws CertificateException {
+                    throw new CertificateException("Shouldn't be called");
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
+                    throws CertificateException {
+                    throw new CertificateException("Shouldn't be called");
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+            }).build();
+        SSLContext clientContext = c.clientContext;
+        SSLSocket client = (SSLSocket)
+            clientContext.getSocketFactory().createSocket(c.host, c.port);
+        final SSLSocket server = (SSLSocket) c.serverSocket.accept();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Void> future = executor.submit(new Callable<Void>() {
+            @Override public Void call() throws Exception {
+                server.startHandshake();
+                return null;
+            }
+        });
+        executor.shutdown();
+        client.startHandshake();
+
+        future.get();
+        client.close();
+        server.close();
+        c.close();
     }
 
     @Test
@@ -879,12 +963,4 @@ public class SSLSocketTest {
         }
     }
 
-    private static SSLSession getHandshakeSession(SSLSocket socket) {
-        try {
-            Method method = socket.getClass().getMethod("getHandshakeSession");
-            return (SSLSession) method.invoke(socket);
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
@@ -198,7 +198,7 @@ public class SSLSocketVersionCompatibilityTest {
             public Void call() throws Exception {
                 server.startHandshake();
                 assertNotNull(server.getSession());
-                assertNull(getHandshakeSession(server));
+                assertNull(server.getHandshakeSession());
                 try {
                     server.getSession().getPeerCertificates();
                     fail();
@@ -399,7 +399,7 @@ public class SSLSocketVersionCompatibilityTest {
                         event.getPeerCertificateChain();
                     Principal peerPrincipal = event.getPeerPrincipal();
                     Principal localPrincipal = event.getLocalPrincipal();
-                    Socket socket = event.getSocket();
+                    SSLSocket socket = event.getSocket();
                     assertNotNull(session);
                     byte[] id = session.getId();
                     assertNotNull(id);
@@ -435,7 +435,7 @@ public class SSLSocketVersionCompatibilityTest {
                     assertNull(localPrincipal);
                     assertNotNull(socket);
                     assertSame(client, socket);
-                    assertNull(getHandshakeSession((SSLSocket) socket));
+                    assertNull(socket.getHandshakeSession());
                     synchronized (handshakeCompletedListenerCalled) {
                         handshakeCompletedListenerCalled[0] = true;
                         handshakeCompletedListenerCalled.notify();
@@ -2275,15 +2275,6 @@ public class SSLSocketVersionCompatibilityTest {
     private static SSLContext defaultInit(SSLContext context) throws KeyManagementException {
         context.init(null, null, null);
         return context;
-    }
-
-    private static SSLSession getHandshakeSession(SSLSocket socket) {
-        try {
-            Method method = socket.getClass().getMethod("getHandshakeSession");
-            return (SSLSession) method.invoke(socket);
-        } catch (Exception e) {
-            return null;
-        }
     }
 
     // Assumes that the negotiated connection will be TLS 1.2

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -575,6 +575,11 @@ final class Platform {
         return null;
     }
 
+    // OpenJDK always has X509ExtendedTrustManager
+    static boolean supportsX509ExtendedTrustManager() {
+        return true;
+    }
+
     /**
      * Check if SCT verification is required for a given hostname.
      *

--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -473,6 +473,11 @@ final class Platform {
         return addr.getHostString();
     }
 
+    // The platform always has X509ExtendedTrustManager
+    static boolean supportsX509ExtendedTrustManager() {
+        return true;
+    }
+
     static boolean isCTVerificationRequired(String hostname) {
         return NetworkSecurityPolicy.getInstance().isCertificateTransparencyVerificationRequired(
                 hostname);


### PR DESCRIPTION
ConscryptEngineSocket uses an SSLEngine internally to function, and
that naturally calls the SSLEngine-accepting methods on
X509ExtendedTrustManager to do trust checks.  We were passing our
given trust manager directly to the SSLEngine, which resulted in an
SSLSocket implementation that ended up calling SSLEngine-based
methods, which isn't right.

Instead, create a delegating trust manager that maps the calls to the
correct objects.  On platforms where X509ExtendedTrustManager isn't
available, we can pass in the provided trust manager directly, since
it doesn't receive a reference to the calling object.

Also adds tests for getHandshakeSession() that ensure it functions in
the middle of the handshake and provides properties that should be
set.