### PR TITLE
Don't send TLS_FALLBACK_SCSV if max version is >= 1.2

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1062,9 +1062,12 @@ public final class NativeCrypto {
             if (cipherSuite.equals(TLS_EMPTY_RENEGOTIATION_INFO_SCSV)) {
                 continue;
             }
+            // Only send TLS_FALLBACK_SCSV if max version >= 1.2 to prevent inadvertent connection
+            // problems when servers upgrade.  See https://github.com/google/conscrypt/issues/574
+            // for more discussion.
             if (cipherSuite.equals(TLS_FALLBACK_SCSV)
-                    && !maxProtocol.equals(SUPPORTED_PROTOCOL_TLSV1_3)
-                    && !maxProtocol.equals(SUPPORTED_PROTOCOL_TLSV1_2)) {
+                    && (maxProtocol.equals(SUPPORTED_PROTOCOL_TLSV1)
+                        || maxProtocol.equals(SUPPORTED_PROTOCOL_TLSV1_1))) {
                 SSL_set_mode(ssl, ssl_holder, NativeConstants.SSL_MODE_SEND_FALLBACK_SCSV);
                 continue;
             }

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -968,16 +968,16 @@ public final class NativeCrypto {
         return SUPPORTED_PROTOCOLS.clone();
     }
 
-    private static class MinMax {
-        final String min;
-        final String max;
-        public MinMax(String min, String max) {
+    private static class Range {
+        public final String min;
+        public final String max;
+        public Range(String min, String max) {
             this.min = min;
             this.max = max;
         }
     }
 
-    private static MinMax getProtocolRange(String[] protocols) {
+    private static Range getProtocolRange(String[] protocols) {
         // TLS protocol negotiation only allows a min and max version
         // to be set, despite the Java API allowing a sparse set of
         // protocols to be enabled.  Use the lowest contiguous range
@@ -1000,14 +1000,14 @@ public final class NativeCrypto {
         if ((min == null) || (max == null)) {
             throw new IllegalArgumentException("No protocols enabled.");
         }
-        return new MinMax(min, max);
+        return new Range(min, max);
     }
 
     static void setEnabledProtocols(long ssl, NativeSsl ssl_holder, String[] protocols) {
         checkEnabledProtocols(protocols);
-        MinMax minMax = getProtocolRange(protocols);
+        Range range = getProtocolRange(protocols);
         SSL_set_protocol_versions(
-            ssl, ssl_holder, getProtocolConstant(minMax.min), getProtocolConstant(minMax.max));
+            ssl, ssl_holder, getProtocolConstant(range.min), getProtocolConstant(range.max));
     }
 
     private static int getProtocolConstant(String protocol) {

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -312,7 +312,8 @@ final class NativeSsl {
                     + " is no longer supported and was filtered from the list");
         }
         NativeCrypto.setEnabledProtocols(ssl, this, parameters.enabledProtocols);
-        NativeCrypto.setEnabledCipherSuites(ssl, this, parameters.enabledCipherSuites);
+        NativeCrypto.setEnabledCipherSuites(
+            ssl, this, parameters.enabledCipherSuites, parameters.enabledProtocols);
 
         if (parameters.applicationProtocols.length > 0) {
             NativeCrypto.setApplicationProtocols(ssl, this, isClient(), parameters.applicationProtocols);

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -697,7 +697,7 @@ public class NativeCryptoTest {
                 cipherSuites.addAll(enabledCipherSuites);
             }
             NativeCrypto.setEnabledCipherSuites(
-                    s, null, cipherSuites.toArray(new String[cipherSuites.size()]));
+                    s, null, cipherSuites.toArray(new String[cipherSuites.size()]), new String[] {"TLSv1.2"});
 
             if (channelIdPrivateKey != null) {
                 NativeCrypto.SSL_set1_tls_channel_id(s, null, channelIdPrivateKey.getNativeRef());

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -696,6 +696,7 @@ public class NativeCryptoTest {
             } else {
                 cipherSuites.addAll(enabledCipherSuites);
             }
+            // Protocol list is included for determining whether to send TLS_FALLBACK_SCSV
             NativeCrypto.setEnabledCipherSuites(
                     s, null, cipherSuites.toArray(new String[cipherSuites.size()]), new String[] {"TLSv1.2"});
 


### PR DESCRIPTION
TLS_FALLBACK_SCSV protects against downgrade attacks, but if it's set
on a non-fallback connection attempt, it will prevent an
otherwise-safe connection if the server supports a version higher than
the client does.  Because the default OpenJDK TLS implementation
doesn't support TLS_FALLBACK_SCSV, some developers mistakenly enable
it on every connection due to thinking it's a normal cipher suite,
which is starting to cause issues when servers upgrade to TLS 1.3.

We can obviously omit it on connections with a max version of 1.3,
since that's Conscrypt's max version, so it can't be a version
fallback.

As far as connections with a max version of 1.2 are concerned, this
type of fallback is generally not needed any longer, since TLS
1.3-supporting servers should all perform version negotiation
properly.  (Chrome and Firefox have both disabled version fallback
entirely.)  Thus TLS_FALLBACK_SCSV's presence in connections with a
max version of 1.2 is significantly more likely to be a
misconfiguration than a true fallback indication.

We continue to include the cipher suite for connections with a max
version of 1.1 or lower.  First, flaws in pre-1.2 versions are more
likely to exist than flaws in 1.2, so the benefit of flagging
downgrades to those versions are higher.  As well, fallback is most
likely to be useful when dealing with buggy TLS 1.2 servers.

Fixes #574