### PR TITLE
Avoid holding a GlobalRef to ALPN selector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: android
+language: minimal
 
 env:
   global:
@@ -17,17 +17,19 @@ matrix:
     ### Linux build is the only platform that builds Android here.
     ###
     - os: linux
-      dist: bionic
-      jdk: openjdk8
+      dist: xenial
 
       env:
         - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
         - ANDROID_HOME="$HOME/android-sdk-linux"
         - ANDROID_NDK_HOME="$ANDROID_HOME/ndk-bundle"
+        - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
         - JAVA7_HOME=/usr/lib/jvm/java-7-openjdk-amd64
         - JAVA11_HOME=/usr/lib/jvm/java-11-openjdk-amd64
         - CC=clang-5.0
         - CXX=clang++-5.0
+        - PATH="$JAVA_HOME/bin:$PATH"
+        - TERM=dumb # to stop verbose build output
 
       before_install:
         - curl -L $ANDROID_TOOLS_URL -o $HOME/tools.zip
@@ -43,11 +45,13 @@ matrix:
         - $ANDROID_HOME/tools/bin/sdkmanager 'extras;android;m2repository' | tr '\r' '\n' | uniq
         - $ANDROID_HOME/tools/bin/sdkmanager ndk-bundle | tr '\r' '\n' | uniq
         - $ANDROID_HOME/tools/bin/sdkmanager 'cmake;3.6.4111459' | tr '\r' '\n' | uniq
+        - gimme 1.13 # Needed for BoringSSL build
+        - source ~/.gimme/envs/go1.13.env
 
       addons:
         apt:
           sources:
-            - llvm-toolchain-trusty-5.0
+            - llvm-toolchain-xenial-5.0
             - openjdk-r-java
             - ubuntu-toolchain-r-test
           packages:
@@ -60,6 +64,7 @@ matrix:
             - linux-libc-dev
             - ninja-build
             - openjdk-7-jre # for running tests with Java 7
+            - openjdk-8-jdk # for building
             - openjdk-11-jre # for running tests with Java 11
 
     ###
@@ -70,6 +75,7 @@ matrix:
       env:
         - CC=clang
         - CXX=clang++
+        - TERM=dumb # to stop verbose build output
 
       before_install:
         - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: android
-dist: trusty
 
 env:
   global:
@@ -18,6 +17,7 @@ matrix:
     ### Linux build is the only platform that builds Android here.
     ###
     - os: linux
+      dist: bionic
       jdk: openjdk8
 
       env:
@@ -57,6 +57,7 @@ matrix:
             - gcc-multilib
             - libc6-dev-i386
             - libc6-dev:i386
+            - linux-libc-dev
             - ninja-build
             - openjdk-7-jre # for running tests with Java 7
             - openjdk-11-jre # for running tests with Java 11

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -6115,12 +6115,8 @@ static ssl_verify_result_t cert_verify_callback(SSL* ssl, CONSCRYPT_UNUSED uint8
 
     JNI_TRACE("ssl=%p cert_verify_callback calling verifyCertificateChain authMethod=%s", ssl,
               authMethod);
-    jstring authMethodString = env->NewStringUTF(authMethod);
-    env->CallVoidMethod(sslHandshakeCallbacks, methodID, array.get(), authMethodString);
-
-    // We need to delete the local references so we not leak memory as this method is called
-    // via callback.
-    env->DeleteLocalRef(authMethodString);
+    ScopedLocalRef<jstring> authMethodString(env, env->NewStringUTF(authMethod));
+    env->CallVoidMethod(sslHandshakeCallbacks, methodID, array.get(), authMethodString.get());
 
     ssl_verify_result_t result = env->ExceptionCheck() ? ssl_verify_invalid : ssl_verify_ok;
     JNI_TRACE("ssl=%p cert_verify_callback => %d", ssl, result);

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1762,6 +1762,15 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     }
 
     @Override
+    public int selectApplicationProtocol(byte[] protocols) {
+        ApplicationProtocolSelectorAdapter adapter = sslParameters.getApplicationProtocolSelector();
+        if (adapter == null) {
+            return NativeConstants.SSL_TLSEXT_ERR_NOACK;
+        }
+        return adapter.selectApplicationProtocol(protocols);
+    }
+
+    @Override
     public String getApplicationProtocol() {
         return SSLUtils.toProtocolString(ssl.getApplicationProtocol());
     }

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -1098,6 +1098,15 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     }
 
     @Override
