### PR TITLE
Include javadoc when publishing openjdk uber jar.

### DIFF
--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -79,6 +79,7 @@ if (buildUberJar) {
     apply from: "$rootDir/gradle/publishing.gradle"
     publishing.publications.maven {
         artifact sourcesJar
+        artifact javadocJar
         artifact jar
     }
 } else {


### PR DESCRIPTION
Got lost in the move to maven-publish.