### PR TITLE
Update Gradle Dependency Configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ arm64-v8a.
 
 ```gradle
 dependencies {
-  compile 'org.conscrypt:conscrypt-android:2.1.0'
+  implementation 'org.conscrypt:conscrypt-android:2.1.0'
 }
 ```
 


### PR DESCRIPTION
It looks like `compile` has been replaced in favor of `implementation`.
https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations
I noticed this and wanted to propose a change to this file.