### PR TITLE
Make SSLSocketVersionCompatibilityTest not flaky

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -226,7 +226,8 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
                     case NEED_UNWRAP:
                         if (in.processDataFromSocket(EmptyArray.BYTE, 0, 0) < 0) {
                             // Can't complete the handshake due to EOF.
-                            throw SSLUtils.toSSLHandshakeException(new EOFException());
+                            throw SSLUtils.toSSLHandshakeException(
+                                    new EOFException("connection closed"));
                         }
                         break;
                     case NEED_WRAP: {


### PR DESCRIPTION
SSLSocketVersionCompatibilityTest checks that SSLHandshakeException messages are due to
connection closed, but the internal SSLUtils utility was being used to convert the EOFException
to a SSLHandshakeException by reusing the message from EOFException. Since we were not
using the EOFException constructor with a message, it was getting NPE when the test
got that exception.

Add the message that explains why an EOFException was thrown.