### PR TITLE
Remove redundant X509_ALGOR_cmp check.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4148,13 +4148,6 @@ static void NativeCrypto_X509_verify(JNIEnv* env, jclass, jlong x509Ref,
         return;
     }
 
-    if (X509_ALGOR_cmp(x509->sig_alg, X509_CINF_get_signature(X509_get_cert_info(x509)))) {
-        conscrypt::jniutil::throwCertificateException(env,
-                "Certificate signature algorithms do not match");
-        JNI_TRACE("X509_verify(%p, %p) => signature alg mismatch", x509, pkey);
-        return;
-    }
-
     if (X509_verify(x509, pkey) != 1) {
         conscrypt::jniutil::throwExceptionFromBoringSSLError(
                 env, "X509_verify", conscrypt::jniutil::throwCertificateException);


### PR DESCRIPTION
This check was added in be510b32477d98f12d1cbd2a9bf51d7c7e035719, to
work around some error-handling issues because, while BoringSSL did this
check, did not add an error to the error queue and Conscrypt's error
handling was very sensitive to this.

Since then, BoringSSL has fix the error-reporting, and Conscrypt has
fixed its error-handling to be based on the return value. This logic is
no longer necessary. (The test still passes when it is removed.)