### PR TITLE
Added vector copy to avoid overlapping Buffer error

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -3661,8 +3661,9 @@ static jint evp_aead_ctx_op_buf(JNIEnv* env, jlong evpAeadRef, jbyteArray keyArr
     size_t inSize = in_limit - in_position;
     uint8_t* outBufEnd = outBuf + out_limit - out_position;
     uint8_t* inBufEnd = inBuf + inSize;
-    std::unique_ptr<uint8_t[]> inCopy(new(std::nothrow) uint8_t[inSize]);
+    std::unique_ptr<uint8_t[]> inCopy;
     if (outBufEnd >= inBuf && inBufEnd >= outBuf) { // We have an overlap
+      inCopy.reset((new(std::nothrow) uint8_t[inSize]));
       if (inCopy.get() == nullptr) {
             conscrypt::jniutil::throwOutOfMemory(env, "Unable to allocate new buffer for overlap");
             return 0;

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -3658,8 +3658,8 @@ static jint evp_aead_ctx_op_buf(JNIEnv* env, jlong evpAeadRef, jbyteArray keyArr
     inBuf += in_position;
     outBuf += out_position;
 
-    uint8_t* outBufEnd = outBuf + out_limit;
-    uint8_t* inBufEnd = inBuf + in_limit;
+    uint8_t* outBufEnd = outBuf + out_limit - out_position;
+    uint8_t* inBufEnd = inBuf + in_limit - in_position;
     if (outBufEnd >= inBuf && inBufEnd >= outBuf) { // We have an overlap doggo
 //        uint8_t* inCopy = (uint8_t*) malloc(in_limit - in_position);
 //        memcpy(inCopy, inBuf, in_limit - in_position);

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -3658,6 +3658,16 @@ static jint evp_aead_ctx_op_buf(JNIEnv* env, jlong evpAeadRef, jbyteArray keyArr
     inBuf += in_position;
     outBuf += out_position;
 
+    uint8_t* outBufEnd = outBuf + out_limit;
+    uint8_t* inBufEnd = inBuf + in_limit;
+    if (outBufEnd >= inBuf && inBufEnd >= outBuf) { // We have an overlap doggo
+//        uint8_t* inCopy = (uint8_t*) malloc(in_limit - in_position);
+//        memcpy(inCopy, inBuf, in_limit - in_position);
+//        inBuf = inCopy;
+        std::vector<uint8_t> inVector(inBuf, inBuf + in_limit);
+        inBuf = inVector.data();
+    }
+
     return evp_aead_ctx_op_common(env, evpAeadRef, keyArray, tagLen, outBuf, nonceArray, inBuf, aadArray, realFunc,
                                inBuffer, outBuffer, out_limit-out_position, in_limit-in_position);
 }

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -3664,8 +3664,9 @@ static jint evp_aead_ctx_op_buf(JNIEnv* env, jlong evpAeadRef, jbyteArray keyArr
 //        uint8_t* inCopy = (uint8_t*) malloc(in_limit - in_position);
 //        memcpy(inCopy, inBuf, in_limit - in_position);
 //        inBuf = inCopy;
-        std::vector<uint8_t> inVector(inBuf, inBuf + in_limit);
-        inBuf = inVector.data();
+        std::vector<uint8_t> inVector(inBuf, inBuf + in_limit - in_position);
+        return evp_aead_ctx_op_common(env, evpAeadRef, keyArray, tagLen, outBuf, nonceArray, inVector.data(), aadArray,
+                                    realFunc, inBuffer, outBuffer, out_limit-out_position, in_limit-in_position);
     }
 
     return evp_aead_ctx_op_common(env, evpAeadRef, keyArray, tagLen, outBuf, nonceArray, inBuf, aadArray, realFunc,

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -3660,10 +3660,7 @@ static jint evp_aead_ctx_op_buf(JNIEnv* env, jlong evpAeadRef, jbyteArray keyArr
 
     uint8_t* outBufEnd = outBuf + out_limit - out_position;
     uint8_t* inBufEnd = inBuf + in_limit - in_position;
-    if (outBufEnd >= inBuf && inBufEnd >= outBuf) { // We have an overlap doggo
-//        uint8_t* inCopy = (uint8_t*) malloc(in_limit - in_position);
-//        memcpy(inCopy, inBuf, in_limit - in_position);
-//        inBuf = inCopy;
+    if (outBufEnd >= inBuf && inBufEnd >= outBuf) { // We have an overlap
         std::vector<uint8_t> inVector(inBuf, inBuf + in_limit - in_position);
         return evp_aead_ctx_op_common(env, evpAeadRef, keyArray, tagLen, outBuf, nonceArray, inVector.data(), aadArray,
                                     realFunc, inBuffer, outBuffer, out_limit-out_position, in_limit-in_position);

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -3664,7 +3664,7 @@ static jint evp_aead_ctx_op_buf(JNIEnv* env, jlong evpAeadRef, jbyteArray keyArr
     std::unique_ptr<uint8_t[]> inCopy(new(std::nothrow) uint8_t[inSize]);
     if (outBufEnd >= inBuf && inBufEnd >= outBuf) { // We have an overlap
       if (inCopy.get() == nullptr) {
-            conscrypt::jniutil::throwOutOfMemory(env, "Unable to allocate new buffer for buffer overlap");
+            conscrypt::jniutil::throwOutOfMemory(env, "Unable to allocate new buffer for overlap");
             return 0;
         }
         memcpy(inCopy.get(), inBuf, inSize);

--- a/common/src/test/java/org/conscrypt/javax/crypto/CipherBasicsTest.java
+++ b/common/src/test/java/org/conscrypt/javax/crypto/CipherBasicsTest.java
@@ -414,6 +414,95 @@ public final class CipherBasicsTest {
         return transformation;
     }
 
+    /**
+     * Encryption with ByteBuffers should be copy-safe even if the buffers have different starting
+     * offsets and/or do not make the backing array visible.
+     *
+     * <p>Note that bugs in this often require a sizeable input to reproduce; the default
+     * implementation of engineUpdate(ByteBuffer, ByteBuffer) copies through 4KB bounce buffers, so we
+     * need to use something larger to see any problems - 8KB is what we use here.
+     *
+     * @see https://bugs.openjdk.java.net/browse/JDK-8181386
+     */
+    @Test
+    public void testByteBufferShiftedAlias() throws Exception {
+        byte[] ptVector = new byte[8192];
+
+        for (int i = 0; i < 3; i++) {
+            // outputOffset = offset relative to start of input.
+            for (int outputOffset = -1; outputOffset <= 1; outputOffset++) {
+
+                SecretKeySpec key = new SecretKeySpec(new byte[16], "AES");
+                GCMParameterSpec parameters = new GCMParameterSpec(128, new byte[12]);
+                Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+                cipher.init(Cipher.ENCRYPT_MODE, key, parameters);
+
+                ByteBuffer output, input, inputRO;
+
+                // We'll try three scenarios: Ordinary array backed buffers, array backed buffers where one
+                // is read-only, and direct byte buffers.
+                String mode;
+                // offsets relative to start of buffer
+                int inputOffsetInBuffer = 1;
+                int outputOffsetInBuffer = inputOffsetInBuffer + outputOffset;
+                int sliceLength = cipher.getOutputSize(ptVector.length);
+                int bufferSize = sliceLength + Math.max(inputOffsetInBuffer, outputOffsetInBuffer);
+
+                mode = "direct buffers";
+                ByteBuffer buf = ByteBuffer.allocateDirect(bufferSize);
+                output = buf.duplicate();
+                output.position(outputOffsetInBuffer);
+                output.limit(sliceLength + outputOffsetInBuffer);
+                output = output.slice();
+
+                input = buf.duplicate();
+                input.position(inputOffsetInBuffer);
+                input.limit(sliceLength + inputOffsetInBuffer);
+                input = input.slice();
+
+                inputRO = input.duplicate();
+
+                // Now that we have our overlapping 'input' and 'output' buffers, we can write our plaintext
+                // into the input buffer.
+                input.put(ptVector);
+                input.flip();
+                // Make sure the RO input buffer has the same limit in case the plaintext is shorter than
+                // sliceLength (which it generally will be for anything other than ECB or CTR mode)
+                inputRO.limit(input.limit());
+
+                try {
+                    int ctSize = cipher.doFinal(inputRO, output);
+
+                    // Now flip the buffers around and undo everything
+                    byte[] tmp = new byte[ctSize];
+                    output.flip();
+                    output.get(tmp);
+
+                    output.clear();
+                    input.clear();
+                    inputRO.clear();
+
+                    input.put(tmp);
+                    input.flip();
+                    inputRO.limit(input.limit());
+
+                    cipher.init(Cipher.DECRYPT_MODE, key, parameters);
+                    cipher.doFinal(inputRO, output);
+
+                    output.flip();
+                    assertEquals(ByteBuffer.wrap(ptVector), output);
+                } catch (Throwable t) {
+                    throw new AssertionError(
+                            "Overlapping buffers test failed with buffer type: "
+                                    + mode
+                                    + " and output offset "
+                                    + outputOffset,
+                            t);
+                }
+            }
+        }
+    }
+
     private static byte[] toBytes(String hex) {
         return TestUtils.decodeHex(hex, /* allowSingleChar= */ true);
     }


### PR DESCRIPTION
Added unique pointer copy of input buffer so when there would be an overlap between the input and output buffers  we pass in the decoy input to BoringSSL instead. Fix for bug 161805064

I have seen that sometimes it throws a run time exception after passing initial testing but only happens in rare occurrence. I have built and tested Conscrypt multiple times and was not able to re create the error but noting it down here.

@prbprbprb 