### PR TITLE
Fix uberjar artifacts

### DIFF
--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -78,7 +78,6 @@ if (buildUberJar) {
 
     apply from: "$rootDir/gradle/publishing.gradle"
     publishing.publications.maven {
-        from components.java
         artifact sourcesJar
         artifact jar
     }


### PR DESCRIPTION
There should only be the "jar" and "sourcesJar" in the uberjar configuration. If you try to copy from components, it will have this error:

> Invalid publication 'maven': multiple artifacts with the identical extension and classifier ('jar', 'null').