### PR TITLE
Create lgtm.com configuration file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,21 @@
+# This configuration file is for https://lgtm.com/ code analysis using Semmle.
+
+extraction:
+  java:
+    prepare:
+      packages:
+      - cmake
+      - golang-go
+      - ninja-build
+    after_prepare:
+    - export BORINGSSL_HOME="$LGTM_WORKSPACE/boringssl"
+    - export CXXFLAGS="-std=c++11"
+    - mkdir -p $BORINGSSL_HOME
+    - curl -Lo - https://boringssl.googlesource.com/boringssl/+archive/refs/heads/master.tar.gz | tar zxvfC - $BORINGSSL_HOME
+    - git config --global user.email "semmle-builder@example.com"
+    - git config --global user.name "Semmle Builder"
+    - ( cd $BORINGSSL_HOME ; git init ; git commit --allow-empty -m "Fake repo" )
+    - mkdir $BORINGSSL_HOME/build64 && pushd $BORINGSSL_HOME/build64
+    - cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_ASM_FLAGS=-Wa,--noexecstack -GNinja ..
+    - ninja
+    - popd


### PR DESCRIPTION
The default extractor on lgtm.com fails because we have special steps
that is needed to setup BoringSSL. This pulls some hints out from the
.travis.yml file and translates it to lgtm's configuration file.

The C/C++ extraction still fails, but this gets the Java extraction working.