### PR TITLE
Migrate to using maven-publish plugin

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -10,10 +10,10 @@ Then to build, run:
 $ ./gradlew build
 ```
 
-To install the artifacts to your Maven local repository for use in your own project, run:
+To publish the artifacts to your Maven local repository for use in your own project, run:
 
 ```bash
-$ ./gradlew install
+$ ./gradlew publishToMavenLocal
 ```
 
 Prerequisites

--- a/android-stub/build.gradle
+++ b/android-stub/build.gradle
@@ -7,8 +7,3 @@ targetCompatibility = androidMinJavaVersion
 dependencies {
     compileOnly project(':conscrypt-libcore-stub')
 }
-
-// Don't include this artifact in the distribution.
-tasks.install.enabled = false
-tasks.uploadArchives.enabled = false;
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.dcendents.android-maven' version '2.1'
+    id 'digital.wup.android-maven-publish' version '3.6.2'
 }
 
 description = 'Conscrypt: Android'
@@ -25,7 +25,6 @@ ext {
 
 if (androidSdkInstalled) {
     apply plugin: 'com.android.library'
-    apply plugin: 'com.github.dcendents.android-maven'
 
     // Since we're not taking a direct dependency on the constants module, we need to add an
     // explicit task dependency to make sure the code is generated.
@@ -153,64 +152,12 @@ if (androidSdkInstalled) {
         from android.sourceSets.main.java.srcDirs
     }
 
-    artifacts {
-        archives sourcesJar
-        archives javadocsJar
+    apply from: "$rootDir/gradle/publishing.gradle"
+    publishing.publications.maven {
+        from components.android
+        artifact sourcesJar
+        artifact javadocsJar
     }
-
-    uploadArchives.repositories.mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-        String stagingUrl
-        if (rootProject.hasProperty('repositoryId')) {
-            stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
-                    rootProject.repositoryId
-        } else {
-            stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-        }
-        def configureAuth = {
-            if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
-                authentication(userName: rootProject.ossrhUsername, password: rootProject.ossrhPassword)
-            }
-        }
-        repository(url: stagingUrl, configureAuth)
-        snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/', configureAuth)
-    }
-
-    [
-            install.repositories.mavenInstaller,
-            uploadArchives.repositories.mavenDeployer,
-    ]*.pom*.whenConfigured { pom ->
-        pom.project {
-            name "$project.group:$project.name"
-            description project.description
-            url 'https://conscrypt.org/'
-
-            scm {
-                connection 'scm:git:https://github.com/google/conscrypt.git'
-                developerConnection 'scm:git:git@github.com:google/conscrypt.git'
-                url 'https://github.com/google/conscrypt'
-            }
-
-            licenses {
-                license {
-                    name 'Apache 2'
-                    url 'https://www.apache.org/licenses/LICENSE-2.0'
-                }
-            }
-
-            developers {
-                developer {
-                    id "conscrypt"
-                    name "Conscrypt Contributors"
-                    email "conscrypt@googlegroups.com"
-                    url "https://conscrypt.org/"
-                    organization = "Google, Inc."
-                    organizationUrl "https://www.google.com"
-                }
-            }
-        }
-    }
-
 } else {
     logger.warn('Android SDK has not been detected. The Android module will not be built.')
 

--- a/api-doclet/build.gradle
+++ b/api-doclet/build.gradle
@@ -3,7 +3,3 @@ description = 'Conscrypt: API Doclet'
 dependencies {
     compile fileTree(dir: "${System.properties['java.home']}/../lib", include: '*tools.jar')
 }
-
-// Don't include this artifact in the distribution.
-tasks.install.enabled = false
-tasks.uploadArchives.enabled = false;

--- a/benchmark-base/build.gradle
+++ b/benchmark-base/build.gradle
@@ -8,7 +8,3 @@ dependencies {
     compile project(':conscrypt-testing'),
             libraries.junit
 }
-
-// Don't include this artifact in the distribution.
-tasks.install.enabled = false
-tasks.uploadArchives.enabled = false;

--- a/benchmark-graphs/build.gradle
+++ b/benchmark-graphs/build.gradle
@@ -10,7 +10,3 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 mainClassName = 'org.conscrypt.graphgen.Main'
-
-// Don't include this artifact in the distribution.
-tasks.install.enabled = false
-tasks.uploadArchives.enabled = false;

--- a/benchmark-jmh/build.gradle
+++ b/benchmark-jmh/build.gradle
@@ -103,7 +103,3 @@ def parseParams(s) {
         [ (pair.first().trim()) : pair.last().split(",").collect { it.trim() } ]
     }
 }
-
-// Don't include this artifact in the distribution.
-tasks.install.enabled = false
-tasks.uploadArchives.enabled = false;

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,10 @@ buildscript {
 }
 
 plugins {
-  // Add dependency for build script so we can access Git from our
-  // build script.
-  id 'org.ajoberstar.grgit' version '2.2.1'
-  id 'net.ltgt.errorprone' version '0.0.11'
+    // Add dependency for build script so we can access Git from our
+    // build script.
+    id 'org.ajoberstar.grgit' version '2.2.1'
+    id 'net.ltgt.errorprone' version '0.0.11'
 }
 
 subprojects {
@@ -41,8 +41,6 @@ subprojects {
             }
         }
     }
-    apply plugin: "maven"
-    apply plugin: "signing"
     apply plugin: "idea"
     apply plugin: "jacoco"
     apply plugin: "net.ltgt.errorprone"
@@ -142,19 +140,6 @@ subprojects {
         jcenter()
     }
 
-    signing {
-        required false
-        sign configurations.archives
-    }
-
-    signArchives.doFirst {
-        configurations.archives.allArtifacts.each {
-            if (it.type == 'jar' && it.classifier != 'sources' && it.classifier != 'javadoc') {
-                signJar(it.file.absolutePath)
-            }
-        }
-    }
-
     jacoco {
         toolVersion = "0.8.4"
     }
@@ -218,64 +203,6 @@ subprojects {
         task sourcesJar(type: Jar) {
             classifier = 'sources'
             from sourceSets.main.allSource
-        }
-
-        artifacts {
-            archives sourcesJar
-            archives javadocJar
-        }
-
-        uploadArchives.repositories.mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-            String stagingUrl
-            if (rootProject.hasProperty('repositoryId')) {
-                stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
-                        rootProject.repositoryId
-            } else {
-                stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            }
-            def configureAuth = {
-                if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
-                    authentication(userName: rootProject.ossrhUsername, password: rootProject.ossrhPassword)
-                }
-            }
-            repository(url: stagingUrl, configureAuth)
-            snapshotRepository(url: 'https://oss.sonatype.org/content/repositories/snapshots/', configureAuth)
-        }
-
-        [
-                install.repositories.mavenInstaller,
-                uploadArchives.repositories.mavenDeployer,
-        ]*.pom*.whenConfigured { pom ->
-            pom.project {
-                name "$project.group:$project.name"
-                description project.description
-                url 'https://conscrypt.org/'
-
-                scm {
-                    connection 'scm:git:https://github.com/google/conscrypt.git'
-                    developerConnection 'scm:git:git@github.com:google/conscrypt.git'
-                    url 'https://github.com/google/conscrypt'
-                }
-
-                licenses {
-                    license {
-                        name 'Apache 2'
-                        url 'https://www.apache.org/licenses/LICENSE-2.0'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id "conscrypt"
-                        name "Conscrypt Contributors"
-                        email "conscrypt@googlegroups.com"
-                        url "https://conscrypt.org/"
-                        organization = "Google, Inc."
-                        organizationUrl "https://www.google.com"
-                    }
-                }
-            }
         }
 
         // At a test failure, log the stack trace to the console so that we don't

--- a/constants/build.gradle
+++ b/constants/build.gradle
@@ -22,11 +22,6 @@ dependencies {
     }
 }
 
-// Generate sources JAR
-artifacts {
-    archives sourcesJar
-}
-
 model {
     components {
         // Builds exe/ which generates the content of NativeConstants.java
@@ -74,11 +69,6 @@ model {
         }
     }
 }
-
-
-// Don't include this artifact in the distribution.
-tasks.install.enabled = false
-tasks.uploadArchives.enabled = false;
 
 // Disable the javadoc task.
 tasks.withType(Javadoc).all { enabled = false }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,70 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+def isSnapshot = project.version.contains('SNAPSHOT')
+
+signing {
+    required false
+    sign publishing.publications
+}
+
+task("signPublications").doFirst {
+    configurations.archives.allArtifacts.each {
+        if (it.type == 'jar' && it.classifier != 'sources' && it.classifier != 'javadoc') {
+            signJar(it.file.absolutePath)
+        }
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            pom {
+                afterEvaluate {
+                    name = "$project.group:$project.name" as String
+                    description = project.description
+                }
+
+                url = 'https://conscrypt.org/'
+
+                scm {
+                    connection = 'scm:git:https://github.com/google/conscrypt.git'
+                    developerConnection = 'scm:git:git@github.com:google/conscrypt.git'
+                    url = 'https://github.com/google/conscrypt'
+                }
+
+                licenses {
+                    license {
+                        name = 'Apache 2'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'conscrypt'
+                        name = 'Conscrypt Contributors'
+                        email = 'conscrypt@googlegroups.com'
+                        url = 'https://conscrypt.org/'
+                        organization = 'Google, Inc.'
+                        organizationUrl = 'https://www.google.com'
+                    }
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            def snapshotUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            def stagingUrl = rootProject.hasProperty('repositoryId') ? \
+                'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' : \
+                'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            url isSnapshot ? snapshotUrl : stagingUrl
+            credentials {
+                username = rootProject.findProperty('ossrhUsername') ?: ''
+                password = rootProject.findProperty('ossrhPassword') ?: ''
+            }
+        }
+    }
+}

--- a/libcore-stub/build.gradle
+++ b/libcore-stub/build.gradle
@@ -19,7 +19,3 @@ javadoc {
     options.doclet = "org.conscrypt.doclet.FilterDoclet"
     options.docletpath = configurations.publicApiDocs.files as List
 }
-
-// Don't include this artifact in the distribution.
-tasks.install.enabled = false
-tasks.uploadArchives.enabled = false;

--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -75,10 +75,16 @@ if (buildUberJar) {
                     'Bundle-SymbolicName': 'org.conscrypt',
                     '-exportcontents': 'org.conscrypt.*')
     }
+
+    apply from: "$rootDir/gradle/publishing.gradle"
+    publishing.publications.maven {
+        from components.java
+        artifact sourcesJar
+        artifact jar
+    }
 } else {
     // Not building an uber jar - disable all tasks.
     tasks.collect {
         it.enabled = false
     }
 }
-

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -148,6 +148,13 @@ artifacts {
     platform platformJar
 }
 
+apply from: "$rootDir/gradle/publishing.gradle"
+publishing.publications.maven {
+    from components.java
+    artifact sourcesJar
+    artifact javadocJar
+}
+
 jar.manifest {
     attributes ('BoringSSL-Version' : boringSslVersion,
                 'Automatic-Module-Name' : 'org.conscrypt',
@@ -159,8 +166,8 @@ dependencies {
     // This is used for the @Internal annotation processing in JavaDoc
     publicApiDocs project(':conscrypt-api-doclet')
 
-    compileOnly project(':conscrypt-constants'),
-                configurations.publicApiDocs
+    // This is listed as compile-only, but we absorb its contents.
+    compileOnly project(':conscrypt-constants')
 
     testImplementation project(':conscrypt-constants'),
             project(':conscrypt-testing'),

--- a/release/README.md
+++ b/release/README.md
@@ -163,7 +163,7 @@ on Linux.
    ```bash
    $ git checkout 1.0.x
    $ ./gradlew conscrypt-openjdk:build
