### PR TITLE
Fix ConscryptEngine state machine

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -251,6 +251,7 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
                 }
             }
         } catch (SSLException e) {
+            drainOutgoingQueue();
             close();
             throw e;
         } catch (IOException e) {
@@ -535,6 +536,18 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
             if (state == STATE_CLOSED) {
                 throw new SocketException("Socket is closed");
             }
+        }
+    }
+
+    private void drainOutgoingQueue() {
+        try {
+            while (engine.pendingOutboundEncryptedBytes() > 0) {
+                out.writeInternal(EMPTY_BUFFER);
+                // Always flush handshake frames immediately.
+                out.flushInternal();
+            }
+        } catch (IOException e) {
+            // Ignore
         }
     }
 

--- a/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
@@ -158,10 +158,23 @@ public class ConscryptEngineTest {
         clientEngine.closeOutbound();
         serverEngine.closeOutbound();
 
-        assertFalse(clientEngine.isInboundDone());
+        // After closing the outbound direction, a shutdown alert should still be pending
+        assertFalse(clientEngine.isOutboundDone());
+        assertFalse(serverEngine.isOutboundDone());
+
+        ByteBuffer drain = bufferType.newBuffer(
+            Math.max(clientEngine.getSession().getPacketBufferSize(),
+                serverEngine.getSession().getPacketBufferSize()));
+        clientEngine.wrap(ByteBuffer.wrap(new byte[0]), drain);
+        drain.clear();
+        serverEngine.wrap(ByteBuffer.wrap(new byte[0]), drain);
+
         assertTrue(clientEngine.isOutboundDone());
-        assertFalse(serverEngine.isInboundDone());
         assertTrue(serverEngine.isOutboundDone());
+
+        // The inbound directions should still be open
+        assertFalse(clientEngine.isInboundDone());
+        assertFalse(serverEngine.isInboundDone());
     }
 
     @Test

--- a/testing/src/main/java/org/conscrypt/javax/net/ssl/TestSSLEnginePair.java
+++ b/testing/src/main/java/org/conscrypt/javax/net/ssl/TestSSLEnginePair.java
@@ -73,10 +73,7 @@ public final class TestSSLEnginePair implements Closeable {
 
     /**
      * Create a new connected server/client engine pair within a
-     * existing SSLContext. Optionally specify clientCipherSuites to
-     * allow forcing new SSLSession to test SSLSessionContext
-     * caching. Optionally specify serverCipherSuites for testing
-     * cipher suite negotiation.
+     * existing SSLContext.
      */
     public static SSLEngine[] connect(final TestSSLContext c,
             Hooks hooks,
@@ -113,12 +110,12 @@ public final class TestSSLEnginePair implements Closeable {
                 break;
             }
 
-            boolean progress = handshakeCompleted(client,
+            boolean progress = handshakeStep(client,
                     clientToServer,
                     serverToClient,
                     scratch,
                     clientFinished);
-            progress |= handshakeCompleted(server,
+            progress |= handshakeStep(server,
                     serverToClient,
                     clientToServer,
                     scratch,
@@ -158,7 +155,7 @@ public final class TestSSLEnginePair implements Closeable {
         }
     }
 
-    private static boolean handshakeCompleted(SSLEngine engine,
+    public static boolean handshakeStep(SSLEngine engine,
             ByteBuffer output,
             ByteBuffer input,
             ByteBuffer scratch,


### PR DESCRIPTION
The SSLEngine state machine is slightly more complicated than our
previous code presumed.  After closeInbound() or closeOutbound() are
called, isInboundDone() and isOutboundDone() shouldn't immediately
return true.  Rather, closeInbound() and closeOutbound() indicate the
caller's intention to never supply any more input data in the given
direction, but isInboundDone() and isOutboundDone() indicate that no
more output data in the given direction will be produced.  This means
those methods need to be adjusted to take into account the state of
internal plaintext/ciphertext buffers.

This simplifies and corrects some of the other code as well.  In
particular, we no longer have to stash exceptions that are thrown
during the handshake, because the caller is expected to see those
exceptions and drain the outgoing buffer (which previously they had no
way of doing).

Fixes #577