### PR TITLE
Make a number of cipher classes public

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -31,7 +31,7 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.spec.IvParameterSpec;
 
 @Internal
-abstract class OpenSSLAeadCipher extends OpenSSLCipher {
+public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     /**
      * The default tag size when one is not specified. Default to
      * full-length tags (128-bits or 16 octets).

--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipherAES.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipherAES.java
@@ -24,7 +24,7 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidParameterSpecException;
 
 @Internal
-abstract class OpenSSLAeadCipherAES extends OpenSSLAeadCipher {
+public abstract class OpenSSLAeadCipherAES extends OpenSSLAeadCipher {
     private static final int AES_BLOCK_SIZE = 16;
 
     OpenSSLAeadCipherAES(Mode mode) {

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -49,7 +49,7 @@ import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
 
 @Internal
-abstract class OpenSSLCipherRSA extends CipherSpi {
+public abstract class OpenSSLCipherRSA extends CipherSpi {
     /**
      * The current OpenSSL key we're operating on.
      */
@@ -422,7 +422,7 @@ abstract class OpenSSLCipherRSA extends CipherSpi {
         }
     }
 
-    static class OAEP extends OpenSSLCipherRSA {
+    public static class OAEP extends OpenSSLCipherRSA {
         private long oaepMd;
         private int oaepMdSizeBytes;
 

--- a/common/src/main/java/org/conscrypt/OpenSSLEvpCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEvpCipher.java
@@ -27,7 +27,7 @@ import javax.crypto.spec.IvParameterSpec;
 import org.conscrypt.NativeRef.EVP_CIPHER_CTX;
 
 @Internal
-abstract class OpenSSLEvpCipher extends OpenSSLCipher {
+public abstract class OpenSSLEvpCipher extends OpenSSLCipher {
     /**
      * Native pointer for the OpenSSL EVP_CIPHER context.
      */

--- a/common/src/main/java/org/conscrypt/OpenSSLEvpCipherAES.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEvpCipherAES.java
@@ -21,7 +21,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import javax.crypto.NoSuchPaddingException;
 
-abstract class OpenSSLEvpCipherAES extends OpenSSLEvpCipher {
+@Internal
+public abstract class OpenSSLEvpCipherAES extends OpenSSLEvpCipher {
     private static final int AES_BLOCK_SIZE = 16;
 
     OpenSSLEvpCipherAES(Mode mode, Padding padding) {
@@ -67,12 +68,12 @@ abstract class OpenSSLEvpCipherAES extends OpenSSLEvpCipher {
         return AES_BLOCK_SIZE;
     }
 
-    static class AES extends OpenSSLEvpCipherAES {
+    public static class AES extends OpenSSLEvpCipherAES {
         AES(Mode mode, Padding padding) {
             super(mode, padding);
         }
 
-        static class CBC extends AES {
+        public static class CBC extends AES {
             CBC(Padding padding) {
                 super(Mode.CBC, padding);
             }
@@ -96,7 +97,7 @@ abstract class OpenSSLEvpCipherAES extends OpenSSLEvpCipher {
             }
         }
 
-        static class ECB extends AES {
+        public static class ECB extends AES {
             ECB(Padding padding) {
                 super(Mode.ECB, padding);
             }
@@ -128,12 +129,12 @@ abstract class OpenSSLEvpCipherAES extends OpenSSLEvpCipher {
         }
     }
 
-    static class AES_128 extends OpenSSLEvpCipherAES {
+    public static class AES_128 extends OpenSSLEvpCipherAES {
         AES_128(Mode mode, Padding padding) {
             super(mode, padding);
         }
 
-        static class CBC extends AES_128 {
+        public static class CBC extends AES_128 {
             CBC(Padding padding) {
                 super(Mode.CBC, padding);
             }
@@ -157,7 +158,7 @@ abstract class OpenSSLEvpCipherAES extends OpenSSLEvpCipher {
             }
         }
 
-        static class ECB extends AES_128 {
+        public static class ECB extends AES_128 {
             ECB(Padding padding) {
                 super(Mode.ECB, padding);
             }
@@ -183,12 +184,12 @@ abstract class OpenSSLEvpCipherAES extends OpenSSLEvpCipher {
         }
     }
 
-    static class AES_256 extends OpenSSLEvpCipherAES {
+    public static class AES_256 extends OpenSSLEvpCipherAES {
         AES_256(Mode mode, Padding padding) {
             super(mode, padding);
         }
 
-        static class CBC extends AES_256 {
+        public static class CBC extends AES_256 {
             CBC(Padding padding) {
                 super(Mode.CBC, padding);
             }
@@ -212,7 +213,7 @@ abstract class OpenSSLEvpCipherAES extends OpenSSLEvpCipher {
             }
         }
 
-        static class ECB extends AES_256 {
+        public static class ECB extends AES_256 {
             ECB(Padding padding) {
                 super(Mode.ECB, padding);
             }

--- a/common/src/main/java/org/conscrypt/OpenSSLEvpCipherDESEDE.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEvpCipherDESEDE.java
@@ -22,14 +22,14 @@ import java.util.Locale;
 import javax.crypto.NoSuchPaddingException;
 
 @Internal
-abstract class OpenSSLEvpCipherDESEDE extends OpenSSLEvpCipher {
+public abstract class OpenSSLEvpCipherDESEDE extends OpenSSLEvpCipher {
     private static final int DES_BLOCK_SIZE = 8;
 
     OpenSSLEvpCipherDESEDE(Mode mode, Padding padding) {
         super(mode, padding);
     }
 
-    static class CBC extends OpenSSLEvpCipherDESEDE {
+    public static class CBC extends OpenSSLEvpCipherDESEDE {
         CBC(Padding padding) {
             super(Mode.CBC, padding);
         }


### PR DESCRIPTION
These classes need to be public to accommodate the Android build
visibility infrastructure.