### PR TITLE
Remove jacoco plugin dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ subprojects {
     apply plugin: "maven"
     apply plugin: "signing"
     apply plugin: "idea"
-    apply plugin: "jacoco"
     apply plugin: "net.ltgt.errorprone"
 
     group = "org.conscrypt"


### PR DESCRIPTION
We don't actually generate coverage reports, so this reduces our deps
a bit.