### PR TITLE
Skip BC keys in EC KeyFactory tests

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestEC.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/KeyFactoryTestEC.java
@@ -20,6 +20,7 @@ import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import tests.util.ServiceTester;
 
 @RunWith(JUnit4.class)
 public class KeyFactoryTestEC extends
@@ -27,6 +28,13 @@ public class KeyFactoryTestEC extends
 
   public KeyFactoryTestEC() {
     super("EC", ECPublicKeySpec.class, ECPrivateKeySpec.class);
+  }
+
+  @Override
+  public ServiceTester customizeTester(ServiceTester tester) {
+    // BC's EC keys always use explicit params, even though it's a bad idea, and we don't support
+    // those, so don't test BC keys
+    return tester.skipProvider("BC");
   }
 
   @Override

--- a/testing/src/main/java/org/conscrypt/java/security/AbstractKeyFactoryTest.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AbstractKeyFactoryTest.java
@@ -40,14 +40,14 @@ public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, Priv
 
     @Test
     public void testKeyFactory() throws Exception {
-        ServiceTester.test("KeyFactory")
+        customizeTester(ServiceTester.test("KeyFactory")
             .withAlgorithm(algorithmName)
             // On OpenJDK 7, the SunPKCS11-NSS provider sometimes doesn't accept keys created by
             // other providers in getKeySpec(), so it fails some of the tests.
             .skipProvider("SunPKCS11-NSS")
             // Android Keystore's KeyFactory must be initialized with its own classes, it can't use
             // the standard init() calls
-            .skipProvider("AndroidKeyStore")
+            .skipProvider("AndroidKeyStore"))
             .run(new ServiceTester.Test() {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
@@ -63,11 +63,11 @@ public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, Priv
 
                     // Test that keys from any other KeyFactory can be translated into working
                     // keys from this KeyFactory
-                    ServiceTester.test("KeyFactory")
+                    customizeTester(ServiceTester.test("KeyFactory")
                         .withAlgorithm(algorithmName)
                         .skipProvider(p.getName())
                         .skipProvider("SunPKCS11-NSS")
-                        .skipProvider("AndroidKeyStore")
+                        .skipProvider("AndroidKeyStore"))
                         .run(new ServiceTester.Test() {
                             @Override
                             public void test(Provider p2, String algorithm) throws Exception {
@@ -81,6 +81,10 @@ public abstract class AbstractKeyFactoryTest<PublicKeySpec extends KeySpec, Priv
                         });
                 }
             });
+    }
+
+    protected ServiceTester customizeTester(ServiceTester tester) {
+        return tester;
     }
 
     protected void check(KeyPair keyPair) throws Exception {}


### PR DESCRIPTION
BC keys always encode their group as explicit params instead of as a
curve name, which is barred by RFC 5280 and is generally a bad idea.
We don't support this in general, so don't test the use of BC's EC
keys.