### PR TITLE
Improve testing of KeyFactory classes

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptJava7Suite.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptJava7Suite.java
@@ -30,6 +30,7 @@ import org.conscrypt.java.security.AlgorithmParametersTestGCM;
 import org.conscrypt.java.security.AlgorithmParametersTestOAEP;
 import org.conscrypt.java.security.KeyFactoryTestDH;
 import org.conscrypt.java.security.KeyFactoryTestDSA;
+import org.conscrypt.java.security.KeyFactoryTestEC;
 import org.conscrypt.java.security.KeyFactoryTestRSA;
 import org.conscrypt.java.security.KeyPairGeneratorTest;
 import org.conscrypt.java.security.KeyPairGeneratorTestDH;
@@ -80,6 +81,7 @@ import org.junit.runners.Suite;
         AlgorithmParametersTestOAEP.class,
         KeyFactoryTestDH.class,
         KeyFactoryTestDSA.class,
+        KeyFactoryTestEC.class,
         KeyFactoryTestRSA.class,
         KeyPairGeneratorTest.class,
         KeyPairGeneratorTestDH.class,

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
@@ -30,6 +30,7 @@ import org.conscrypt.java.security.AlgorithmParametersTestGCM;
 import org.conscrypt.java.security.AlgorithmParametersTestOAEP;
 import org.conscrypt.java.security.KeyFactoryTestDH;
 import org.conscrypt.java.security.KeyFactoryTestDSA;
+import org.conscrypt.java.security.KeyFactoryTestEC;
 import org.conscrypt.java.security.KeyFactoryTestRSA;
 import org.conscrypt.java.security.KeyPairGeneratorTest;
 import org.conscrypt.java.security.KeyPairGeneratorTestDH;
@@ -82,6 +83,7 @@ import org.junit.runners.Suite;
         AlgorithmParametersTestOAEP.class,
         KeyFactoryTestDH.class,
         KeyFactoryTestDSA.class,
+        KeyFactoryTestEC.class,
         KeyFactoryTestRSA.class,
         KeyPairGeneratorTest.class,
         KeyPairGeneratorTestDH.class,

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestEC.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestEC.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.java.security;
+
+import java.security.KeyPair;
+import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.ECPublicKeySpec;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class KeyFactoryTestEC extends
+    AbstractKeyFactoryTest<ECPublicKeySpec, ECPrivateKeySpec> {
+
+  public KeyFactoryTestEC() {
+    super("EC", ECPublicKeySpec.class, ECPrivateKeySpec.class);
+  }
+
+  @Override
+  protected void check(KeyPair keyPair) throws Exception {
+    new SignatureHelper("SHA256withECDSA").test(keyPair);
+  }
+}

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
@@ -18,6 +18,7 @@ package org.conscrypt.java.security;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPrivateKeySpec;
@@ -26,12 +27,12 @@ import java.security.spec.X509EncodedKeySpec;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import tests.util.ServiceTester;
 
 @RunWith(JUnit4.class)
 public class KeyFactoryTestRSA extends
         AbstractKeyFactoryTest<RSAPublicKeySpec, RSAPrivateKeySpec> {
 
-    @SuppressWarnings("unchecked")
     public KeyFactoryTestRSA() {
         super("RSA", RSAPublicKeySpec.class, RSAPrivateKeySpec.class);
     }
@@ -43,19 +44,35 @@ public class KeyFactoryTestRSA extends
 
     @Test
     public void testExtraBufferSpace_Private() throws Exception {
-        PrivateKey privateKey = DefaultKeys.getPrivateKey("RSA");
-        byte[] encoded = privateKey.getEncoded();
-        byte[] longBuffer = new byte[encoded.length + 147];
-        System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
-        KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(longBuffer));
+        ServiceTester.test("KeyFactory")
+            .withAlgorithm("RSA")
+            .run(new ServiceTester.Test() {
+                @Override
+                public void test(Provider p, String algorithm) throws Exception {
+                    PrivateKey privateKey = DefaultKeys.getPrivateKey("RSA");
+                    byte[] encoded = privateKey.getEncoded();
+                    byte[] longBuffer = new byte[encoded.length + 147];
+                    System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
+                    KeyFactory.getInstance(algorithm, p).generatePrivate(
+                        new PKCS8EncodedKeySpec(longBuffer));
+                }
+            });
     }
 
     @Test
     public void testExtraBufferSpace_Public() throws Exception {
-        PublicKey publicKey = DefaultKeys.getPublicKey("RSA");
-        byte[] encoded = publicKey.getEncoded();
-        byte[] longBuffer = new byte[encoded.length + 147];
-        System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
-        KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(longBuffer));
+        ServiceTester.test("KeyFactory")
+            .withAlgorithm("RSA")
+            .run(new ServiceTester.Test() {
+                @Override
+                public void test(Provider p, String algorithm) throws Exception {
+                    PublicKey publicKey = DefaultKeys.getPublicKey("RSA");
+                    byte[] encoded = publicKey.getEncoded();
+                    byte[] longBuffer = new byte[encoded.length + 147];
+                    System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
+                    KeyFactory.getInstance(algorithm, p).generatePublic(
+                        new X509EncodedKeySpec(longBuffer));
+                }
+            });
     }
 }

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
@@ -187,13 +187,6 @@ public class KeyPairGeneratorTest {
                 // the uncommon ones.
                 continue;
             }
