### PR TITLE
Suppress stack-trace filling of ShortBufferException

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -230,7 +230,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
         // output buffer isn't large enough.
         if (output != null) {
             if (getOutputSizeForFinal(inputLen) > output.length - outputOffset) {
-                throw new ShortBufferException("Insufficient output space");
+                throw new ShortBufferWithoutStackTraceException("Insufficient output space");
             }
         }
         return super.engineDoFinal(input, inputOffset, inputLen, output, outputOffset);

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherChaCha20.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherChaCha20.java
@@ -71,7 +71,7 @@ public class OpenSSLCipherChaCha20 extends OpenSSLCipher {
     int updateInternal(byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset,
             int maximumLen) throws ShortBufferException {
         if (inputLen > output.length - outputOffset) {
-            throw new ShortBufferException("Insufficient output space");
+            throw new ShortBufferWithoutStackTraceException("Insufficient output space");
         }
         int inputLenRemaining = inputLen;
         if (currentBlockConsumedBytes > 0) {

--- a/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLCipherRSA.java
@@ -329,7 +329,7 @@ public abstract class OpenSSLCipherRSA extends CipherSpi {
 
         final int lastOffset = outputOffset + b.length;
         if (lastOffset > output.length) {
-            throw new ShortBufferException("output buffer is too small " + output.length + " < "
+            throw new ShortBufferWithoutStackTraceException("output buffer is too small " + output.length + " < "
                     + lastOffset);
         }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLECDHKeyAgreement.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECDHKeyAgreement.java
@@ -97,7 +97,7 @@ public final class OpenSSLECDHKeyAgreement extends KeyAgreementSpi {
         checkCompleted();
         int available = sharedSecret.length - offset;
         if (mResult.length > available) {
-            throw new ShortBufferException(
+            throw new ShortBufferWithoutStackTraceException(
                     "Needed: " + mResult.length + ", available: " + available);
         }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLEvpCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLEvpCipher.java
@@ -115,7 +115,7 @@ public abstract class OpenSSLEvpCipher extends OpenSSLCipher {
 
         final int bytesLeft = output.length - outputOffset;
         if (bytesLeft < maximumLen) {
-            throw new ShortBufferException("output buffer too small during update: "
+            throw new ShortBufferWithoutStackTraceException("output buffer too small during update: "
                     + bytesLeft + " < " + maximumLen);
         }
 
@@ -150,7 +150,7 @@ public abstract class OpenSSLEvpCipher extends OpenSSLCipher {
             final byte[] lastBlock = new byte[maximumLen];
             writtenBytes = NativeCrypto.EVP_CipherFinal_ex(cipherCtx, lastBlock, 0);
             if (writtenBytes > bytesLeft) {
-                throw new ShortBufferException("buffer is too short: " + writtenBytes + " > "
+                throw new ShortBufferWithoutStackTraceException("buffer is too short: " + writtenBytes + " > "
                         + bytesLeft);
             } else if (writtenBytes > 0) {
                 System.arraycopy(lastBlock, 0, output, outputOffset, writtenBytes);

--- a/common/src/main/java/org/conscrypt/ShortBufferWithoutStackTraceException.java
+++ b/common/src/main/java/org/conscrypt/ShortBufferWithoutStackTraceException.java
@@ -20,9 +20,8 @@ import javax.crypto.ShortBufferException;
 
 /**
  * This class basically does the same thing the ShortBufferException class does
- * except not filling in stack trace in the exception to get better performance
- * stack trace to save CPU-time for it in an environment where this can be thrown
- * many times. e.g. OpenJDK 8.
+ * except not filling in stack trace in the exception to save CPU-time for it
+ * in an environment where this can be thrown many times. e.g. OpenJDK 8.
  */
 @Internal
 final class ShortBufferWithoutStackTraceException extends ShortBufferException {

--- a/common/src/main/java/org/conscrypt/ShortBufferWithoutStackTraceException.java
+++ b/common/src/main/java/org/conscrypt/ShortBufferWithoutStackTraceException.java
@@ -25,7 +25,7 @@ import javax.crypto.ShortBufferException;
  * many times. e.g. OpenJDK 8.
  */
 @Internal
-public class ShortBufferWithoutStackTraceException extends ShortBufferException {
+final class ShortBufferWithoutStackTraceException extends ShortBufferException {
     private static final long serialVersionUID = 676150236007842683L;
 
     public ShortBufferWithoutStackTraceException() {
@@ -36,7 +36,7 @@ public class ShortBufferWithoutStackTraceException extends ShortBufferException 
         super(msg);
     }
 
-    @Override public synchronized Throwable fillInStackTrace() {
+    @Override public Throwable fillInStackTrace() {
         return this;
     }
 }

--- a/common/src/main/java/org/conscrypt/ShortBufferWithoutStackTraceException.java
+++ b/common/src/main/java/org/conscrypt/ShortBufferWithoutStackTraceException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import javax.crypto.ShortBufferException;
+
+/**
+ * This class basically does the same thing the ShortBufferException class does
+ * except not filling in stack trace in the exception to get better performance
+ * stack trace to save CPU-time for it in an environment where this can be thrown
+ * many times. e.g. OpenJDK 8.
+ */
+@Internal
+public class ShortBufferWithoutStackTraceException extends ShortBufferException {
+    private static final long serialVersionUID = 676150236007842683L;
+
+    public ShortBufferWithoutStackTraceException() {
+        super();
+    }
+
+    public ShortBufferWithoutStackTraceException(String msg) {
+        super(msg);
+    }
+
+    @Override public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}


### PR DESCRIPTION
This is about modifying Conscrypt to throw `ShortBufferWithoutStackTraceException` instead of `ShortBufferException` for the purpose of not wasting cpu-time filling in a stack trace which isn't used actually.

This is particularity problematic on Java 8 because it has a bug to throw an excessive number of ShortBufferExceptions, which was fixed on Java 11 by [JDK-8178374](https://bugs.openjdk.java.net/browse/JDK-8178374) and will be included in future OpenJDK 8. But this still be valuable for those who have to use OpenJDK8 252 or older.

The bottom screenshot was taken from my gRPC Java benchmark and it was wasting up to 9% cpu-time just calling `fillInStackTrace`.

![Screenshot from 2020-06-01 17-08-15](https://user-images.githubusercontent.com/2793282/83466221-410ad780-a42b-11ea-8616-6c74321f0938.png)

With this PR, this unnecessary code path can be removed. Note that this is sort-of implementation detail of CipherSpi and stripping the stack trace from `ShortBufferException` doesn't hurt the usability of Conscrypt. 
![Screenshot from 2020-06-01 17-18-24](https://user-images.githubusercontent.com/2793282/83466438-f3429f00-a42b-11ea-8271-fec15f1017e4.png)
