### PR TITLE
Allow creation of OpenSSLKeys from hardware-backed EVP_PKEYs.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLECPublicKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECPublicKey.java
@@ -17,6 +17,7 @@
 package org.conscrypt;
 
 import java.io.IOException;
+import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.security.InvalidKeyException;
@@ -167,6 +168,9 @@ final class OpenSSLECPublicKey implements ECPublicKey, OpenSSLKeyHolder {
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {
+        if (key.isHardwareBacked()) {
+            throw new NotSerializableException("Hardware backed keys cannot be serialized");
+        }
         stream.defaultWriteObject();
         stream.writeObject(getEncoded());
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLKey.java
@@ -37,13 +37,27 @@ final class OpenSSLKey {
 
     private final boolean wrapped;
 
+    // If true, indicates that this key is hardware-backed, e.g. stored in a TEE keystore.
+    // Conscrypt never creates such keys, but setting this field to true allows developers
+    // to create an EVP_PKEY from a hardware-backed key and then create an OpenSSLKey from it
+    // which can be used with Conscrypt.
+    // Hardware-backed keys cannot be serialised or have any private key material extracted.
+    private final boolean hardwareBacked;
+
     OpenSSLKey(long ctx) {
         this(ctx, false);
     }
 
     OpenSSLKey(long ctx, boolean wrapped) {
+        this(ctx, wrapped, false);
+    }
+
+    // Constructor for users who need to set the |hardwareBacked| field to true.
+    // See the field documentation for more information.
+    OpenSSLKey(long ctx, boolean wrapped, boolean hardwareBacked) {
         this.ctx = new NativeRef.EVP_PKEY(ctx);
         this.wrapped = wrapped;
+        this.hardwareBacked = hardwareBacked;
     }
 
     /**
@@ -55,6 +69,10 @@ final class OpenSSLKey {
 
     boolean isWrapped() {
         return wrapped;
+    }
+
+    boolean isHardwareBacked() {
+        return hardwareBacked;
     }
 
     static OpenSSLKey fromPrivateKey(PrivateKey key) throws InvalidKeyException {

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateCrtKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateCrtKey.java
@@ -17,6 +17,7 @@
 package org.conscrypt;
 
 import java.io.IOException;
+import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigInteger;
@@ -217,19 +218,28 @@ final class OpenSSLRSAPrivateCrtKey extends OpenSSLRSAPrivateKey implements RSAP
             ensureReadParams();
             RSAPrivateCrtKey other = (RSAPrivateCrtKey) o;
 
-            return getModulus().equals(other.getModulus())
-                    && publicExponent.equals(other.getPublicExponent())
-                    && getPrivateExponent().equals(other.getPrivateExponent())
-                    && primeP.equals(other.getPrimeP()) && primeQ.equals(other.getPrimeQ())
-                    && primeExponentP.equals(other.getPrimeExponentP())
-                    && primeExponentQ.equals(other.getPrimeExponentQ())
-                    && crtCoefficient.equals(other.getCrtCoefficient());
+            if (getOpenSSLKey().isHardwareBacked()) {
+                return getModulus().equals(other.getModulus())
+                        && publicExponent.equals(other.getPublicExponent());
+            } else {
+                return getModulus().equals(other.getModulus())
+                        && publicExponent.equals(other.getPublicExponent())
+                        && getPrivateExponent().equals(other.getPrivateExponent())
+                        && primeP.equals(other.getPrimeP()) && primeQ.equals(other.getPrimeQ())
+                        && primeExponentP.equals(other.getPrimeExponentP())
+                        && primeExponentQ.equals(other.getPrimeExponentQ())
+                        && crtCoefficient.equals(other.getCrtCoefficient());
+            }
         } else if (o instanceof RSAPrivateKey) {
             ensureReadParams();
             RSAPrivateKey other = (RSAPrivateKey) o;
 
-            return getModulus().equals(other.getModulus())
-                    && getPrivateExponent().equals(other.getPrivateExponent());
+            if (getOpenSSLKey().isHardwareBacked()) {
+                return getModulus().equals(other.getModulus());
+            } else {
+                return getModulus().equals(other.getModulus())
+                        && getPrivateExponent().equals(other.getPrivateExponent());
+            }
         }
 
         return false;
@@ -278,6 +288,10 @@ final class OpenSSLRSAPrivateCrtKey extends OpenSSLRSAPrivateKey implements RSAP
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {
+        if (getOpenSSLKey().isHardwareBacked()) {
+            throw new NotSerializableException("Hardware backed keys cannot be serialized");
+        }
+
         ensureReadParams();
         stream.defaultWriteObject();
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateKey.java
@@ -17,6 +17,7 @@
 package org.conscrypt;
 
 import java.io.IOException;
+import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigInteger;
@@ -170,7 +171,7 @@ class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
     void readParams(byte[][] params) {
         if (params[0] == null) {
             throw new NullPointerException("modulus == null");
-        } else if (params[2] == null) {
+        } else if (params[2] == null && !key.isHardwareBacked()) {
             throw new NullPointerException("privateExponent == null");
         }
 
@@ -184,6 +185,9 @@ class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
 
     @Override
     public final BigInteger getPrivateExponent() {
+        if (key.isHardwareBacked()) {
+            throw new UnsupportedOperationException("Private exponent cannot be extracted");
+        }
         ensureReadParams();
         return privateExponent;
     }
@@ -196,11 +200,17 @@ class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
 
     @Override
     public final byte[] getEncoded() {
+        if (key.isHardwareBacked()) {
+            return null;
+        }
         return NativeCrypto.EVP_marshal_private_key(key.getNativeRef());
     }
 
     @Override
     public final String getFormat() {
+        if (key.isHardwareBacked()) {
+            return null;
+        }
         return "PKCS#8";
     }
 
@@ -271,6 +281,9 @@ class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {
+        if (key.isHardwareBacked()) {
+            throw new NotSerializableException("Hardware backed keys can not be serialized");
+        }
         ensureReadParams();
         stream.defaultWriteObject();
     }


### PR DESCRIPTION
Allows the use case of EVP_PKEYs created outside Conscrypt
whose private key material is backed by hardware and cannot
be extracted.

Originally review on AOSP: https://r.android.com/1331613