+    public int selectApplicationProtocol(byte[] protocols) {
+        ApplicationProtocolSelectorAdapter adapter = sslParameters.getApplicationProtocolSelector();
+        if (adapter == null) {
+            return NativeConstants.SSL_TLSEXT_ERR_NOACK;
+        }
+        return adapter.selectApplicationProtocol(protocols);
+    }
+
+    @Override
     final void setApplicationProtocols(String[] protocols) {
         sslParameters.setApplicationProtocols(protocols);
     }

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1289,6 +1289,16 @@ public final class NativeCrypto {
          * @return the cached session or {@code 0} if no session was found matching the given ID.
          */
         @SuppressWarnings("unused") long serverSessionRequested(byte[] id);
+
+        /**
+         * Called when acting as a server, the socket has an {@link
+         * ApplicationProtocolSelectorAdapter} associated with it,  and the application protocol
+         * needs to be selected.
+         *
+         * @param applicationProtocols list of application protocols in length-prefix format
+         * @return the index offset of the selected protocol
+         */
+        @SuppressWarnings("unused") int selectApplicationProtocol(byte[] applicationProtocols);
     }
 
     static native String SSL_CIPHER_get_kx_name(long cipherAddress);
@@ -1330,12 +1340,13 @@ public final class NativeCrypto {
             long ssl, NativeSsl ssl_holder, boolean client, byte[] protocols) throws IOException;
 
     /**
-     * Called for a server endpoint only. Enables ALPN and sets a BiFunction that will
-     * be called to delegate protocol selection to the application. Calling this method overrides
+     * Called for a server endpoint only. Enables ALPN and indicates that the {@link
+     * SSLHandshakeCallbacks#selectApplicationProtocol} will be called to select the
+     * correct protocol during a handshake. Calling this method overrides
      * {@link #setApplicationProtocols(long, NativeSsl, boolean, byte[])}.
      */
-    static native void setApplicationProtocolSelector(
-            long ssl, NativeSsl ssl_holder, ApplicationProtocolSelectorAdapter selector) throws IOException;
+    static native void setHasApplicationProtocolSelector(long ssl, NativeSsl ssl_holder, boolean hasSelector)
+            throws IOException;
 
     /**
      * Returns the selected ALPN protocol. If the server did not select a

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -319,7 +319,7 @@ final class NativeSsl {
             NativeCrypto.setApplicationProtocols(ssl, this, isClient(), parameters.applicationProtocols);
         }
         if (!isClient() && parameters.applicationProtocolSelector != null) {
-            NativeCrypto.setApplicationProtocolSelector(ssl, this, parameters.applicationProtocolSelector);
+            NativeCrypto.setHasApplicationProtocolSelector(ssl, this, true);
         }
 
         // setup server certificates and private keys.

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -308,6 +308,13 @@ final class SSLParametersImpl implements Cloneable {
     }
 
     /**
+     * Returns the application protocol (ALPN) selector for this socket.
+     */
+    ApplicationProtocolSelectorAdapter getApplicationProtocolSelector() {
+        return applicationProtocolSelector;
+    }
+
+    /**
      * Tunes the peer holding this parameters to work in client mode.
      * @param   mode if the peer is configured to work in client mode
      */

--- a/constants/src/gen/cpp/generate_constants.cc
+++ b/constants/src/gen/cpp/generate_constants.cc
@@ -15,6 +15,7 @@
 /* This program generates output that is expected to become
  * NativeConstants.java. This reifies several OpenSSL constants into Java. */
 
+#include <openssl/tls1.h>
 #include <stdio.h>
 
 #include <openssl/ec.h>
@@ -76,6 +77,8 @@ int main(int /* argc */, char ** /* argv */) {
   CONST(TLS1_1_VERSION);
   CONST(TLS1_2_VERSION);
   CONST(TLS1_3_VERSION);
+
+  CONST(SSL_TLSEXT_ERR_NOACK);
 
   CONST(SSL_SENT_SHUTDOWN);
   CONST(SSL_RECEIVED_SHUTDOWN);


### PR DESCRIPTION
The ALPN selector code used to hold a GlobalRef for the callback. This
appeared to make it impossible to discard the ref since there wasn't any
trigger for the AppData to be cleared as there is with the
SSLHandshakeCallbacks. Instead move the management of the reference into
Java and use the same SSLHandshakeCallbacks to manage calling into the
ALPN selector code.
    
This fixes #711
