### PR TITLE
Upgrade to Gradle 6.1.1 and use Gradle lazy APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
         shell: bash
         run: |
           echo "::set-env name=ANDROID_HOME::${{ runner.temp }}/android-sdk"
-          echo "::set-env name=ANDROID_NDK::${{ runner.temp }}/android-sdk/ndk-bundle"
           echo "::set-env name=BORINGSSL_HOME::${{ runner.temp }}/boringssl"
           echo "::set-env name=SDKMANAGER::${{ runner.temp }}/android-sdk/tools/bin/sdkmanager"
           echo "::set-env name=M2_REPO::${{ runner.temp }}/m2"
@@ -160,7 +159,7 @@ jobs:
           "$SDKMANAGER" 'build-tools;28.0.3' | tr '\r' '\n' | uniq
           "$SDKMANAGER" 'platforms;android-26' | tr '\r' '\n' | uniq
           "$SDKMANAGER" 'extras;android;m2repository' | tr '\r' '\n' | uniq
-          "$SDKMANAGER" ndk-bundle | tr '\r' '\n' | uniq
+          "$SDKMANAGER" 'ndk;21.3.6528147' | tr '\r' '\n' | uniq
           "$SDKMANAGER" 'cmake;3.10.2.4988404' | tr '\r' '\n' | uniq
 
       - name: Build with Gradle

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Gradle
 build
-gradle.properties
 .gradle
 local.properties
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
         - $ANDROID_HOME/tools/bin/sdkmanager 'build-tools;28.0.3' | tr '\r' '\n' | uniq
         - $ANDROID_HOME/tools/bin/sdkmanager 'platforms;android-26' | tr '\r' '\n' | uniq
         - $ANDROID_HOME/tools/bin/sdkmanager 'extras;android;m2repository' | tr '\r' '\n' | uniq
-        - $ANDROID_HOME/tools/bin/sdkmanager ndk-bundle | tr '\r' '\n' | uniq
+        - $ANDROID_HOME/tools/bin/sdkmanager 'ndk;21.3.6528147' | tr '\r' '\n' | uniq
         - $ANDROID_HOME/tools/bin/sdkmanager 'cmake;3.10.2.4988404' | tr '\r' '\n' | uniq
         - gimme 1.13 # Needed for BoringSSL build
         - source ~/.gimme/envs/go1.13.env

--- a/android-stub/build.gradle
+++ b/android-stub/build.gradle
@@ -9,4 +9,4 @@ dependencies {
 }
 
 // Disable the javadoc task.