-   $ ./gradlew -Dorg.gradle.parallel=false uploadArchives
+   $ ./gradlew -Dorg.gradle.parallel=false publish
    ```
 1. Note the BoringSSL commit used for this build.
    ```bash
@@ -189,7 +189,7 @@ See [BUILDING](../BUILDING.md) for instructions for setting up the build environ
 1. Build the code and upload it to the staging repository noted previously.
    ```bash
    $ ./gradlew conscrypt-openjdk:build
-   $ ./gradlew conscrypt-openjdk:uploadArchives -Dorg.gradle.parallel=false -PrepositoryId=<repository-id>
+   $ ./gradlew conscrypt-openjdk:publish -Dorg.gradle.parallel=false -PrepositoryId=<repository-id>
    ```
    (Omit the `./` for the Windows build.)
 
@@ -213,7 +213,7 @@ the Android SDK installed, do the following:
 1. Build the code.
    ```bash
    $ ./gradlew conscrypt-android:build
-   $ ./gradlew conscrypt-android:uploadArchives -Dorg.gradle.parallel=false
+   $ ./gradlew conscrypt-android:publish -Dorg.gradle.parallel=false
    ```
 1. Visit the OSSRH site and close and release the repository.
 
@@ -227,7 +227,7 @@ and build the Uber jar.
    # If you left the container, reattach to it
    $ docker container attach {CONTAINER_ID}
    $ ./gradlew conscrypt-openjdk-uber:build -Dorg.conscrypt.openjdk.buildUberJar=true