-            if ("EC".equals(algorithm)
-                    && "SunPKCS11-NSS".equalsIgnoreCase(kpg.getProvider().getName())
-                    && keySize == 224) {
-                // TODO(flooey): Remove when we stop supporting Java 6
-                // This Sun provider doesn't support 224-bit EC keys
-                continue;
-            }
             kpg.initialize(keySize);
             test_KeyPair(kpg, kpg.genKeyPair());
             test_KeyPair(kpg, kpg.generateKeyPair());

--- a/testing/src/main/java/org/conscrypt/java/security/AbstractKeyFactoryTest.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AbstractKeyFactoryTest.java
@@ -42,6 +42,9 @@ public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, Priv
     public void testKeyFactory() throws Exception {
         ServiceTester.test("KeyFactory")
             .withAlgorithm(algorithmName)
+            // On OpenJDK 7, the SunPKCS11-NSS provider sometimes doesn't accept keys created by
+            // other providers in getKeySpec(), so it fails some of the tests.
+            .skipProvider("SunPKCS11-NSS")
             .run(new ServiceTester.Test() {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
@@ -60,6 +63,7 @@ public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, Priv
                     ServiceTester.test("KeyFactory")
                         .withAlgorithm(algorithmName)
                         .skipProvider(p.getName())
+                        .skipProvider("SunPKCS11-NSS")
                         .run(new ServiceTester.Test() {
                             @Override
                             public void test(Provider p2, String algorithm) throws Exception {

--- a/testing/src/main/java/org/conscrypt/java/security/AbstractKeyFactoryTest.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AbstractKeyFactoryTest.java
@@ -18,17 +18,17 @@ package org.conscrypt.java.security;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.spec.KeySpec;
-import org.junit.Before;
 import org.junit.Test;
+import tests.util.ServiceTester;
 
 public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, PrivateKeySpec extends KeySpec> {
 
     private final String algorithmName;
     private final Class<PublicKeySpec> publicKeySpecClass;
     private final Class<PrivateKeySpec> privateKeySpecClass;
-    private KeyFactory factory;
 
     public AbstractKeyFactoryTest(String algorithmName,
             Class<PublicKeySpec> publicKeySpecClass,
@@ -38,24 +38,41 @@ public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, Priv
         this.privateKeySpecClass = privateKeySpecClass;
     }
 
-    @Before
-    public void setUp() throws Exception {
-        factory = getFactory();
-    }
-
-    private KeyFactory getFactory() throws Exception {
-        return KeyFactory.getInstance(algorithmName);
-    }
-
     @Test
     public void testKeyFactory() throws Exception {
-        PrivateKeySpec privateKeySpec = factory.getKeySpec(DefaultKeys.getPrivateKey(algorithmName),
-                                                           privateKeySpecClass);
-        PrivateKey privateKey =  factory.generatePrivate(privateKeySpec);
-        PublicKeySpec publicKeySpec = factory.getKeySpec(DefaultKeys.getPublicKey(algorithmName),
-                                                         publicKeySpecClass);
-        PublicKey publicKey = factory.generatePublic(publicKeySpec);
-        check(new KeyPair(publicKey, privateKey));
+        ServiceTester.test("KeyFactory")
+            .withAlgorithm(algorithmName)
+            .run(new ServiceTester.Test() {
+                @Override
+                public void test(Provider p, String algorithm) throws Exception {
+                    final KeyFactory factory = KeyFactory.getInstance(algorithm, p);
+
+                    final PrivateKeySpec privateKeySpec = factory.getKeySpec(DefaultKeys.getPrivateKey(algorithmName),
+                        privateKeySpecClass);
+                    PrivateKey privateKey = factory.generatePrivate(privateKeySpec);
+                    final PublicKeySpec publicKeySpec = factory.getKeySpec(DefaultKeys.getPublicKey(algorithmName),
+                        publicKeySpecClass);
+                    PublicKey publicKey = factory.generatePublic(publicKeySpec);
+                    check(new KeyPair(publicKey, privateKey));
+
+                    // Test that keys from any other KeyFactory can be translated into working
+                    // keys from this KeyFactory
+                    ServiceTester.test("KeyFactory")
+                        .withAlgorithm(algorithmName)
+                        .skipProvider(p.getName())
+                        .run(new ServiceTester.Test() {
+                            @Override
+                            public void test(Provider p2, String algorithm) throws Exception {
+                                KeyFactory factory2 = KeyFactory.getInstance(algorithm, p2);
+                                PrivateKey privateKey2 = factory2.generatePrivate(privateKeySpec);
+                                PublicKey publicKey2 = factory2.generatePublic(publicKeySpec);
+
+                                check(new KeyPair((PublicKey) factory.translateKey(publicKey2),
+                                    (PrivateKey) factory.translateKey(privateKey2)));
+                            }
+                        });
+                }
+            });
     }
 
     protected void check(KeyPair keyPair) throws Exception {}

--- a/testing/src/main/java/org/conscrypt/java/security/DefaultKeys.java
+++ b/testing/src/main/java/org/conscrypt/java/security/DefaultKeys.java
@@ -24,6 +24,7 @@ import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.HashMap;
+import org.conscrypt.TestUtils;
 
 public class DefaultKeys {
     private static final byte[] RSA_private = new byte[] {
@@ -180,7 +181,13 @@ public class DefaultKeys {
         (byte) 0xA5, (byte) 0xC9, (byte) 0x93, (byte) 0xCE, (byte) 0xC1, (byte) 0x1D, (byte) 0x30, (byte) 0x73, (byte) 0xA3, (byte) 0xE1, (byte) 0x69, (byte) 0xA8, (byte) 0x11, (byte) 0x98, (byte) 0x78, (byte) 0xF3, (byte) 0xF9,
         (byte) 0x8F, (byte) 0x04    };
 
-
+        private static final byte[] EC_private = TestUtils.decodeBase64(
+            "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgXbi5zGvh/MoXidykzJKs1yEbrN99"
+                + "/A3bQy1bMNQR/c2hRANCAAQqgfCMR3JAG/JhR386L6bTmo7XTd1B0oHCPaqPP5+YLzL5wY"
+                + "AbDExaCdzXEljDvrupjn1HfqjZNCVAc0j13QIM");
+        private static final byte[] EC_public = TestUtils.decodeBase64(
+            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKoHwjEdyQBvyYUd/Oi+m05qO103dQdKBwj2qjz+f"
+                + "mC8y+cGAGwxMWgnc1xJYw767qY59R36o2TQlQHNI9d0CDA==");
 
     private static final HashMap<String, KeySpec> keys = new HashMap<String, KeySpec>();
     static {
@@ -190,6 +197,8 @@ public class DefaultKeys {
         keys.put("DSA_private", new PKCS8EncodedKeySpec(DSA_private));
         keys.put("RSA_public", new X509EncodedKeySpec(RSA_public));
         keys.put("RSA_private", new PKCS8EncodedKeySpec(RSA_private));
+        keys.put("EC_public", new X509EncodedKeySpec(EC_public));
+        keys.put("EC_private", new PKCS8EncodedKeySpec(EC_private));
     }
 
     public static PrivateKey getPrivateKey(String algorithmName) throws NoSuchAlgorithmException, InvalidKeySpecException


### PR DESCRIPTION
Adds a test for EC KeyFactory.

Updates AbstractKeyFactoryTest to test factories from all providers,
not just the highest-ranked one.

Adds tests for transform() by building keys from all other providers
and ensuring each provider can transform the other providers' keys
into its own keys.