### PR TITLE
Update jarsigner logic for new Maven publishing plugin.

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -3,19 +3,6 @@ apply plugin: 'signing'
 
 def isSnapshot = project.version.contains('SNAPSHOT')
 
-signing {
-    required false
-    sign publishing.publications
-}
-
-tasks.register("signPublications").configure {
-    configurations.archives.allArtifacts.each {
-        if (it.type == 'jar' && it.classifier != 'sources' && it.classifier != 'javadoc') {
-            signJar(it.file.absolutePath)
-        }
-    }
-}
-
 publishing {
     publications {
         maven(MavenPublication) {
@@ -68,4 +55,18 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    required false
+    sign publishing.publications.maven
+}
+
+signMavenPublication.doFirst {
+    publishing.publications.maven.artifacts.each {
+        if (it.file.absolutePath.endsWith('.jar') && it.classifier != 'sources' && it.classifier != 'javadoc') {
+            logger.info("Signing jar: ${it.file.absolutePath}")
+            signJar(it.file.absolutePath)
+        }
+   }
 }


### PR DESCRIPTION
The previous hook for signing jars before Maven PGP signatures
were generated was not actually being called.

Additionally, it was signing only the generic jar, not the
platform one which actually gets uploaded.  This may have worked
with previous combinations of Gradle/Maven publishing, but
currently the platform jar is not added to
`configurations.archives.allArtifacts` (possibly a separate bug).
Workaround: search all artifacts to be uploaded for candidate
jars.

Tested on Macos and Linux.