### PR TITLE
Fix engine socket tests

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -16,6 +16,7 @@
 
 package org.conscrypt;
 
+import static javax.net.ssl.SSLEngineResult.Status.CLOSED;
 import static javax.net.ssl.SSLEngineResult.Status.OK;
 import static org.conscrypt.SSLUtils.EngineStates.STATE_CLOSED;
 import static org.conscrypt.SSLUtils.EngineStates.STATE_HANDSHAKE_COMPLETED;
@@ -608,14 +609,13 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
             init();
 
             // Need to loop through at least once to enable handshaking where no application
-            // bytes are
-            // processed.
+            // bytes are processed.
             int len = buffer.remaining();
             SSLEngineResult engineResult;
             do {
                 target.clear();
                 engineResult = engine.wrap(buffer, target);
-                if (engineResult.getStatus() != OK) {
+                if (engineResult.getStatus() != OK && engineResult.getStatus() != CLOSED) {
                     throw new SSLException("Unexpected engine result " + engineResult.getStatus());
                 }
                 if (target.position() != engineResult.bytesProduced()) {

--- a/openjdk-integ-tests/build.gradle
+++ b/openjdk-integ-tests/build.gradle
@@ -42,11 +42,11 @@ test {
     include suiteClass
 }
 
-task testEngineSocket(type: Test, dependsOn: test) {
-    jvmArgs "-Dorg.conscrypt.useEngineSocketByDefault=true"
+task testEngineSocket(type: Test) {
     include suiteClass
     InvokerHelper.setProperties(testLogging, test.testLogging.properties)
     systemProperties = test.systemProperties
+    systemProperty "org.conscrypt.useEngineSocketByDefault", true
 }
 check.dependsOn testEngineSocket
 


### PR DESCRIPTION
The engine test system property was being overwritten, which resulted
in the engine socket test not actually being executed with the engine
socket.  This fixes that problem, so :testEngineSocket now actually
runs with the engine socket.

This revealed several test failures that were all due to the engine
and engine socket closing behavior.  In particular, the engine
wouldn't mark itself as closed when an SSLException was thrown, which
it is supposed to per the documentation.  This meant that when the
engine socket attempted to flush the outgoing buffer, it would just
trigger whatever exception had originally caused the problem again,
the outgoing buffer wouldn't get flushed, and alerts wouldn't reach
the peer.  Closing the engine whenever an exception propagates out
fixes this problem, along with tolerating a CLOSED status return in
the engine socket.