### PR TITLE
Make X509CertificateTest more tolerant

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
@@ -182,7 +182,8 @@ public class X509CertificateTest {
                     CertificateFactory cf = CertificateFactory.getInstance("X509", p);
                     Certificate c = cf.generateCertificate(new ByteArrayInputStream(
                         VALID_CERT.getBytes(Charset.forName("US-ASCII"))));
-                    assertEquals("SHA256withRSA", ((X509Certificate) c).getSigAlgName());
+                    assertEquals("SHA256WITHRSA",
+                        ((X509Certificate) c).getSigAlgName().toUpperCase());
                 }
             });
     }


### PR DESCRIPTION
The case of algorithms isn't specified, and Bouncy Castle uses
all-caps algorithm names, so make it accept any casing.