### PR TITLE
Ensure ConscryptEngineSocket.getInputStream().read() returns unsigned…

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -713,7 +713,7 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
                 if (count != 1) {
                     throw new SSLException("read incorrect number of bytes " + count);
                 }
-                return (int) singleByte[0];
+                return singleByte[0] & 0xff;
             }
         }
 

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -259,6 +259,18 @@ public class SSLSocketTest {
     }
 
     @Test
+    public void test_SSLSocket_InputStream_read() throws Exception {
+        // Regression test for https://github.com/google/conscrypt/issues/738
+        // Ensure values returned from InputStream.read() are unsigned.
+        TestSSLSocketPair pair = TestSSLSocketPair.create().connect();
+
+        for (int i = 0; i < 256; i++) {
+            pair.client.getOutputStream().write(i);
+            assertEquals(i, pair.server.getInputStream().read());
+        }
+    }
+
+    @Test
     public void test_SSLSocket_getEnabledCipherSuites_returnsCopies() throws Exception {
         SSLSocketFactory sf = (SSLSocketFactory) SSLSocketFactory.getDefault();
         SSLSocket ssl = (SSLSocket) sf.createSocket();


### PR DESCRIPTION
… bytes.

Fixes #738.