### PR TITLE
Add a boolean to OpenSSLAeadCipher to control optimisations.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -33,6 +33,11 @@ import javax.crypto.spec.IvParameterSpec;
 @Internal
 public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     /**
+     * Controls whether no-copy optimizations for direct ByteBuffers are enabled.
+     */
+    private static final boolean ENABLE_BYTEBUFFER_OPTIMIZATIONS = true;
+
+    /**
      * The default tag size when one is not specified. Default to
      * full-length tags (128-bits or 16 octets).
      */
@@ -223,6 +228,9 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     @Override
     protected int engineDoFinal(ByteBuffer input, ByteBuffer output) throws ShortBufferException,
             IllegalBlockSizeException, BadPaddingException {
+        if (!ENABLE_BYTEBUFFER_OPTIMIZATIONS) {
+            return super.engineDoFinal(input, output);
+        }
         if (input == null || output == null) {
             throw new NullPointerException("Null ByteBuffer Error");
         }


### PR DESCRIPTION
Controls whether the no-copy optimisations for direct ByteBuffers
are enabled. If false, then the inherited default behaciour from
CipherSpi is used.