### PR TITLE
Support OIDs as curve names

### DIFF
--- a/common/src/main/java/org/conscrypt/ECParameters.java
+++ b/common/src/main/java/org/conscrypt/ECParameters.java
@@ -87,7 +87,7 @@ public class ECParameters extends AlgorithmParametersSpi {
         if (aClass == ECParameterSpec.class) {
             return (T) curve.getECParameterSpec();
         } else if (aClass == ECGenParameterSpec.class) {
-            return (T) new ECGenParameterSpec(Platform.getCurveName(curve.getECParameterSpec()));
+            return (T) new ECGenParameterSpec(curve.getCurveName());
         } else {
             throw new InvalidParameterSpecException("Unsupported class: " + aClass);
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLECGroupContext.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECGroupContext.java
@@ -24,11 +24,26 @@ import java.security.spec.ECFieldFp;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.EllipticCurve;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents a BoringSSL EC_GROUP object.
  */
 final class OpenSSLECGroupContext {
+    private static final Map<String, String> ALIASES = new HashMap<>();
+    static {
+        // Workaround for OpenSSL not supporting SECG names for NIST P-256 (aka
+        // ANSI X9.62 prime256v1).
+        ALIASES.put("secp256r1", "prime256v1");
+        // OpenJDK uses string OIDs as names in lots of places, and expects them to
+        // be accepted in ECGenParameterSpec as well, so accept those
+        ALIASES.put("1.3.132.0.33", "secp224r1");
+        ALIASES.put("1.3.132.0.34", "secp384r1");
+        ALIASES.put("1.3.132.0.35", "secp521r1");
+        ALIASES.put("1.2.840.10045.3.1.7", "prime256r1");
+    }
+
     private final NativeRef.EC_GROUP groupCtx;
 
     OpenSSLECGroupContext(NativeRef.EC_GROUP groupCtx) {
@@ -36,10 +51,8 @@ final class OpenSSLECGroupContext {
     }
 
     static OpenSSLECGroupContext getCurveByName(String curveName) {
-        // Workaround for OpenSSL not supporting SECG names for NIST P-256 (aka
-        // ANSI X9.62 prime256v1).
-        if ("secp256r1".equals(curveName)) {
-            curveName = "prime256v1";
+        if (ALIASES.containsKey(curveName)) {
+            curveName = ALIASES.get(curveName);
         }
 
         final long ctx = NativeCrypto.EC_GROUP_new_by_curve_name(curveName);
@@ -152,6 +165,10 @@ final class OpenSSLECGroupContext {
         NativeRef.EC_GROUP groupRef = new NativeRef.EC_GROUP(group);
 
         return new OpenSSLECGroupContext(groupRef);
+    }
+
+    String getCurveName() {
+        return NativeCrypto.EC_GROUP_get_curve_name(groupCtx);
     }
 
     ECParameterSpec getECParameterSpec() {

--- a/common/src/main/java/org/conscrypt/OpenSSLECGroupContext.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECGroupContext.java
@@ -41,7 +41,7 @@ final class OpenSSLECGroupContext {
         ALIASES.put("1.3.132.0.33", "secp224r1");
         ALIASES.put("1.3.132.0.34", "secp384r1");
         ALIASES.put("1.3.132.0.35", "secp521r1");
-        ALIASES.put("1.2.840.10045.3.1.7", "prime256r1");
+        ALIASES.put("1.2.840.10045.3.1.7", "prime256v1");
     }
 
     private final NativeRef.EC_GROUP groupCtx;

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptJava7Suite.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptJava7Suite.java
@@ -26,6 +26,7 @@ import org.conscrypt.java.security.AlgorithmParametersTestDES;
 import org.conscrypt.java.security.AlgorithmParametersTestDESede;
 import org.conscrypt.java.security.AlgorithmParametersTestDH;
 import org.conscrypt.java.security.AlgorithmParametersTestDSA;
+import org.conscrypt.java.security.AlgorithmParametersTestEC;
 import org.conscrypt.java.security.AlgorithmParametersTestGCM;
 import org.conscrypt.java.security.AlgorithmParametersTestOAEP;
 import org.conscrypt.java.security.KeyFactoryTestDH;
@@ -79,6 +80,7 @@ import org.junit.runners.Suite;
         AlgorithmParametersTestDESede.class,
         AlgorithmParametersTestDH.class,
         AlgorithmParametersTestDSA.class,
+        AlgorithmParametersTestEC.class,
         AlgorithmParametersTestGCM.class,
         AlgorithmParametersTestOAEP.class,
         KeyFactoryTestDH.class,

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/ConscryptSuite.java
@@ -26,6 +26,7 @@ import org.conscrypt.java.security.AlgorithmParametersTestDES;
 import org.conscrypt.java.security.AlgorithmParametersTestDESede;
 import org.conscrypt.java.security.AlgorithmParametersTestDH;
 import org.conscrypt.java.security.AlgorithmParametersTestDSA;
+import org.conscrypt.java.security.AlgorithmParametersTestEC;
 import org.conscrypt.java.security.AlgorithmParametersTestGCM;
 import org.conscrypt.java.security.AlgorithmParametersTestOAEP;
 import org.conscrypt.java.security.KeyFactoryTestDH;
@@ -81,6 +82,7 @@ import org.junit.runners.Suite;
         AlgorithmParametersTestDESede.class,
         AlgorithmParametersTestDH.class,
         AlgorithmParametersTestDSA.class,
+        AlgorithmParametersTestEC.class,
         AlgorithmParametersTestGCM.class,
         AlgorithmParametersTestOAEP.class,
         KeyFactoryTestDH.class,

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestEC.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestEC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 The Android Open Source Project
+ * Copyright (C) 2019 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestEC.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestEC.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.java.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.security.AlgorithmParameters;
+import java.security.Provider;
+import java.security.spec.ECGenParameterSpec;
+import org.conscrypt.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import tests.util.ServiceTester;
+
+@RunWith(JUnit4.class)
+public class AlgorithmParametersTestEC extends AbstractAlgorithmParametersTest {
+
+    private static final String CURVE_NAME = "secp384r1";
+    private static final String CURVE_OID = "1.3.132.0.34";
+
+    // See README.ASN1 for how to understand and reproduce this data
+
+    // asn1=OID:1.3.132.0.34
+    private static final String ENCODED_DATA = "BgUrgQQAIg==";
+
+    public AlgorithmParametersTestEC() {
+        super("EC", new AlgorithmParameterSignatureHelper<>(
+            "SHA256withECDSA", "EC", ECGenParameterSpec.class),
+            new ECGenParameterSpec(CURVE_NAME));
+    }
+
+    @Test
+    public void testEncoding() throws Exception {
+        ServiceTester.test("AlgorithmParameters")
+            .withAlgorithm("EC")
+            .run(new ServiceTester.Test() {
+                @Override
+                public void test(Provider p, String algorithm) throws Exception {
+                    AlgorithmParameters params = AlgorithmParameters.getInstance("EC", p);
+                    params.init(new ECGenParameterSpec(CURVE_NAME));
+                    assertEquals(ENCODED_DATA, TestUtils.encodeBase64(params.getEncoded()));
+
+                    params = AlgorithmParameters.getInstance("EC", p);
+                    params.init(new ECGenParameterSpec(CURVE_OID));
+                    assertEquals(ENCODED_DATA, TestUtils.encodeBase64(params.getEncoded()));
+
+                    params = AlgorithmParameters.getInstance("EC", p);
+                    params.init(TestUtils.decodeBase64(ENCODED_DATA));
+                    String name = params.getParameterSpec(ECGenParameterSpec.class).getName();
+                    assertTrue(CURVE_NAME.equals(name) || CURVE_OID.equals(name));
+                }
+            });
+    }
+
+}

--- a/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestEC.java
+++ b/openjdk-integ-tests/src/test/java/org/conscrypt/java/security/AlgorithmParametersTestEC.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.assertTrue;
 import java.security.AlgorithmParameters;
 import java.security.Provider;
 import java.security.spec.ECGenParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+import java.util.Arrays;
+import java.util.List;
 import org.conscrypt.TestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,6 +68,35 @@ public class AlgorithmParametersTestEC extends AbstractAlgorithmParametersTest {
                     assertTrue(CURVE_NAME.equals(name) || CURVE_OID.equals(name));
                 }
             });
+    }
+
+    // This should be an exhaustive list of all curves that are supported in Conscrypt
+    private static final List<String> SUPPORTED_CURVES =
+        Arrays.asList("secp224r1", "secp256r1", "secp384r1", "secp521r1", "prime256v1",
+            "1.3.132.0.33", "1.3.132.0.34", "1.3.132.0.35", "1.2.840.10045.3.1.7");
+
+    // A selection of curves that aren't supported
+    private static final List<String> UNSUPPORTED_CURVES =
+        Arrays.asList("secp192r1", "secp256k1", "prime192v1", "curve25519", "x25519",
+            "1.2.840.10045.3.1.1", "1.3.132.0.10");
+
+    @Test
+    public void testCurveSupport() throws Exception {
+        AlgorithmParameterSignatureHelper<ECGenParameterSpec> helper =
+            new AlgorithmParameterSignatureHelper<>(
+                "SHA256withECDSA", "EC", ECGenParameterSpec.class);
+        for (String curve : SUPPORTED_CURVES) {
+            AlgorithmParameters params = AlgorithmParameters.getInstance("EC");
+            params.init(new ECGenParameterSpec(curve));
+            helper.test(params);
+        }
+        for (String curve : UNSUPPORTED_CURVES) {
+            try {
+                AlgorithmParameters params = AlgorithmParameters.getInstance("EC");
+                params.init(new ECGenParameterSpec(curve));
+            } catch (InvalidParameterSpecException expected) {
+            }
+        }
     }
 
 }

--- a/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSignatureHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSignatureHelper.java
@@ -28,11 +28,20 @@ public class AlgorithmParameterSignatureHelper<T extends AlgorithmParameterSpec>
         extends TestHelper<AlgorithmParameters> {
 
     private final String algorithmName;
+    private final String keyPairAlgorithmName;
     private final String plainData = "some data do sign and verify";
     private final Class<T> parameterSpecClass;
 
     public AlgorithmParameterSignatureHelper(String algorithmName, Class<T> parameterSpecCla1ss) {
         this.algorithmName = algorithmName;
+        this.keyPairAlgorithmName = algorithmName;
+        this.parameterSpecClass = parameterSpecCla1ss;
+    }
+
+    public AlgorithmParameterSignatureHelper(String algorithmName, String keyPairAlgorithmName,
+            Class<T> parameterSpecCla1ss) {
+        this.algorithmName = algorithmName;
+        this.keyPairAlgorithmName = keyPairAlgorithmName;
         this.parameterSpecClass = parameterSpecCla1ss;
     }
 
@@ -40,7 +49,7 @@ public class AlgorithmParameterSignatureHelper<T extends AlgorithmParameterSpec>
     public void test(AlgorithmParameters parameters) throws Exception {
         Signature signature = Signature.getInstance(algorithmName);
         T parameterSpec = parameters.getParameterSpec(parameterSpecClass);
-        KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithmName);
+        KeyPairGenerator generator = KeyPairGenerator.getInstance(keyPairAlgorithmName);
 
         generator.initialize(parameterSpec);
         KeyPair keyPair = generator.genKeyPair();

--- a/testing/src/main/java/tests/util/ServiceTester.java
+++ b/testing/src/main/java/tests/util/ServiceTester.java
@@ -164,7 +164,7 @@ public final class ServiceTester {
   private void doTest(Test test, Provider p, String algorithm, PrintStream errors) {
     try {
       test.test(p, algorithm);
-    } catch (Exception e) {
+    } catch (Exception|AssertionError e) {
       errors.append("Failure testing " + service + ":" + algorithm
           + " from provider " + p.getName() + ":\n");
       e.printStackTrace(errors);


### PR DESCRIPTION
OpenJDK's providers insist on using curve OIDs in ECGenParameterSpec
instances, which doesn't seem right to me (ECGenParameterSpec says it
contains a "standard or predefined name"), but interoperability
suggests we should accept it anyway.

Also add tests for our EC AlgorithmParameters implementation, which
were missing.