### PR TITLE
Update publishing scripts with maven-publish

### DIFF
--- a/release/docker
+++ b/release/docker
@@ -32,7 +32,7 @@ sed -i 's\signing.secretKeyRingFile=.*\signing.secretKeyRingFile=/root/.gnupg/se
 sed -i 's\signingKeystore=.*\signingKeystore=/root/certkeystore\' /root/.gradle/gradle.properties
 
 ./gradlew conscrypt-openjdk:build
-./gradlew -Dorg.gradle.parallel=false uploadArchives
+./gradlew -Dorg.gradle.parallel=false publish
 
 cd /usr/src/boringssl
 

--- a/release/macos
+++ b/release/macos
@@ -31,4 +31,4 @@ ninja
 popd >/dev/null
 
 ./gradlew conscrypt-openjdk:build
-./gradlew conscrypt-openjdk:uploadArchives -Dorg.gradle.parallel=false -PrepositoryId="$2"
+./gradlew conscrypt-openjdk:publish -Dorg.gradle.parallel=false -PrepositoryId="$2"

--- a/release/windows.bat
+++ b/release/windows.bat
@@ -42,4 +42,4 @@ ninja
 popd
 
 call gradlew conscrypt-openjdk:build
-call gradlew conscrypt-openjdk:uploadArchives -Dorg.gradle.parallel=false -PrepositoryId=%2
+call gradlew conscrypt-openjdk:publish -Dorg.gradle.parallel=false -PrepositoryId=%2


### PR DESCRIPTION
The scripts still referred to the old task of "uploadArchives" but they should be
using the new task name of "publish"