-tasks.withType(Javadoc).all { enabled = false }
+tasks.withType(Javadoc).configureEach { enabled = false }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,7 @@ ext {
     androidVersionName = "$version"
     androidMinSdkVersion = 9
     androidTargetSdkVersion = 26
+    androidNdkVersion = "21.3.6528147"
 }
 
 if (androidSdkInstalled) {
@@ -32,6 +33,7 @@ if (androidSdkInstalled) {
 
     android {
         compileSdkVersion androidTargetSdkVersion
+        ndkVersion androidNdkVersion
 
         compileOptions {
             sourceCompatibility androidMinJavaVersion

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -119,14 +119,15 @@ if (androidSdkInstalled) {
         compileOnly project(':conscrypt-constants')
     }
 
-    task configureJavadocs {
+    def configureJavaDocs = tasks.register("configureJavadocs") {
         dependsOn configurations.publicApiDocs
         doLast {
             javadocs.options.docletpath = configurations.publicApiDocs.files as List
         }
     }
 
-    task javadocs(type: Javadoc, dependsOn: [configureJavadocs]) {
+    def javadocs = tasks.register("javadocs", Javadoc) {
+        dependsOn configureJavadocs
         source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator)) + project(':conscrypt-android-stub').sourceSets.main.output
         // TODO(nmittler): Fix the javadoc errors.
@@ -142,12 +143,15 @@ if (androidSdkInstalled) {
         }
     }
 
-    task javadocsJar(type: Jar, dependsOn: javadocs) {
+    def javadocsJar = tasks.register("javadocsJar", Jar) {
+        dependsOn javadocs
         classifier = 'javadoc'
-        from javadocs.destinationDir
+        from {
+            javadocs.get().destinationDir
+        }
     }
 
-    task sourcesJar(type: Jar) {
+    def sourcesJar = tasks.register("sourcesJar", Jar) {
         classifier = 'sources'
         from android.sourceSets.main.java.srcDirs
     }
@@ -155,8 +159,8 @@ if (androidSdkInstalled) {
     apply from: "$rootDir/gradle/publishing.gradle"
     publishing.publications.maven {
         from components.android
-        artifact sourcesJar
-        artifact javadocsJar
+        artifact sourcesJar.get()
+        artifact javadocsJar.get()
     }
 } else {
     logger.warn('Android SDK has not been detected. The Android module will not be built.')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -166,7 +166,7 @@ if (androidSdkInstalled) {
     logger.warn('Android SDK has not been detected. The Android module will not be built.')
 
     // Disable all tasks
-    tasks.collect {
+    tasks.configureEach {
         it.enabled = false
     }
 }

--- a/api-doclet/build.gradle
+++ b/api-doclet/build.gradle
@@ -1,6 +1,8 @@
 description = 'Conscrypt: API Doclet'
 
-dependencies {
-    // This should be removed when upgrading to Gradle 5.x
-    compile files(org.gradle.internal.jvm.Jvm.current().toolsJar)
+def toolsJar = org.gradle.internal.jvm.Jvm.current().toolsJar
+if (toolsJar != null) {
+    dependencies {
+        compile files(toolsJar)
+    }
 }

--- a/benchmark-android/build.gradle
+++ b/benchmark-android/build.gradle
@@ -83,7 +83,7 @@ if (androidSdkInstalled) {
     // the .aar and .jar contents before the actual archives are built. To do this we create a
     // configure task where the "from" contents is set inside a doLast stanza to ensure it is run
     // after the execution phase of the "assemble" task.
-    task configureDepsJar {
+    def configureDepsJar = tasks.register("configureDepsJar") {
         dependsOn assemble, \
                   configurations.depsJarApi.artifacts, \
                   configurations.depsJarImplementation.artifacts
@@ -124,11 +124,12 @@ if (androidSdkInstalled) {
         }
     }
 
-    task depsJar(type: Jar, dependsOn: configureDepsJar) {
+    def depsJar = tasks.register("depsJar", Jar) {
+        dependsOn configureDepsJar
         archiveName = 'bundled-deps.jar'
     }
 
-    task getAndroidDeviceAbi {
+    def getAndroidDeviceAbi = tasks.register("getAndroidDeviceAbi") {
         doLast {
             new ByteArrayOutputStream().withStream { os ->
                 def result = exec {
@@ -142,7 +143,7 @@ if (androidSdkInstalled) {
         }
     }
 
-    task configureExtractNativeLib {
+    def configureExtractNativeLib = tasks.register("configureExtractNativeLib") {
         dependsOn getAndroidDeviceAbi, depsJar
         doLast {
             extractNativeLib.from {
@@ -156,11 +157,12 @@ if (androidSdkInstalled) {
         }
     }
 
-    task extractNativeLib(type: Copy, dependsOn: configureExtractNativeLib) {
+    def extractNativeLib = tasks.register("extractNativeLib", Copy) {
+        dependsOn configureExtractNativeLib
         into "$buildDir/extracted-native-libs"
     }
 
-    task configurePushNativeLibrary {
+    def configurePushNativeLibrary = tasks.register("configurePushNativeLibrary") {
         dependsOn extractNativeLib
         doLast {
             project.ext.nativeLibPath = "/system/lib${androidDevice64Bit ? '64' : ''}/libconscrypt_jni.so"
@@ -168,11 +170,13 @@ if (androidSdkInstalled) {
         }
     }
 
-    task pushNativeLibrary(type: Exec, dependsOn: configurePushNativeLibrary) {
+    def pushNativeLibrary = tasks.register("pushNativeLibrary", Exec) {
+        dependsOn configurePushNativeLibrary
         pushNativeLibrary.executable android.adbExecutable
     }
 
-    task runBenchmarks(dependsOn: [depsJar, pushNativeLibrary]) {
+    def runBenchmarks = tasks.register("runBenchmarks") {
+        dependsOn depsJar, pushNativeLibrary
         doLast {
             // Execute the benchmarks
             exec {

--- a/benchmark-android/build.gradle
+++ b/benchmark-android/build.gradle
@@ -202,7 +202,7 @@ if (androidSdkInstalled) {
     logger.warn('Android SDK has not been detected. The Android Benchmark module will not be built.')
 
     // Disable all tasks
-    tasks.collect {
+    tasks.configureEach {
         it.enabled = false
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.util.VersionNumber
 
 buildscript {
-    ext.android_tools = 'com.android.tools.build:gradle:3.5.0'
+    ext.android_tools = 'com.android.tools.build:gradle:4.0.0'
     ext.errorproneVersion = '2.3.3'
     ext.errorproneJavacVersion = '9+181-r4173-1'
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ subprojects {
         errorproneJavac("com.google.errorprone:javac:$errorproneJavacVersion")
     }
 
-    task generateProperties(type: WriteProperties) {
+    tasks.register("generateProperties", WriteProperties) {
         ext {
             parsedVersion = VersionNumber.parse(version)
         }
@@ -168,26 +168,30 @@ subprojects {
         sourceCompatibility = JavaVersion.VERSION_1_7
         targetCompatibility = JavaVersion.VERSION_1_7
 
-        [compileJava, compileTestJava].each() {
-            it.options.compilerArgs += ["-Xlint:all", "-Xlint:-options", '-Xmaxwarns', '9999999']
-            it.options.encoding = "UTF-8"
-            if (rootProject.hasProperty('failOnWarnings') && rootProject.failOnWarnings.toBoolean()) {
-                it.options.compilerArgs += ["-Werror"]
+        [tasks.named("compileJava"), tasks.named("compileTestJava")].forEach { t ->
+            t.configure {
+                options.compilerArgs += ["-Xlint:all", "-Xlint:-options", '-Xmaxwarns', '9999999']
+                options.encoding = "UTF-8"
+                if (rootProject.hasProperty('failOnWarnings') && rootProject.failOnWarnings.toBoolean()) {
+                    options.compilerArgs += ["-Werror"]
+                }
             }
         }
 
-        compileTestJava {
+        tasks.named("compileTestJava").configure {
             // serialVersionUID is basically guaranteed to be useless in our tests
             options.compilerArgs += ["-Xlint:-serial"]
         }
 
-        jar.manifest {
-            attributes('Implementation-Title': name,
-                    'Implementation-Version': version,
-                    'Built-By': System.getProperty('user.name'),
-                    'Built-JDK': System.getProperty('java.version'),
-                    'Source-Compatibility': sourceCompatibility,
-                    'Target-Compatibility': targetCompatibility)
+        tasks.named("jar").configure {
+            manifest {
+                attributes('Implementation-Title': name,
+                        'Implementation-Version': version,
+                        'Built-By': System.getProperty('user.name'),
+                        'Built-JDK': System.getProperty('java.version'),
+                        'Source-Compatibility': sourceCompatibility,
+                        'Target-Compatibility': targetCompatibility)
+            }
         }
 
         javadoc.options {
@@ -204,12 +208,12 @@ subprojects {
             }
         }
 
-        task javadocJar(type: Jar) {
+        tasks.register("javadocJar", Jar) {
             classifier = 'javadoc'
             from javadoc
         }
 
-        task sourcesJar(type: Jar) {
+        tasks.register("sourcesJar", Jar) {
             classifier = 'sources'
             from sourceSets.main.allSource
         }

--- a/constants/build.gradle
+++ b/constants/build.gradle
@@ -71,4 +71,4 @@ model {
 }
 
 // Disable the javadoc task.
-tasks.withType(Javadoc).all { enabled = false }
+tasks.withType(Javadoc).configureEach { enabled = false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libcore-stub/build.gradle
+++ b/libcore-stub/build.gradle
@@ -16,4 +16,4 @@ dependencies {
 }
 
 // Disable the javadoc task.
-tasks.withType(Javadoc).all { enabled = false }
+tasks.withType(Javadoc).configureEach { enabled = false }

--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -34,7 +34,8 @@ if (buildUberJar) {
     /**
      * Copy the native libraries to the resources directory.
      */
-    task copySharedLibs(type: Copy, dependsOn: configurations.uberJar) {
+    def copySharedLibs = tasks.register("copySharedLibs",  Copy) {
+        dependsOn configurations.uberJar
         from {
             configurations.uberJar.collect {
                 zipTree(it)
@@ -43,12 +44,15 @@ if (buildUberJar) {
         include '/META-INF/native/**'
         into file(resourcesDir)
     }
-    jar.dependsOn copySharedLibs
+    tasks.named("jar").configure {
+        dependsOn copySharedLibs
+    }
 
     /**
      * Copy the object files to the classes directory.
      */
-    task copyClasses(type: Copy, dependsOn: configurations.uberJar) {
+    def copyClasses = tasks.register("copyClasses", Copy) {
+        dependsOn configurations.uberJar
         from {
             configurations.uberJar.collect {
                 zipTree(it)
@@ -57,15 +61,20 @@ if (buildUberJar) {
         exclude '/META-INF/**'
         into file(classesDir)
     }
-    jar.dependsOn copyClasses
+    tasks.named("jar").configure {
+        dependsOn copyClasses
+    }
 
-    task copySources(type: Copy, dependsOn: ":conscrypt-openjdk:sourcesJar") {
+    def copySources = tasks.register("copySources", Copy) {
+        dependsOn ":conscrypt-openjdk:sourcesJar"
         from {
             project(":conscrypt-openjdk").sourceSets.main.java
         }
         into file(sourcesDir)
     }
-    sourcesJar.dependsOn copySources
+    tasks.named("sourcesJar").configure {
+        dependsOn copySources
+    }
 
     // Note that this assumes that the version of BoringSSL for each
     // artifact exactly matches the one on the current system.

--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -84,7 +84,7 @@ if (buildUberJar) {
     }
 } else {
     // Not building an uber jar - disable all tasks.
-    tasks.collect {
+    tasks.configureEach {
         it.enabled = false
     }
 }

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -82,12 +82,12 @@ compileJava {
     dependsOn generateProperties
 }
 
-task platformJar(type: Jar) {
+tasks.register("platformJar", Jar) {
     from sourceSets.platform.output
 }
 
 if (isExecutableOnPath('cpplint')) {
-    task cpplint(type: Exec) {
+    def cpplint = tasks.register("cpplint", Exec) {
         executable = 'cpplint'
 
         // TODO(nmittler): Is there a better way of getting the JNI sources?
@@ -190,8 +190,7 @@ nativeClassifiers.each { nativeClassifier ->
 def addNativeJar(nativeClassifier) {
     // Create a JAR for this configuration and add it to the output archives.
     SourceSet sourceSet = sourceSet(nativeClassifier)
-    def jarTaskName = sourceSet.jarTaskName
-    task "$jarTaskName"(type: Jar) { Jar t ->
+    def jarTask = tasks.register(sourceSet.jarTaskName, Jar) { Jar t ->
         // Depend on the regular classes task
         dependsOn classes
         manifest = jar.manifest
@@ -206,13 +205,11 @@ def addNativeJar(nativeClassifier) {
         }
     }
 
-    def jarTask = tasks["$jarTaskName"]
-
     // Add the jar task to the standard build.
     jar.dependsOn jarTask
 
     // Add it to the publishing archives list.
-    publishing.publications.maven.artifact jarTask
+    publishing.publications.maven.artifact jarTask.get()
 }
 
 
@@ -233,7 +230,7 @@ test {
     include suiteClass, "org/conscrypt/ConscryptOpenJdkSuite.class"
 }
 
-task testFdSocket(type: Test) {
+def testFdSocket = tasks.register("testFdSocket", Test) {
     include suiteClass, "org/conscrypt/ConscryptOpenJdkSuite.class"
     InvokerHelper.setProperties(testLogging, test.testLogging.properties)
     systemProperties = test.systemProperties
@@ -247,7 +244,7 @@ check.dependsOn testFdSocket
 // if Conscrypt is installed as the default provider, so these need to live in
 // a different task than the other tests, most of which need Conscrypt to be
 // installed to function.
-task testInterop(type: Test) {
+def testInterop = tasks.register("testInterop", Test) {
     include "org/conscrypt/ConscryptEngineTest.class"
     include "org/conscrypt/RenegotiationTest.class"
 }
@@ -400,8 +397,8 @@ model {
             def source = binary.sharedLibraryFile
 
             // Copies the native library to a resource location that will be included in the jar.
-            def copyTaskName = "copyNativeLib${sourceSetName}"
-            task "$copyTaskName"(type: Copy, dependsOn: binary.tasks.link) {
+            def copyTask = project.tasks.register("copyNativeLib${sourceSetName}", Copy) {
+                dependsOn binary.tasks.link
                 from source
                 // Rename the artifact to include the generated classifier
                 rename '(.+)(\\.[^\\.]+)', "\$1-$classifier\$2"
@@ -413,12 +410,14 @@ model {
             if (osName == 'linux' && (!rootProject.hasProperty('nostrip') ||
                     !rootProject.nostrip.toBoolean())) {
                 def stripTask = binary.tasks.taskName("strip")
-                    task "$stripTask"(type: Exec) {
-                        dependsOn binary.tasks.link
-                        executable "strip"
-                        args binary.tasks.link.linkedFile.asFile.get()
-                    }
-                project.tasks["$copyTaskName"].dependsOn stripTask
+                project.tasks.register(stripTask as String, Exec) {
+                    dependsOn binary.tasks.link
+                    executable "strip"
+                    args binary.tasks.link.linkedFile.asFile.get()
+                }
+                copyTask.configure {
+                    dependsOn stripTask
+                }
             }
         }
     }

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -109,7 +109,7 @@ if (androidSdkInstalled) {
     }
 
     // Disable running the tests.
-    tasks.withType(Test){
+    tasks.withType(Test).configureEach {
         enabled = false
     }
 

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -117,7 +117,7 @@ if (androidSdkInstalled) {
     logger.warn('Android SDK has not been detected. The Android Platform module will not be built.')
 
     // Disable all tasks
-    tasks.collect {
+    tasks.configureEach {
         it.enabled = false
     }
 }


### PR DESCRIPTION
Upgrade to Gradle 6.1.1 and newer Android gradle plugin.

These changes also use Gradle's lazy API to avoid task execution. Below are statistics. The "Created immediately" and "Created during configuration" are the 'bad' things to avoid.

**Before lazy API usage:**

Total Tasks | 1021
--- | ---
Created immediately | 57	 	 
Created during configuration |	114	 	 
Created during task execution | 14	 	 
Created during task graph calculation | 224	 	 
Not created | 612	 	 

**After lazy API usage:**

Total tasks  | 1048
--- | ---	 	 
Created immediately | 6	 	 
Created during configuration | 44	 	 
Created during task execution | 15	 	 
Created during task graph calculation | 307	 	 
Not created | 676	 	 