### PR TITLE
Allow selection of fd-based SSLSocket using a flag file.

### DIFF
--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -41,6 +41,7 @@ import static org.conscrypt.NativeConstants.SSL3_RT_HEADER_LENGTH;
 import static org.conscrypt.NativeConstants.SSL3_RT_MAX_PACKET_SIZE;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.security.cert.CertificateEncodingException;
@@ -61,10 +62,8 @@ import javax.security.cert.CertificateException;
  * This is a public class to allow testing to occur on Android via CTS.
  */
 final class SSLUtils {
-    static final boolean USE_ENGINE_SOCKET_BY_DEFAULT = Boolean.parseBoolean(
-            System.getProperty("org.conscrypt.useEngineSocketByDefault", "false"));
+    static final boolean USE_ENGINE_SOCKET_BY_DEFAULT = useEngineSocketByDefault();
     private static final int MAX_PROTOCOL_LENGTH = 255;
-
     private static final Charset US_ASCII = Charset.forName("US-ASCII");
 
     // TODO(nathanmittler): Should these be in NativeConstants?
@@ -575,6 +574,22 @@ final class SSLUtils {
             resultOffset += array.length;
         }
         return result;
+    }
+
+    // Flag file created by CtsConscryptFdSocketTestCases.  This is a temporary measure
+    // so CTS can test both implementations easily until FdSocket is retired.
+    // Name chosen so that it is unlikely to exist by accident on other platforms.
+    // If this file exists, always use fd-based socket.  Otherwise default to true but
+    // allow overriding by system property.
+    // TODO(prb): Consider gating on target API level on Android.
+    private static final String CTS_FDSOCKET_FILE
+        = "/data/local/tmp/ctslibcore/org.conscrypt.use_fd_socket";
+    private static boolean useEngineSocketByDefault() {
+        if (new File(CTS_FDSOCKET_FILE).exists()) {
+            return false;
+        }
+        return Boolean.parseBoolean(
+            System.getProperty("org.conscrypt.useEngineSocketByDefault", "true"));
     }
 
     private SSLUtils() {}


### PR DESCRIPTION
This is a bit of an ugly hack, but temporary in nature and
less ugly that having to write a custom CTS test runner to
pass in a Java property.

Allows us to create a CTS test suite that exercises a
number of Conscrypt and non-Conscrypt APIs with the SSLSocket
implementation set to ConscryptFileDescriptorSocket even though
the AOSP default is ConscryptEngineSocket.

Flag file name chosen to minimise potential for accidental
collisions.

To be kept until ConscryptFileDescriptorSocket is removed in
order to ensure we continue to test both implementations on
all platforms.