### PR TITLE
Prepare for upcoming BoringSSL error change.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -238,9 +238,16 @@ int throwForCipherError(JNIEnv* env, int reason, const char* message,
         case CIPHER_R_WRONG_FINAL_BLOCK_LENGTH:
             return throwIllegalBlockSizeException(env, message);
             break;
-        case CIPHER_R_AES_KEY_SETUP_FAILED:
+        // TODO(davidben): Remove these ifdefs after
+        // https://boringssl-review.googlesource.com/c/boringssl/+/35565 has
+        // rolled out to relevant BoringSSL copies.
+#if defined(CIPHER_R_BAD_KEY_LENGTH)
         case CIPHER_R_BAD_KEY_LENGTH:
+#endif
+#if defined(CIPHER_R_UNSUPPORTED_KEY_SIZE)
         case CIPHER_R_UNSUPPORTED_KEY_SIZE:
+#endif
+        case CIPHER_R_INVALID_KEY_LENGTH:
             return throwInvalidKeyException(env, message);
             break;
         case CIPHER_R_BUFFER_TOO_SMALL:


### PR DESCRIPTION
https://boringssl-review.googlesource.com/c/boringssl/+/35565 cleans up
errors used by EVP_AEAD. We had many duplicate errors that were used
inconsistently. (I think we kept adding new ones without noticing that
they already existed. Oops.) To prepare for that in Conscrypt:

- Remove CIPHER_R_AES_KEY_SETUP_FAILED. It indicates an internal error
  in BoringSSL, should be unreachable, and doesn't indicate an invalid
  key from the Java side.

- #ifdef CIPHER_R_BAD_KEY_LENGTH and CIPHER_R_UNSUPPORTED_KEY_SIZE.
  They'll be removed later.

- Add CIPHER_R_INVALID_KEY_LENGTH to the set of key length errors
  checked. The two errors above will be folded into
  CIPHER_R_INVALID_KEY_LENGTH and EVP_CIPHER_CTX_set_key_length already
  uses it.