### PR TITLE
Push AliasChooser implementation down to leaf classes.

### DIFF
--- a/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
@@ -39,12 +39,11 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509KeyManager;
 import javax.security.auth.x500.X500Principal;
-import org.conscrypt.SSLParametersImpl.AliasChooser;
 
 /**
  * Abstract base class for all Conscrypt {@link SSLSocket} classes.
  */
-abstract class AbstractConscryptSocket extends SSLSocket implements AliasChooser {
+abstract class AbstractConscryptSocket extends SSLSocket {
     final Socket socket;
     private final boolean autoClose;
 
@@ -513,17 +512,6 @@ abstract class AbstractConscryptSocket extends SSLSocket implements AliasChooser
             builder.append(super.toString());
         }
         return builder.toString();
-    }
-
-    @Override
-    public final String chooseServerAlias(X509KeyManager keyManager, String keyType) {
-        return keyManager.chooseServerAlias(keyType, null, this);
-    }
-
-    @Override
-    public final String chooseClientAlias(X509KeyManager keyManager, X500Principal[] issuers,
-        String[] keyTypes) {
-        return keyManager.chooseClientAlias(keyTypes, issuers, this);
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -43,12 +43,14 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
 
 /**
  * Implements crypto handling by delegating to {@link ConscryptEngine}.
  */
-class ConscryptEngineSocket extends OpenSSLSocketImpl {
+class ConscryptEngineSocket extends OpenSSLSocketImpl implements SSLParametersImpl.AliasChooser {
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
 
     private final ConscryptEngine engine;
@@ -565,6 +567,17 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl {
 
     private InputStream getUnderlyingInputStream() throws IOException {
         return super.getInputStream();
+    }
+
+    @Override
+    public final String chooseServerAlias(X509KeyManager keyManager, String keyType) {
+        return keyManager.chooseServerAlias(keyType, null, this);
+    }
+
+    @Override
+    public final String chooseClientAlias(X509KeyManager keyManager, X500Principal[] issuers,
+                                          String[] keyTypes) {
+        return keyManager.chooseClientAlias(keyTypes, issuers, this);
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -42,7 +42,10 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
+
 import org.conscrypt.ExternalSession.Provider;
 import org.conscrypt.NativeRef.SSL_SESSION;
 
@@ -58,7 +61,8 @@ import org.conscrypt.NativeRef.SSL_SESSION;
  */
 class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
         implements NativeCrypto.SSLHandshakeCallbacks,
-                   SSLParametersImpl.PSKCallbacks {
+                   SSLParametersImpl.PSKCallbacks,
+                   SSLParametersImpl.AliasChooser {
     private static final boolean DBG_STATE = false;
 
     // @GuardedBy("ssl");
@@ -1164,6 +1168,17 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     public final SecretKey getPSKKey(PSKKeyManager keyManager, String identityHint, String identity) {
         return keyManager.getKey(identityHint, identity, this);
+    }
+
+    @Override
+    public final String chooseServerAlias(X509KeyManager keyManager, String keyType) {
+        return keyManager.chooseServerAlias(keyType, null, this);
+    }
+
+    @Override
+    public final String chooseClientAlias(X509KeyManager keyManager, X500Principal[] issuers,
+                                          String[] keyTypes) {
+        return keyManager.chooseClientAlias(keyTypes, issuers, this);
     }
 
     private ClientSessionContext clientSessionContext() {


### PR DESCRIPTION
Moving AliasChooser up to AbstractConscryptSocket was a mistake
as it also adds it to OpenSSLSocketImpl which is unwanted.

Pushing it back down to the leaf socket implementations causes
some minor code duplication but this will go away with
ConscryptFileDescriptorSocket.