### PR TITLE
Don't loop forever in writeInternal if making no progress.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -627,6 +627,9 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
                 if (len != buffer.remaining()) {
                     throw new SSLException("Engine did not read the correct number of bytes");
                 }
+                if (engineResult.getStatus() == CLOSED && engineResult.bytesProduced() == 0) {
+                    throw new SocketException("Socket closed");
+                }
 
                 target.flip();
 

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
@@ -1462,14 +1462,16 @@ public class SSLSocketVersionCompatibilityTest {
         final Socket underlying = new Socket(c.host, c.port);
         final SSLSocket wrapping = (SSLSocket) c.clientContext.getSocketFactory().createSocket(
             underlying, c.host.getHostName(), c.port, true);
-        final byte[] data = new byte[1024 * 220];
+        final byte[] data = new byte[1024 * 64];
 
         Future<Void> clientFuture = runAsync(new Callable<Void>() {
             @Override
             public Void call() throws Exception {
                 wrapping.startHandshake();
                 try {
-                    wrapping.getOutputStream().write(data);
+                    for (int i = 0; i < 64; i++) {
+                        wrapping.getOutputStream().write(data);
+                    }
                     // Failure here means that no exception was thrown, so the data buffer is
                     // probably too small.
                     fail();
@@ -1484,7 +1486,7 @@ public class SSLSocketVersionCompatibilityTest {
 
         // Read one byte so that both ends are in a fully connected state and data has
         // started to flow, and then close the socket from this thread.
-        server.getInputStream().read();
+        int unused = server.getInputStream().read();
         wrapping.close();
 
         clientFuture.get();

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
@@ -1446,6 +1446,52 @@ public class SSLSocketVersionCompatibilityTest {
         server.close();
     }
 
+    /**
+     * Test to confirm that an SSLSocket.close() on one
+     * thread will interrupt another thread blocked writing on the same
+     * socket.
+     *
+     * See also b/147323301 where close() triggered an infinite loop instead.
+     */
+    @Test
+    public void test_SSLSocket_interrupt_write_withAutoclose() throws Exception {
+        final TestSSLContext c = new TestSSLContext.Builder()
+            .clientProtocol(clientVersion)
+            .serverProtocol(serverVersion)
+            .build();
+        final Socket underlying = new Socket(c.host, c.port);
+        final SSLSocket wrapping = (SSLSocket) c.clientContext.getSocketFactory().createSocket(
+            underlying, c.host.getHostName(), c.port, true);
+        final byte[] data = new byte[1024 * 220];
+
+        Future<Void> clientFuture = runAsync(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                wrapping.startHandshake();
+                try {
+                    wrapping.getOutputStream().write(data);
+                    // Failure here means that no exception was thrown, so the data buffer is
+                    // probably too small.
+                    fail();
+                } catch (SocketException expected) {
+                    assertTrue(expected.getMessage().contains("closed"));
+                }
+                return null;
+            }
+        });
+        SSLSocket server = (SSLSocket) c.serverSocket.accept();
+        server.startHandshake();
+
+        // Read one byte so that both ends are in a fully connected state and data has
+        // started to flow, and then close the socket from this thread.
+        server.getInputStream().read();
+        wrapping.close();
+
+        clientFuture.get();
+        server.close();
+    }
+
+
     @Test
     public void test_SSLSocket_ClientHello_record_size() throws Exception {
         // This test checks the size of ClientHello of the default SSLSocket. TLS/SSL handshakes


### PR DESCRIPTION
PR #707 made ConscryptEngineSocket.SSLOutputSteam.writeInternal tolerant
of the underlying engine being CLOSED in order to ensure any pending
alerts get flushed to the underlying socket.

However in the case where SSLSocket.close() was called from another
thread causing the underlying socket to get closed too then this could
loop forever.  Added a condition that if no new data is produced for
sending in this state then signal the SSLSocket is closed by throwing
a SocketException, which is consistent with the
ConscryptFileDescriptorSocket behaviour.

This could also potentially be fixed ConscryptEngine.wrap() by throwing
directly from there instead of returning a CLOSED result, but I am not
convinced that is the only code path that can provoke this, so better
to ensure the writeInternal() loop will always exit.

The added test for this isn't a perfect regression test, as it's timing
dependent whether the writing thread will be looping in writeInternal
or blocked in socketOutputStream.write(), hence the test is only run
with autoClose=true until b/147870945 is resolved (Engine-based socket
doesn't wake blocked threads on close).  I'll rationalize the tests as
part of the fix for that, but this change is useful on its own as it
should unblock wider testing of the engine base socket again.