### PR TITLE
Fix ConscryptEngineSocket.close().

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -622,6 +622,14 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         }
     }
 
+    // After handshake has started, provide active session otherwise a null session,
+    // for code which needs to read session attributes without triggering the handshake.
+    private ConscryptSession provideAfterHandshakeSession() {
+        return (state < STATE_HANDSHAKE_STARTED)
+                ? SSLNullSession.getNullSession()
+                : provideSession();
+    }
+
     @Override
     public String[] getSupportedCipherSuites() {
         return NativeCrypto.getSupportedCipherSuites();
@@ -1775,13 +1783,13 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
 
     @Override
     public String getApplicationProtocol() {
-        return SSLUtils.toProtocolString(ssl.getApplicationProtocol());
+        return provideAfterHandshakeSession().getApplicationProtocol();
     }
 
     @Override
     public String getHandshakeApplicationProtocol() {
         synchronized (ssl) {
-            return state == STATE_HANDSHAKE_STARTED ? getApplicationProtocol() : null;
+            return state >= STATE_HANDSHAKE_STARTED ? getApplicationProtocol() : null;
         }
     }
 

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -18,6 +18,7 @@ package org.conscrypt;
 
 import static javax.net.ssl.SSLEngineResult.Status.CLOSED;
 import static javax.net.ssl.SSLEngineResult.Status.OK;
+import static org.conscrypt.Preconditions.checkNotNull;
 import static org.conscrypt.SSLUtils.EngineStates.STATE_CLOSED;
 import static org.conscrypt.SSLUtils.EngineStates.STATE_HANDSHAKE_COMPLETED;
 import static org.conscrypt.SSLUtils.EngineStates.STATE_HANDSHAKE_STARTED;
@@ -435,7 +436,9 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
             return;
         }
 
+        int previousState;
         synchronized (stateLock) {
+            previousState = state;
             if (state == STATE_CLOSED) {
                 // close() has already been called, so do nothing and return.
                 return;
@@ -447,16 +450,28 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
         }
 
         try {
-            // Close the underlying socket.
-            super.close();
-        } finally {
             // Close the engine.
             engine.closeInbound();
             engine.closeOutbound();
-            
-            // Release any resources we're holding
-            if (in != null) {
-                in.release();
+            // Closing the outbound direction of a connected engine will trigger a TLS close
+            // notify, which we should try and send.
+            // If we don't, then closeOutbound won't be able to free resources because there are
+            // bytes queued for transmission so drain the queue those and call closeOutbound a
+            // second time.
+            if (previousState >= STATE_HANDSHAKE_STARTED) {
+                // checkNotNull(out, "Output stream is null");
+                drainOutgoingQueue();
+                engine.closeOutbound();
+            }
+        } finally {
+            // In case of an exception thrown while closing the engine, we still need to close the
+            // underlying socket and release any resources the input stream is holding.
+            try {
+                super.close();
+            } finally {
+                if (in != null) {
+                    in.release();
+                }
             }
         }
     }
@@ -634,7 +649,10 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
                     throw new SSLException("Engine did not read the correct number of bytes");
                 }
                 if (engineResult.getStatus() == CLOSED && engineResult.bytesProduced() == 0) {
-                    throw new SocketException("Socket closed");
+                    if (len > 0) {
+                        throw new SocketException("Socket closed");
+                    }
+                    break;
                 }
 
                 target.flip();

--- a/openjdk/src/test/java/org/conscrypt/SSLUtilsTest.java
+++ b/openjdk/src/test/java/org/conscrypt/SSLUtilsTest.java
@@ -186,6 +186,29 @@ public class SSLUtilsTest {
         assertEquals(Arrays.asList("EC", "RSA"), keyTypes);
     }
 
+    @Test
+    public void engineStateValues() {
+        int[] expectedValues = {
+                SSLUtils.EngineStates.STATE_NEW,
+                SSLUtils.EngineStates.STATE_MODE_SET,
+                SSLUtils.EngineStates.STATE_HANDSHAKE_STARTED,
+                SSLUtils.EngineStates.STATE_HANDSHAKE_COMPLETED,
+                SSLUtils.EngineStates.STATE_READY_HANDSHAKE_CUT_THROUGH,
+                SSLUtils.EngineStates.STATE_READY,
+                SSLUtils.EngineStates.STATE_CLOSED_INBOUND,
+                SSLUtils.EngineStates.STATE_CLOSED_OUTBOUND,
+                SSLUtils.EngineStates.STATE_CLOSED,
+        };
+
+        // Check the values for the engine state are as expected because logic
+        // in the engine and sockets relies on it,
+        // e.g. STATE_NEW < STATE_HANDSHAKE_STARTED < STATE_READY < STATE_CLOSED
+        // But to be sure we assert the exact ordering.
+        for (int i = 0; i < expectedValues.length; i++) {
+            assertEquals(i, expectedValues[i]);
+        }
+    }
+
     private static String[] toStrings(byte[][] protocols) {
         int numProtocols = protocols.length;
         String[] out = new String[numProtocols];


### PR DESCRIPTION
[Apologies for the duplicate PR, got the original into a state where I can't reopen it]

Previously, this method closed the underlying socket first and then
the SSLEngine.  However closing a connected SSLEngine queues a TLS
close notification which obviously can't be sent if the socket is
closed.  Also, the pending bytes prevent the engine from freeing
its native resources including pipe file descriptors until the
SSLEngine is eventually garbage collected.

Fixing this exposed that the fix for #781 was incomplete and relied
on the native SSL data *not* being cleared on close and so that
is also fixed herein.

This may also help with #835 but didn't help me to reproduce that.