### PR TITLE
Add ability to specify default TLS version

### DIFF
--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -134,12 +134,13 @@ public final class Conscrypt {
     @Deprecated
     public static Provider newProvider(String providerName) {
         checkAvailability();
-        return new OpenSSLProvider(providerName, Platform.provideTrustManagerByDefault());
+        return newProviderBuilder().setName(providerName).build();
     }
 
     public static class ProviderBuilder {
         private String name = Platform.getDefaultProviderName();
         private boolean provideTrustManager = Platform.provideTrustManagerByDefault();
+        private String defaultTlsProtocol = NativeCrypto.SUPPORTED_PROTOCOL_TLSV1_3;
 
         private ProviderBuilder() {}
 
@@ -170,8 +171,17 @@ public final class Conscrypt {
             return this;
         }
 
+        /**
+         * Specifies what the default TLS protocol should be for SSLContext identifiers
+         * {@code TLS}, {@code SSL}, and {@code Default}.
+         */
+        public ProviderBuilder defaultTlsProtocol(String defaultTlsProtocol) {
+            this.defaultTlsProtocol = defaultTlsProtocol;
+            return this;
+        }
+
         public Provider build() {
-            return new OpenSSLProvider(name, provideTrustManager);
+            return new OpenSSLProvider(name, provideTrustManager, defaultTlsProtocol);
         }
     }
 

--- a/common/src/main/java/org/conscrypt/DefaultSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/DefaultSSLContextImpl.java
@@ -34,7 +34,7 @@ import javax.net.ssl.TrustManagerFactory;
  * Support class for this package.
  */
 @Internal
-public final class DefaultSSLContextImpl extends OpenSSLContextImpl {
+public class DefaultSSLContextImpl extends OpenSSLContextImpl {
 
     /**
      * Accessed by SSLContextImpl(DefaultSSLContextImpl) holding the
@@ -54,12 +54,12 @@ public final class DefaultSSLContextImpl extends OpenSSLContextImpl {
      * rest of this constructor to guarantee that we don't have races in
      * creating the state shared between all default SSLContexts.
      */
-    public DefaultSSLContextImpl() throws GeneralSecurityException, IOException {
-        super();
+    private DefaultSSLContextImpl(String[] protocols) throws GeneralSecurityException, IOException {
+        super(protocols, true);
     }
 
     // TODO javax.net.ssl.keyStoreProvider system property
-    KeyManager[] getKeyManagers () throws GeneralSecurityException, IOException {
+    KeyManager[] getKeyManagers() throws GeneralSecurityException, IOException {
         if (KEY_MANAGERS != null) {
             return KEY_MANAGERS;
         }
@@ -125,5 +125,17 @@ public final class DefaultSSLContextImpl extends OpenSSLContextImpl {
     public void engineInit(KeyManager[] kms, TrustManager[] tms,
             SecureRandom sr) throws KeyManagementException {
         throw new KeyManagementException("Do not init() the default SSLContext ");
+    }
+
+    public final static class TLSv13 extends DefaultSSLContextImpl {
+        public TLSv13() throws GeneralSecurityException, IOException {
+            super(NativeCrypto.TLSV13_PROTOCOLS);
+        }
+    }
+
+    public final static class TLSv12 extends DefaultSSLContextImpl {
+        public TLSv12() throws GeneralSecurityException, IOException {
+            super(NativeCrypto.TLSV12_PROTOCOLS);
+        }
     }
 }

--- a/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
@@ -45,7 +45,7 @@ public abstract class OpenSSLContextImpl extends SSLContextSpi {
     private static DefaultSSLContextImpl defaultSslContextImpl;
 
     /** TLS algorithm to initialize all sockets. */
-    private final String[] algorithms;
+    private final String[] protocols;
 
     /** Client session cache. */
     private final ClientSessionContext clientSessionContext;
@@ -60,18 +60,20 @@ public abstract class OpenSSLContextImpl extends SSLContextSpi {
         return new TLSv13();
     }
 
-    OpenSSLContextImpl(String[] algorithms) {
-        this.algorithms = algorithms;
+    OpenSSLContextImpl(String[] protocols) {
+        this.protocols = protocols;
         clientSessionContext = new ClientSessionContext();
         serverSessionContext = new ServerSessionContext();
     }
 
     /**
-     * Constuctor for the DefaultSSLContextImpl.
+     * Constuctor for the DefaultSSLContextImpl.  The unused boolean parameter is solely to
+     * indicate that this constructor is desired.
      */
-    OpenSSLContextImpl() throws GeneralSecurityException, IOException {
+    OpenSSLContextImpl(String[] protocols, boolean unused)
+            throws GeneralSecurityException, IOException {
         synchronized (DefaultSSLContextImpl.class) {
-            this.algorithms = null;
+            this.protocols = null;
             if (defaultSslContextImpl == null) {
                 clientSessionContext = new ClientSessionContext();
                 serverSessionContext = new ServerSessionContext();
@@ -84,7 +86,7 @@ public abstract class OpenSSLContextImpl extends SSLContextSpi {
             }
             sslParameters = new SSLParametersImpl(defaultSslContextImpl.getKeyManagers(),
                     defaultSslContextImpl.getTrustManagers(), null, clientSessionContext,
-                    serverSessionContext, algorithms);
+                    serverSessionContext, protocols);
         }
     }
 
@@ -102,7 +104,7 @@ public abstract class OpenSSLContextImpl extends SSLContextSpi {
     public void engineInit(KeyManager[] kms, TrustManager[] tms, SecureRandom sr)
             throws KeyManagementException {
         sslParameters = new SSLParametersImpl(
-                kms, tms, sr, clientSessionContext, serverSessionContext, algorithms);
+                kms, tms, sr, clientSessionContext, serverSessionContext, protocols);
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
@@ -44,7 +44,7 @@ public abstract class OpenSSLContextImpl extends SSLContextSpi {
      */
     private static DefaultSSLContextImpl defaultSslContextImpl;
 
-    /** TLS algorithm to initialize all sockets. */
+    /** TLS protocols to enable by default. */
     private final String[] protocols;
 
     /** Client session cache. */

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -189,12 +189,12 @@ public final class TestUtils {
                 .getDeclaredMethod("getDefaultProviderName")
                 .invoke(null);
             Constructor<?> c = conscryptClass("OpenSSLProvider")
-                .getDeclaredConstructor(String.class, Boolean.TYPE);
+                .getDeclaredConstructor(String.class, Boolean.TYPE, String.class);
 
             if (!isClassAvailable("javax.net.ssl.X509ExtendedTrustManager")) {
-                return (Provider) c.newInstance(defaultName, false);
+                return (Provider) c.newInstance(defaultName, false, "TLSv1.3");
             } else {
-                return (Provider) c.newInstance(defaultName, true);
+                return (Provider) c.newInstance(defaultName, true, "TLSv1.3");
             }
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
In some use cases, it can be helpful for compatibility reasons to have
the default TLS protocol still be TLS 1.2, with 1.3 only enabled by
explicit request.  This allows construction of a provider with a
default protocol of TLS 1.2.