### PR TITLE
Fix ConscryptEngineSocket.close().

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -622,6 +622,14 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         }
     }
 
+    // After handshake has started, provide active session otherwise a null session,
+    // for code which needs to read session attributes without triggering the handshake.
+    private ConscryptSession provideAfterHandshakeSession() {
+        return (state < STATE_HANDSHAKE_STARTED)
+                ? SSLNullSession.getNullSession()
+                : provideSession();
+    }
+
     @Override
     public String[] getSupportedCipherSuites() {
         return NativeCrypto.getSupportedCipherSuites();
@@ -1775,13 +1783,13 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
 
     @Override
     public String getApplicationProtocol() {
-        return SSLUtils.toProtocolString(ssl.getApplicationProtocol());
+        return provideAfterHandshakeSession().getApplicationProtocol();
     }
 
     @Override
     public String getHandshakeApplicationProtocol() {
         synchronized (ssl) {
-            return state == STATE_HANDSHAKE_STARTED ? getApplicationProtocol() : null;
+            return state >= STATE_HANDSHAKE_STARTED ? getApplicationProtocol() : null;
         }
     }
 


### PR DESCRIPTION
Previousy, this method closed the underlying socket first and then
the SSLEngine.  However closing a connected SSLEngine queues a TLS
close notification which obviously can't be sent if the socket is
closed.  Also, the pending bytes prevent the engine from freeing
its native resources including pipe file descriptors until the
SSLEngine is eventually garbage collected.

Fixing this exposed that the fix for #781 was incomplete and relied
on the native SSL data *not* being cleared on close and so that
is also fixed herein.

This may also help with #835 but didn't help me to reproduce that.