### PR TITLE
Simplify some tests so they pass on Android

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
@@ -18,7 +18,6 @@ package org.conscrypt.java.security;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.PrivateKey;
-import java.security.Provider;
 import java.security.PublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPrivateKeySpec;
@@ -27,7 +26,6 @@ import java.security.spec.X509EncodedKeySpec;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import tests.util.ServiceTester;
 
 @RunWith(JUnit4.class)
 public class KeyFactoryTestRSA extends
@@ -44,35 +42,19 @@ public class KeyFactoryTestRSA extends
 
     @Test
     public void testExtraBufferSpace_Private() throws Exception {
-        ServiceTester.test("KeyFactory")
-            .withAlgorithm("RSA")
-            .run(new ServiceTester.Test() {
-                @Override
-                public void test(Provider p, String algorithm) throws Exception {
-                    PrivateKey privateKey = DefaultKeys.getPrivateKey("RSA");
-                    byte[] encoded = privateKey.getEncoded();
-                    byte[] longBuffer = new byte[encoded.length + 147];
-                    System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
-                    KeyFactory.getInstance(algorithm, p).generatePrivate(
-                        new PKCS8EncodedKeySpec(longBuffer));
-                }
-            });
+        PrivateKey privateKey = DefaultKeys.getPrivateKey("RSA");
+        byte[] encoded = privateKey.getEncoded();
+        byte[] longBuffer = new byte[encoded.length + 147];
+        System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
+        KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(longBuffer));
     }
 
     @Test
     public void testExtraBufferSpace_Public() throws Exception {
-        ServiceTester.test("KeyFactory")
-            .withAlgorithm("RSA")
-            .run(new ServiceTester.Test() {
-                @Override
-                public void test(Provider p, String algorithm) throws Exception {
-                    PublicKey publicKey = DefaultKeys.getPublicKey("RSA");
-                    byte[] encoded = publicKey.getEncoded();
-                    byte[] longBuffer = new byte[encoded.length + 147];
-                    System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
-                    KeyFactory.getInstance(algorithm, p).generatePublic(
-                        new X509EncodedKeySpec(longBuffer));
-                }
-            });
+        PublicKey publicKey = DefaultKeys.getPublicKey("RSA");
+        byte[] encoded = publicKey.getEncoded();
+        byte[] longBuffer = new byte[encoded.length + 147];
+        System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
+        KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(longBuffer));
     }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/AbstractKeyFactoryTest.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AbstractKeyFactoryTest.java
@@ -45,6 +45,9 @@ public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, Priv
             // On OpenJDK 7, the SunPKCS11-NSS provider sometimes doesn't accept keys created by
             // other providers in getKeySpec(), so it fails some of the tests.
             .skipProvider("SunPKCS11-NSS")
+            // Android Keystore's KeyFactory must be initialized with its own classes, it can't use
+            // the standard init() calls
+            .skipProvider("AndroidKeyStore")
             .run(new ServiceTester.Test() {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
@@ -64,6 +67,7 @@ public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, Priv
                         .withAlgorithm(algorithmName)
                         .skipProvider(p.getName())
                         .skipProvider("SunPKCS11-NSS")
+                        .skipProvider("AndroidKeyStore")
                         .run(new ServiceTester.Test() {
                             @Override
                             public void test(Provider p2, String algorithm) throws Exception {


### PR DESCRIPTION
Android Keystore doesn't work like normal KeyFactories, so ignore it
in AbstractKeyFactoryTest.

Accepting extra buffer space in RSA key parsing is a
backwards-compatibility feature that we want for Conscrypt, but it's
not required that anyone implement it, so return those tests to only
testing the Conscrypt implementation.