### PR TITLE
Add more coverage for OpenSSLRSAKeyFactory and OpenSSLECPrivateKey

### DIFF
--- a/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestEC.java
+++ b/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestEC.java
@@ -16,8 +16,16 @@
 package org.conscrypt.java.security;
 
 import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import tests.util.ServiceTester;
@@ -40,5 +48,23 @@ public class KeyFactoryTestEC extends
   @Override
   protected void check(KeyPair keyPair) throws Exception {
     new SignatureHelper("SHA256withECDSA").test(keyPair);
+  }
+
+  @Override
+  protected List<KeyPair> getKeys() throws NoSuchAlgorithmException, InvalidKeySpecException {
+    return Arrays.asList(
+        new KeyPair(
+            DefaultKeys.getPublicKey("EC"),
+            DefaultKeys.getPrivateKey("EC")
+        ),
+        new KeyPair(
+            new TestPublicKey(DefaultKeys.getPublicKey("EC")),
+            new TestPrivateKey(DefaultKeys.getPrivateKey("EC"))
+        ),
+        new KeyPair(
+            new TestECPublicKey((ECPublicKey)DefaultKeys.getPublicKey("EC")),
+            new TestECPrivateKey((ECPrivateKey)DefaultKeys.getPrivateKey("EC"))
+        )
+    );
   }
 }

--- a/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
+++ b/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
@@ -15,14 +15,23 @@
  */
 package org.conscrypt.java.security;
 
+import static org.junit.Assert.fail;
+
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
+import java.security.Security;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPrivateCrtKeySpec;
 import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -56,5 +65,35 @@ public class KeyFactoryTestRSA extends
         byte[] longBuffer = new byte[encoded.length + 147];
         System.arraycopy(encoded, 0, longBuffer, 0, encoded.length);
         KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(longBuffer));
+    }
+
+    @Test
+    public void testInvalidKeySpec() throws Exception {
+        Provider p = Security.getProvider(StandardNames.JSSE_PROVIDER_NAME);
+        final KeyFactory factory = KeyFactory.getInstance("RSA", p);
+
+        try {
+            factory.getKeySpec(new TestPrivateKey(DefaultKeys.getPrivateKey("RSA"), "Invalid"),
+                RSAPrivateKeySpec.class);
+            fail();
+        } catch (InvalidKeySpecException e) {
+            // expected
+        }
+
+        try {
+            factory.getKeySpec(new TestPrivateKey(DefaultKeys.getPrivateKey("RSA"), "Invalid"),
+                RSAPrivateCrtKeySpec.class);
+            fail();
+        } catch (InvalidKeySpecException e) {
+            // expected
+        }
+
+        try {
+            factory.getKeySpec(new TestPublicKey(DefaultKeys.getPublicKey("RSA"), "Invalid"),
+                RSAPublicKeySpec.class);
+            fail();
+        } catch (InvalidKeySpecException e) {
+            // expected
+        }
     }
 }

--- a/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSACrt.java
+++ b/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSACrt.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.java.security;
+
+import java.security.KeyPair;
+import java.security.spec.RSAPrivateCrtKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import tests.util.ServiceTester;
+
+// Similar to KeyFactoryTestRSA, but uses RSAPrivateCrtKeySpec instead of RSAPrivateKeySpec.
+@RunWith(JUnit4.class)
+public class KeyFactoryTestRSACrt extends
+    AbstractKeyFactoryTest<RSAPublicKeySpec, RSAPrivateCrtKeySpec> {
+
+  public KeyFactoryTestRSACrt() {
+    super("RSA", RSAPublicKeySpec.class, RSAPrivateCrtKeySpec.class);
+  }
+
+  @Override
+  protected void check(KeyPair keyPair) throws Exception {
+    new CipherAsymmetricCryptHelper("RSA").test(keyPair);
+  }
+
+  @Override
+  public ServiceTester customizeTester(ServiceTester tester) {
+    // BouncyCastle's KeyFactory.engineGetKeySpec() doesn't handle custom PublicKey
+    // implmenetations.
+    return tester.skipProvider("BC");
+  }
+}

