### PR TITLE
Update Mockito and Google Truth versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,8 +111,8 @@ subprojects {
                 bouncycastle_apis: 'org.bouncycastle:bcpkix-jdk15on:1.63',
                 bouncycastle_provider: 'org.bouncycastle:bcprov-jdk15on:1.63',
                 junit  : 'junit:junit:4.12',
-                mockito: 'org.mockito:mockito-core:1.9.5',
-                truth  : 'com.google.truth:truth:0.28',
+                mockito: 'org.mockito:mockito-core:2.28.2',
+                truth  : 'com.google.truth:truth:1.0',
 
                 // Benchmark dependencies
                 jmh_core: "org.openjdk.jmh:jmh-core:${jmhVersion}",

--- a/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
+++ b/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
@@ -19,7 +19,7 @@ package org.conscrypt;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/openjdk/src/test/java/org/conscrypt/ApplicationProtocolSelectorAdapterTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ApplicationProtocolSelectorAdapterTest.java
@@ -17,14 +17,14 @@
 package org.conscrypt;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.Charset;
 import javax.net.ssl.SSLEngine;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -77,7 +77,7 @@ public class ApplicationProtocolSelectorAdapterTest {
     }
 
     private void mockSelection(String returnValue) {
-        when(selector.selectApplicationProtocol(same(engine), Matchers.anyListOf(String.class)))
+        when(selector.selectApplicationProtocol(same(engine), ArgumentMatchers.<String>anyList()))
                 .thenReturn(returnValue);
     }
 

--- a/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 @RunWith(Parameterized.class)
@@ -319,7 +319,7 @@ public class ConscryptEngineTest {
 
         // Configure server selector
         ApplicationProtocolSelector selector = Mockito.mock(ApplicationProtocolSelector.class);
-        when(selector.selectApplicationProtocol(same(serverEngine), Matchers.anyListOf(String.class)))
+        when(selector.selectApplicationProtocol(same(serverEngine), ArgumentMatchers.<String>anyList()))
                 .thenReturn("spdy/2");
         Conscrypt.setApplicationProtocolSelector(serverEngine, selector);
 
@@ -338,7 +338,7 @@ public class ConscryptEngineTest {
 
         // Configure server selector
         ApplicationProtocolSelector selector = Mockito.mock(ApplicationProtocolSelector.class);
-        when(selector.selectApplicationProtocol(same(serverEngine), Matchers.anyListOf(String.class)))
+        when(selector.selectApplicationProtocol(same(serverEngine), ArgumentMatchers.<String>anyList()))
                 .thenReturn("h2");
         Conscrypt.setApplicationProtocolSelector(serverEngine, selector);
 

--- a/openjdk/src/test/java/org/conscrypt/ConscryptSocketTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptSocketTest.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -61,6 +61,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 @RunWith(Parameterized.class)
@@ -471,7 +472,7 @@ public class ConscryptSocketTest {
 
         // Configure server selector
         ApplicationProtocolSelector selector = Mockito.mock(ApplicationProtocolSelector.class);
-        when(selector.selectApplicationProtocol(any(SSLSocket.class), anyListOf(String.class)))
+        when(selector.selectApplicationProtocol(any(SSLSocket.class), ArgumentMatchers.<String>anyList()))
                 .thenReturn("spdy/2");
         c.serverHooks.alpnProtocolSelector = selector;
 
@@ -491,7 +492,7 @@ public class ConscryptSocketTest {
 
         // Configure server selector
         ApplicationProtocolSelector selector = Mockito.mock(ApplicationProtocolSelector.class);
-        when(selector.selectApplicationProtocol(any(SSLSocket.class), anyListOf(String.class)))
+        when(selector.selectApplicationProtocol(any(SSLSocket.class), ArgumentMatchers.<String>anyList()))
                 .thenReturn("h2");
         c.serverHooks.alpnProtocolSelector = selector;
 

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -86,7 +86,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
@@ -2113,7 +2113,7 @@ public class NativeCryptoTest {
         ApplicationProtocolSelector selector = Mockito.mock(ApplicationProtocolSelector.class);
         SSLEngine engine = Mockito.mock(SSLEngine.class);
         ApplicationProtocolSelectorAdapter adapter = new ApplicationProtocolSelectorAdapter(engine, selector);
-        when(selector.selectApplicationProtocol(same(engine), Matchers.anyListOf(String.class)))
+        when(selector.selectApplicationProtocol(same(engine), ArgumentMatchers.<String>anyList()))
                 .thenReturn("spdy/2");
 
         ServerSocket listener = newServerSocket();
@@ -2152,7 +2152,7 @@ public class NativeCryptoTest {
         ApplicationProtocolSelector selector = Mockito.mock(ApplicationProtocolSelector.class);
         SSLEngine engine = Mockito.mock(SSLEngine.class);
         ApplicationProtocolSelectorAdapter adapter = new ApplicationProtocolSelectorAdapter(engine, selector);
-        when(selector.selectApplicationProtocol(same(engine), Matchers.anyListOf(String.class)))
+        when(selector.selectApplicationProtocol(same(engine), ArgumentMatchers.<String>anyList()))
                 .thenReturn("h2");
 
         ServerSocket listener = newServerSocket();


### PR DESCRIPTION
Older version of Mockito use a method of creating mock classes that Java 11 does not
like version much. New versions of Mockito have a method that is compatible with old
and new versions of Java language.

Update calls to deprecated Matchers methods to use ArgumentMatchers for the new version
of Mockito as well.