### PR TITLE
GitHub Actions: speed up BoringSSL checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Clone BoringSSL repo
         run: |
-          git clone --depth 1 https://boringssl.googlesource.com/boringssl.git "${{ runner.temp }}/boringssl"
+          git clone --depth 1 --filter=blob:none --no-checkout https://boringssl.googlesource.com/boringssl.git "${{ runner.temp }}/boringssl"
           echo Using BoringSSL commit: $(cd "${{ runner.temp }}/boringssl"; git rev-parse HEAD)
 
       - name: Archive BoringSSL source
@@ -92,6 +92,12 @@ jobs:
         with:
           name: boringssl-source
           path: ${{ runner.temp }}/boringssl
+
+      - name: Checkout BoringSSL master branch
+        shell: bash
+        run: |
+          cd "$BORINGSSL_HOME"
+          git checkout master
 
       - name: Build BoringSSL 64-bit Linux and MacOS
         if: runner.os != 'Windows'


### PR DESCRIPTION
Instead of uploading the entire checked-out repo, just get the bare minimum to
ensure the same BoringSSL commit is used in all builders. This speeds up the
checkouts by about 9 minutes.