### PR TITLE
Throw SSLException if SSLEngine inbound is closed before outbound.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -457,7 +457,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     }
 
     @Override
-    public void closeInbound() {
+    public void closeInbound() throws SSLException {
         synchronized (ssl) {
             if (state == STATE_CLOSED || state == STATE_CLOSED_INBOUND) {
                 return;
@@ -466,7 +466,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
                 if (state == STATE_CLOSED_OUTBOUND) {
                     transitionTo(STATE_CLOSED);
                 } else {
-                    transitionTo(STATE_CLOSED_INBOUND);
+                    throw new SSLException("Closed SSLEngine inbound before outbound");
                 }
                 freeIfDone();
             } else {
@@ -1337,7 +1337,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         }
     }
 
-    private void closeAll() {
+    private void closeAll() throws SSLException {
         closeOutbound();
         closeInbound();
     }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -451,9 +451,9 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
             super.close();
         } finally {
             // Close the engine.
-            engine.closeInbound();
             engine.closeOutbound();
-            
+            engine.closeInbound();
+
             // Release any resources we're holding
             if (in != null) {
                 in.release();

--- a/testing/src/main/java/org/conscrypt/javax/net/ssl/TestSSLEnginePair.java
+++ b/testing/src/main/java/org/conscrypt/javax/net/ssl/TestSSLEnginePair.java
@@ -146,8 +146,8 @@ public final class TestSSLEnginePair implements Closeable {
         try {
             for (SSLEngine engine : engines) {
                 if (engine != null) {
-                    engine.closeInbound();
                     engine.closeOutbound();
+                    engine.closeInbound();
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #839.

This should be _mostly_ uncontroversial as it is already documented
to do so[1] but could cause app compat issues.  A quick scan of
AOSP suggests no major issues however there is a CTS test for the
old behaviour[2] which will need changing.

The bulk of this change is regression tests for the correct behaviour
for the various possible orderings of close calls and TLS close
alerts. The behaviour change test is
closingInboundBeforeClosingOutboundShouldFail() in place of
closingInboundShouldOnlyCloseInbound().  Changes outside
ConscryptEngineTest are minimal.

Close behaviour before handshaking starts is undefined and we differ
from the RI, but I don't think that's problematic.

Obviously also needs documenting in Conscrypt and Android release
notes.

This also means that STATE_CLOSED_INBOUND is never reached, which
means it can be eliminated in a future CL allowing some minor
simplifications.

NB This can be merged independently of #844 and I'll rebase that
change on top of it.

[1] https://developer.android.com/reference/javax/net/ssl/SSLEngine#closeInbound()
[2] https://cs.android.com/android/platform/superproject/+/master:libcore/harmony-tests/src/test/java/org/apache/harmony/tests/javax/net/ssl/SSLEngineTest.java;l=611