### PR TITLE
OpenSSLSocketImpl.getApplicationProtocol() should not trigger handshake.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -691,12 +691,15 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
         return activeSession;
     }
 
+    // After handshake has started, provide active session otherwise a null session,
+    // for code which needs to read session attributes without triggering the handshake.
     private ConscryptSession provideAfterHandshakeSession() {
         return (state < STATE_HANDSHAKE_STARTED)
             ? SSLNullSession.getNullSession()
             : provideSession();
     }
 
+    // If handshake is in progress, provide active session otherwise a null session.
     private ConscryptSession provideHandshakeSession() {
         synchronized (ssl) {
             return state >= STATE_HANDSHAKE_STARTED && state < STATE_READY ? activeSession

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -691,6 +691,12 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
         return activeSession;
     }
 
+    private ConscryptSession provideAfterHandshakeSession() {
+        return (state < STATE_HANDSHAKE_STARTED)
+            ? SSLNullSession.getNullSession()
+            : provideSession();
+    }
+
     private ConscryptSession provideHandshakeSession() {
         synchronized (ssl) {
             return state >= STATE_HANDSHAKE_STARTED && state < STATE_READY ? activeSession
@@ -1118,7 +1124,7 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
 
     @Override
     public final String getApplicationProtocol() {
-        return provideSession().getApplicationProtocol();
+        return provideAfterHandshakeSession().getApplicationProtocol();
     }
 
     @Override

--- a/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
@@ -397,6 +397,25 @@ public class ConscryptEngineTest {
         assertEquals(alpnProtocol, Conscrypt.getApplicationProtocol(clientEngine));
     }
 
+    @Test
+    // getApplicationProtocol should initially return null and not trigger handshake. b/146235331
+    public void getAlpnIsNullBeforeHandshake() throws Exception {
+        String alpnProtocol = "spdy/2";
+        String[] alpnProtocols = new String[]{alpnProtocol};
+
+        setupEngines(TestKeyStore.getClient(), TestKeyStore.getServer());
+
+        assertNull(Conscrypt.getApplicationProtocol(clientEngine));
+        assertNull(Conscrypt.getApplicationProtocol(serverEngine));
+
+        Conscrypt.setApplicationProtocols(clientEngine, alpnProtocols);
+        Conscrypt.setApplicationProtocols(serverEngine, alpnProtocols);
+
+        doHandshake(true);
+
+        assertEquals(alpnProtocol, Conscrypt.getApplicationProtocol(clientEngine));
+    }
+
     private void doMutualAuthHandshake(
             TestKeyStore clientKs, TestKeyStore serverKs, ClientAuth clientAuth) throws Exception {
         setupEngines(clientKs, serverKs);

--- a/openjdk/src/test/java/org/conscrypt/ConscryptSocketTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptSocketTest.java
@@ -284,6 +284,9 @@ public class ConscryptSocketTest {
             AbstractConscryptSocket socket =
                     socketType.newClientSocket(createContext(), listener, underlyingSocketType);
             socket.setHostname(hostname);
+            // getApplicationProtocol should initially return null and not trigger handshake:
+            // b/146235331
+            assertNull(Conscrypt.getApplicationProtocol(socket));
             if (alpnProtocols != null) {
                 Conscrypt.setApplicationProtocols(socket, alpnProtocols);
             }


### PR DESCRIPTION
Fixes regression caused by #785 where reading the application protocol
before starting handshake would trigger the handshake, possibly before
the client's list of application protocols was set.

Bug: 146235331