### PR TITLE
Fix tests to not depend on hardware acceleration

### DIFF
--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -31,6 +31,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.KeyManager;
@@ -583,8 +584,15 @@ public class SSLEngineTest {
                         // By the point of the handshake where we're validating certificates,
                         // the hostname is known and the cipher suite should be agreed
                         assertEquals(referenceContext.host.getHostName(), session.getPeerHost());
-                        assertEquals(referenceEngine.getEnabledCipherSuites()[0],
-                            session.getCipherSuite());
+
+                        // The negotiated cipher suite should be one of the enabled ones, but
+                        // BoringSSL may have reordered them based on things like hardware support,
+                        // so we don't know which one may have been negotiated.
+                        String sessionSuite = session.getCipherSuite();
+                        List<String> enabledSuites =
+                            Arrays.asList(referenceEngine.getEnabledCipherSuites());
+                        assertTrue(enabledSuites.contains(sessionSuite));
+
                         wasCalled[0] = true;
                     } catch (Exception e) {
                         throw new CertificateException("Something broke", e);

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -511,8 +511,15 @@ public class SSLSocketTest {
                         // By the point of the handshake where we're validating certificates,
                         // the hostname is known and the cipher suite should be agreed
                         assertEquals(referenceContext.host.getHostName(), session.getPeerHost());
-                        assertEquals(referenceClientSocket.getEnabledCipherSuites()[0],
-                            session.getCipherSuite());
+
+                        // The negotiated cipher suite should be one of the enabled ones, but
+                        // BoringSSL may have reordered them based on things like hardware support,
+                        // so we don't know which one may have been negotiated.
+                        String sessionSuite = session.getCipherSuite();
+                        List<String> enabledSuites =
+                            Arrays.asList(referenceClientSocket.getEnabledCipherSuites());
+                        assertTrue(enabledSuites.contains(sessionSuite));
+
                         wasCalled[0] = true;
                     } catch (Exception e) {
                         throw new CertificateException("Something broke", e);


### PR DESCRIPTION
The priority order of cipher suites for TLS 1.3 depends in part on
things like whether AES hardware acceleration is present.  We delegate
those decisions to BoringSSL, so we only want to check whether the
negotiated suite was enabled rather than the specific suite that was
negotiated.