--- a/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSACustom.java
+++ b/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSACustom.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.java.security;
+
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPrivateKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import tests.util.ServiceTester;
+
+// Similar to KeyFactoryTestRSA, but uses custom RSA PublicKey
+// implementation to exercise less common parts of OpenSSLRSAKeyFactory.
+@RunWith(JUnit4.class)
+public class KeyFactoryTestRSACustom extends
+    AbstractKeyFactoryTest<RSAPublicKeySpec, RSAPrivateKeySpec> {
+
+  public KeyFactoryTestRSACustom() {
+    super("RSA", RSAPublicKeySpec.class, RSAPrivateKeySpec.class);
+  }
+
+  @Override
+  protected void check(KeyPair keyPair) throws Exception {
+    new CipherAsymmetricCryptHelper("RSA").test(keyPair);
+  }
+
+  @Override
+  public ServiceTester customizeTester(ServiceTester tester) {
+      // BouncyCastle's KeyFactory.engineGetKeySpec() doesn't handle custom PublicKey
+      // implmenetations.
+      return tester.skipProvider("BC");
+  }
+
+  @Override
+  protected List<KeyPair> getKeys() throws NoSuchAlgorithmException, InvalidKeySpecException {
+    return Arrays.asList(
+        new KeyPair(
+            new TestPublicKey(DefaultKeys.getPublicKey("RSA")),
+            new TestPrivateKey(DefaultKeys.getPrivateKey("RSA"))
+        )
+    );
+  }
+}

--- a/common/src/test/java/org/conscrypt/java/security/TestECPrivateKey.java
+++ b/common/src/test/java/org/conscrypt/java/security/TestECPrivateKey.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.java.security;
+
+import java.math.BigInteger;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECParameterSpec;
+import java.util.Objects;
+
+class TestECPrivateKey implements ECPrivateKey {
+  private ECPrivateKey key;
+  private String format;
+
+  TestECPrivateKey(ECPrivateKey key) {
+    this(key, key.getFormat());
+  }
+
+  TestECPrivateKey(ECPrivateKey key, String format) {
+    Objects.requireNonNull(key);
+    this.key = key;
+    this.format = format;
+  }
+
+  @Override
+  public String getAlgorithm() {
+    return key.getAlgorithm();
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    return key.getEncoded();
+  }
+
+  @Override
+  public String getFormat() {
+    return format;
+  }
+
+  @Override
+  public ECParameterSpec getParams() {
+    return key.getParams();
+  }
+
+  @Override
+  public BigInteger getS() {
+    return key.getS();
+  }
+}

--- a/common/src/test/java/org/conscrypt/java/security/TestECPublicKey.java
+++ b/common/src/test/java/org/conscrypt/java/security/TestECPublicKey.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.java.security;
+
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.util.Objects;
+
+class TestECPublicKey implements ECPublicKey {
+  private ECPublicKey key;
+  private String format;
+
+  TestECPublicKey(ECPublicKey key) {
+    this(key, key.getFormat());
+  }
+
+  TestECPublicKey(ECPublicKey key, String format) {
+    Objects.requireNonNull(key);
+    this.key = key;
+    this.format = format;
+  }
+
+  @Override
+  public String getAlgorithm() {
+    return key.getAlgorithm();
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    return key.getEncoded();
+  }
+
+  @Override
+  public String getFormat() {
+    return format;
+  }
+
+  @Override
+  public ECParameterSpec getParams() {
+    return key.getParams();
+  }
+
+  @Override
+  public ECPoint getW() {
+    return key.getW();
+  }
+}

--- a/common/src/test/java/org/conscrypt/java/security/TestPrivateKey.java
+++ b/common/src/test/java/org/conscrypt/java/security/TestPrivateKey.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.java.security;
+
+import java.security.PrivateKey;
+
+class TestPrivateKey implements PrivateKey {
+  private PrivateKey key;
+  private String format;
+
+  TestPrivateKey(PrivateKey key) {
+    this(key, key.getFormat());
+  }
+
+  TestPrivateKey(PrivateKey key, String format) {
+    this.key = key;
+    this.format = format;
+  }
+
+  @Override
+  public String getAlgorithm() {
+    return key.getAlgorithm();
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    return key.getEncoded();
+  }
+
+  @Override
+  public String getFormat() {
+    return format;
+  }
+}

--- a/common/src/test/java/org/conscrypt/java/security/TestPublicKey.java
+++ b/common/src/test/java/org/conscrypt/java/security/TestPublicKey.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.java.security;
+
+import java.security.PublicKey;
+
+class TestPublicKey implements PublicKey {
+  private PublicKey key;
+  private String format;
+
+  TestPublicKey(PublicKey key) {
+    this(key, key.getFormat());
+  }
+
+  TestPublicKey(PublicKey key, String format) {
+    this.key = key;
+    this.format = format;
+  }
+
+  @Override
+  public String getAlgorithm() {
+    return key.getAlgorithm();
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    return key.getEncoded();
+  }
+
+  @Override
+  public String getFormat() {
+    return format;
+  }
+}


### PR DESCRIPTION
Certain code paths that handle generic PublicKey and PrivateKey (as opposed to RSAPublicKey , OpenSSLECPublicKey or OpenSSLECPrivateKey, etc) are not covered, this change addresses that.