### PR TITLE
Tidy up error mapping.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -217,18 +217,7 @@ int throwForAsn1Error(JNIEnv* env, int reason, const char* message,
                       int (*defaultThrow)(JNIEnv*, const char*)) {
     switch (reason) {
         case ASN1_R_UNSUPPORTED_PUBLIC_KEY_TYPE:
-#if defined(ASN1_R_UNABLE_TO_DECODE_RSA_KEY)
-        case ASN1_R_UNABLE_TO_DECODE_RSA_KEY:
-#endif
-#if defined(ASN1_R_WRONG_PUBLIC_KEY_TYPE)
         case ASN1_R_WRONG_PUBLIC_KEY_TYPE:
-#endif
-#if defined(ASN1_R_UNABLE_TO_DECODE_RSA_PRIVATE_KEY)
-        case ASN1_R_UNABLE_TO_DECODE_RSA_PRIVATE_KEY:
-#endif
-#if defined(ASN1_R_UNKNOWN_PUBLIC_KEY_TYPE)
-        case ASN1_R_UNKNOWN_PUBLIC_KEY_TYPE:
-#endif
             return throwInvalidKeyException(env, message);
             break;
         case ASN1_R_UNKNOWN_SIGNATURE_ALGORITHM:
@@ -268,21 +257,8 @@ int throwForEvpError(JNIEnv* env, int reason, const char* message,
             return throwInvalidKeyException(env, message);
             break;
         case EVP_R_UNSUPPORTED_ALGORITHM:
-#if defined(EVP_R_X931_UNSUPPORTED)
-        case EVP_R_X931_UNSUPPORTED:
-#endif
             return throwNoSuchAlgorithmException(env, message);
             break;
-#if defined(EVP_R_WRONG_PUBLIC_KEY_TYPE)
-        case EVP_R_WRONG_PUBLIC_KEY_TYPE:
-            return throwInvalidKeyException(env, message);
-            break;
-#endif
-#if defined(EVP_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM)
-        case EVP_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM:
-            return throwNoSuchAlgorithmException(env, message);
-            break;
-#endif
         default:
             return defaultThrow(env, message);
             break;
@@ -294,9 +270,6 @@ int throwForRsaError(JNIEnv* env, int reason, const char* message,
     switch (reason) {
         case RSA_R_BLOCK_TYPE_IS_NOT_01:
         case RSA_R_PKCS_DECODING_ERROR:
-#if defined(RSA_R_BLOCK_TYPE_IS_NOT_02)
-        case RSA_R_BLOCK_TYPE_IS_NOT_02:
-#endif
             return throwBadPaddingException(env, message);
             break;
         case RSA_R_BAD_SIGNATURE:


### PR DESCRIPTION
These ifdefs are remnants of older BoringSSL versions. We can remove them now.