### PR TITLE
Add ChaCha20-Poly1305 as an alias for ChaCha20/Poly1305/NoPadding

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -427,6 +427,7 @@ public final class OpenSSLProvider extends Provider {
                 "OpenSSLCipherChaCha20");
         putSymmetricCipherImplClass("ChaCha20/Poly1305/NoPadding",
                 "OpenSSLCipher$EVP_AEAD$ChaCha20");
+        put("Alg.Alias.Cipher.ChaCha20-Poly1305", "ChaCha20/Poly1305/NoPadding");
 
         /* === Mac === */
 


### PR DESCRIPTION
Some other providers appear to have used ChaCha20-Poly1305 as the
identifier for this cipher, so support it for compatibility.