### PR TITLE
Fix alias choices in ConscryptEngineSocket.

### DIFF
--- a/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
@@ -37,11 +37,14 @@ import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.X509KeyManager;
+import javax.security.auth.x500.X500Principal;
+import org.conscrypt.SSLParametersImpl.AliasChooser;
 
 /**
  * Abstract base class for all Conscrypt {@link SSLSocket} classes.
  */
-abstract class AbstractConscryptSocket extends SSLSocket {
+abstract class AbstractConscryptSocket extends SSLSocket implements AliasChooser {
     final Socket socket;
     private final boolean autoClose;
 
@@ -510,6 +513,17 @@ abstract class AbstractConscryptSocket extends SSLSocket {
             builder.append(super.toString());
         }
         return builder.toString();
+    }
+
+    @Override
+    public final String chooseServerAlias(X509KeyManager keyManager, String keyType) {
+        return keyManager.chooseServerAlias(keyType, null, this);
+    }
+
+    @Override
+    public final String chooseClientAlias(X509KeyManager keyManager, X500Principal[] issuers,
+        String[] keyTypes) {
+        return keyManager.chooseClientAlias(keyTypes, issuers, this);
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -92,6 +92,7 @@ import javax.security.auth.x500.X500Principal;
 import org.conscrypt.ExternalSession.Provider;
 import org.conscrypt.NativeRef.SSL_SESSION;
 import org.conscrypt.NativeSsl.BioWrapper;
+import org.conscrypt.SSLParametersImpl.AliasChooser;
 
 /**
  * Implements the {@link SSLEngine} API using OpenSSL's non-blocking interfaces.
@@ -179,27 +180,29 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     ConscryptEngine(SSLParametersImpl sslParameters) {
         this.sslParameters = sslParameters;
         peerInfoProvider = PeerInfoProvider.nullProvider();
-        this.ssl = newSsl(sslParameters, this);
+        this.ssl = newSsl(sslParameters, this, this);
         this.networkBio = ssl.newBio();
     }
 
     ConscryptEngine(String host, int port, SSLParametersImpl sslParameters) {
         this.sslParameters = sslParameters;
         this.peerInfoProvider = PeerInfoProvider.forHostAndPort(host, port);
-        this.ssl = newSsl(sslParameters, this);
+        this.ssl = newSsl(sslParameters, this, this);
         this.networkBio = ssl.newBio();
     }
 
-    ConscryptEngine(SSLParametersImpl sslParameters, PeerInfoProvider peerInfoProvider) {
+    ConscryptEngine(SSLParametersImpl sslParameters, PeerInfoProvider peerInfoProvider,
+        AliasChooser aliasChooser) {
         this.sslParameters = sslParameters;
         this.peerInfoProvider = checkNotNull(peerInfoProvider, "peerInfoProvider");
-        this.ssl = newSsl(sslParameters, this);
+        this.ssl = newSsl(sslParameters, this, aliasChooser);
         this.networkBio = ssl.newBio();
     }
 
-    private static NativeSsl newSsl(SSLParametersImpl sslParameters, ConscryptEngine engine) {
+    private static NativeSsl newSsl(SSLParametersImpl sslParameters, ConscryptEngine engine,
+        AliasChooser aliasChooser) {
         try {
-            return NativeSsl.newInstance(sslParameters, engine, engine, engine);
+            return NativeSsl.newInstance(sslParameters, engine, aliasChooser, engine);
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -108,7 +108,8 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
         } else {
             modifiedParams = sslParameters;
         }
-        ConscryptEngine engine = new ConscryptEngine(modifiedParams, socket.peerInfoProvider());
+        ConscryptEngine engine =
+            new ConscryptEngine(modifiedParams, socket.peerInfoProvider(), socket);
 
         // When the handshake completes, notify any listeners.
         engine.setHandshakeListener(new HandshakeListener() {

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -42,9 +42,7 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSession;
-import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
-import javax.security.auth.x500.X500Principal;
 import org.conscrypt.ExternalSession.Provider;
 import org.conscrypt.NativeRef.SSL_SESSION;
 
@@ -60,7 +58,6 @@ import org.conscrypt.NativeRef.SSL_SESSION;
  */
 class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
         implements NativeCrypto.SSLHandshakeCallbacks,
-                   SSLParametersImpl.AliasChooser,
                    SSLParametersImpl.PSKCallbacks {
     private static final boolean DBG_STATE = false;
 
@@ -1149,17 +1146,6 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     public final void setSSLParameters(SSLParameters p) {
         super.setSSLParameters(p);
         Platform.setSSLParameters(p, sslParameters, this);
-    }
-
-    @Override
-    public final String chooseServerAlias(X509KeyManager keyManager, String keyType) {
-        return keyManager.chooseServerAlias(keyType, null, this);
-    }
-
-    @Override
-    public final String chooseClientAlias(X509KeyManager keyManager, X500Principal[] issuers,
-            String[] keyTypes) {
-        return keyManager.chooseClientAlias(keyTypes, issuers, this);
     }
 
     @Override


### PR DESCRIPTION
Pushes AliasChooser implementation up to AbstractConscryptSocket
and passes the correct implementation to ConscryptEngine.newSsl()
to ensure the engine-based socket chooses the same aliases as
the fd-based one.

Fixes: 149912502