### PR TITLE
Fix implementation of available() in sockets

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -738,8 +738,7 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
             startHandshake();
             synchronized (readLock) {
                 init();
-                return fromEngine.remaining()
-                        + (fromSocket.hasRemaining() || socketInputStream.available() > 0 ? 1 : 0);
+                return fromEngine.remaining();
             }
         }
 

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -558,6 +558,11 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
             }
         }
 
+        @Override
+        public int available() {
+            return ssl.getPendingReadableBytes();
+        }
+
         void awaitPendingOps() {
             if (DBG_STATE) {
                 synchronized (ssl) {

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -236,6 +236,29 @@ public class SSLSocketTest {
     }
 
     @Test
+    public void test_SSLSocket_getInputStream_available() throws Exception {
+        TestSSLSocketPair pair = TestSSLSocketPair.create().connect();
+
+        pair.client.getOutputStream().write(new byte[] { 1, 2, 3, 4 });
+        // We read a single byte first because it's okay if available() returns zero
+        // before we've checked the network to see if any packets are available to
+        // be decrypted, but we should show available bytes once we've decrypted a packet
+        assertEquals(1, pair.server.getInputStream().read());
+        assertTrue(pair.server.getInputStream().available() > 0);
+        assertEquals(3, pair.server.getInputStream().read(new byte[4]));
+        assertEquals(0, pair.server.getInputStream().available());
+
+        pair.server.getOutputStream().write(new byte[] { 1, 2, 3, 4 });
+        // We read a single byte first because it's okay if available() returns zero
+        // before we've checked the network to see if any packets are available to
+        // be decrypted, but we should show available bytes once we've decrypted a packet
+        assertEquals(1, pair.client.getInputStream().read());
+        assertTrue(pair.client.getInputStream().available() > 0);
+        assertEquals(3, pair.client.getInputStream().read(new byte[4]));
+        assertEquals(0, pair.client.getInputStream().available());
+    }
+
+    @Test
     public void test_SSLSocket_getEnabledCipherSuites_returnsCopies() throws Exception {
         SSLSocketFactory sf = (SSLSocketFactory) SSLSocketFactory.getDefault();
         SSLSocket ssl = (SSLSocket) sf.createSocket();


### PR DESCRIPTION
The file descriptor socket used the default implementation of
available(), which just always returns 0.  We can at least return the
pending bytes in the plaintext buffer, since those are definitely
available.

The engine socket had two issues.  First, it used
fromSocket.remaining(), but fromSocket was in a writing posture, so it
always had a high return from remaining() regardless of whether there
was pending readable data in the buffer.  This was the cause of #433:
a BufferedReader would read some data, then check available() to see
if it could freely fill some more data without blocking.  The engine
socket would report that it could, so it would try to read that data
and then unexpectedly block.

The second issue is that incoming socket data doesn't necessarily
imply readable plaintext data: it might be a partial TLS record, a
handshake or other management record, etc.  So we should only report
plaintext data that's actually been successfully decrypted from
available().

Fixes #433