### PR TITLE
Return correct esxception if SSLEngine.beginHandshake is called twice.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -413,7 +413,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
             case STATE_CLOSED_INBOUND:
             case STATE_CLOSED_OUTBOUND:
             case STATE_CLOSED:
-                throw new IllegalStateException("Engine has already been closed");
+                throw new SSLHandshakeException("Engine has already been closed");
             default:
                 // We've already started the handshake, just return
                 return;


### PR DESCRIPTION
IllegalStateException should only be thrown if the client/server mode has not yet been set.

See https://developer.android.com/reference/javax/net/ssl/SSLEngine#beginHandshake()

Fixes #840