-   $ ./gradlew conscrypt-openjdk-uber:uploadArchives -Dorg.gradle.parallel=false -Dorg.conscrypt.openjdk.buildUberJar=true
+   $ ./gradlew conscrypt-openjdk-uber:publish -Dorg.gradle.parallel=false -Dorg.conscrypt.openjdk.buildUberJar=true
    ```
 1. Visit the OSSRH site and close and release the repository.
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,3 +26,5 @@ project(':conscrypt-libcore-stub').projectDir = "$rootDir/libcore-stub" as File
 project(':conscrypt-openjdk').projectDir = "$rootDir/openjdk" as File
 project(':conscrypt-openjdk-uber').projectDir = "$rootDir/openjdk-uber" as File
 project(':conscrypt-testing').projectDir = "$rootDir/testing" as File
+
+enableFeaturePreview('STABLE_PUBLISHING')

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -16,7 +16,3 @@ dependencies {
             libraries.bouncycastle_apis,
             libraries.bouncycastle_provider
 }
-
-// Don't include this artifact in the distribution.
-tasks.install.enabled = false
-tasks.uploadArchives.enabled = false;


### PR DESCRIPTION
The old Gradle "maven" plugin has been deprecated and the new way of publishing
is "maven-publish." Switch to that in order to be able to update to newer versions
of Gradle. The plugins supporting Android with Gradle publishing have stopped
development, so upgrading to a newer Gradle version becomes difficult without
doing this first.