### PR TITLE
Propagate socket implementation type changes to default factories.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLServerSocketFactoryImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLServerSocketFactoryImpl.java
@@ -19,6 +19,7 @@ package org.conscrypt;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import javax.net.ServerSocketFactory;
 import java.security.KeyManagementException;
 import javax.net.ssl.SSLServerSocketFactory;
 
@@ -51,10 +52,16 @@ final class OpenSSLServerSocketFactoryImpl extends SSLServerSocketFactory {
     }
 
     /**
-     * Configures the default socket to be created for all instances.
+     * Configures the default socket type to be created for the default and all new instances.
      */
     static void setUseEngineSocketByDefault(boolean useEngineSocket) {
         useEngineSocketByDefault = useEngineSocket;
+        // The default SSLServerSocketFactory may already have been created, so also change its
+        // setting.
+        ServerSocketFactory defaultFactory = SSLServerSocketFactory.getDefault();
+        if (defaultFactory instanceof OpenSSLServerSocketFactoryImpl) {
+            ((OpenSSLServerSocketFactoryImpl) defaultFactory).setUseEngineSocket(useEngineSocket);
+        }
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketFactoryImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketFactoryImpl.java
@@ -25,6 +25,7 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.security.KeyManagementException;
+import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
@@ -58,10 +59,15 @@ final class OpenSSLSocketFactoryImpl extends SSLSocketFactory {
     }
 
     /**
-     * Configures the default socket to be created for all instances.
+     * Configures the default socket type to be created for the default and all new instances.
      */
     static void setUseEngineSocketByDefault(boolean useEngineSocket) {
         useEngineSocketByDefault = useEngineSocket;
+        // The default SSLSocketFactory may already have been created, so also change its setting.
+        SocketFactory defaultFactory = SSLSocketFactory.getDefault();
+        if (defaultFactory instanceof OpenSSLSocketFactoryImpl) {
+            ((OpenSSLSocketFactoryImpl) defaultFactory).setUseEngineSocket(useEngineSocket);
+        }
     }
 
     /**


### PR DESCRIPTION
Conscrypt.setUseEngineSocketByDefault() sets the default
SSLSocket implementation to use by calling the same method on
OpenSSLSocketFactoryImpl and OpenSSLServerSocketFactoryImpl.

Those methods set a static boolean which is used to determine
the initial default for new factories but which has no effect
on existing factories.  This is mostly what's wanted except the
default SSLSocketFactory (and SSLServerSocketFactory) can be
long lived and created by static initializers before any code
has a chance to call Conscrypt.setUseEngineSocketByDefault().

This change also change the flag for the default
SSLSocketFactory and SSLServerSocketFactory, so that an app
using these behaves as expected.

Negative:  This will change means that calling
Conscrypt.setUseEngineSocketByDefault will create a default
SSLServerSocketFactory, which some apps may never use, however
the overhead is low and it seems better than changing the
API to add a setUseEngineServerSocketByDefault() method,
as existing apps might need changing to call both methods.
Also this API should only last in the short to medium term
until we can retire the fd-based implementation.