### PR TITLE
Skip RSA cipher tests on SunMSCAPI

### DIFF
--- a/common/src/test/java/org/conscrypt/javax/crypto/CipherTest.java
+++ b/common/src/test/java/org/conscrypt/javax/crypto/CipherTest.java
@@ -1126,6 +1126,12 @@ public final class CipherTest {
             algorithm = "RSA/ECB/PKCS1Padding";
         }
 
+        // SunMSCAPI seems to have different opinion on what RSA should do compared to other
+        // providers. As such it fails many tests, so we will skip it for now.
+        if (algorithm.startsWith("RSA") && provider.getName().equals("SunMSCAPI")) {
+            return;
+        }
+
         // Cipher.getInstance(String)
         Cipher c1 = Cipher.getInstance(algorithm);
         if (provider.equals(c1.getProvider())) {
@@ -3720,6 +3726,12 @@ public final class CipherTest {
                 // It's OKish not to test AndroidKeyStore's Signature here because it's tested
                 // by cts/tests/test/keystore.
                 if (provider.getName().startsWith("AndroidKeyStore")) {
+                    continue;
+                }
+
+                // SunMSCAPI seems to have different opinion on what RSA should do compared to other
+                // providers. As such it fails many tests, so we will skip it for now.
+                if (provider.getName().equals("SunMSCAPI") && testVector.transformation.startsWith("RSA")) {
                     continue;
                 }
 


### PR DESCRIPTION
The RSA cipher implementation that uses MSCAPI does not consider itself a block
cipher, so it returns 0 for getBlockSize() among other things. This is at odds
with all other implementations tested.

We will skip these tests until newer implementations address these
deficiencies.