### PR TITLE
Test Conscrypt on multiple Java versions and OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,10 +307,3 @@ jobs:
         with:
           name: test-results-${{ matrix.platform }}-${{ matrix.java }}
           path: results
-
-      - name: Publish test results
-        uses: scacap/action-surefire-report@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          check_name: OpenJDK Test Report (${{ matrix.platform }}, ${{ matrix.java }})
-          report_paths: 'results/**/TEST-*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,19 @@ jobs:
           name: m2repo-${{ runner.os }}
           path: ${{ runner.temp }}/m2
 
+      - name: Build test JAR with dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: ./gradlew :conscrypt-openjdk:testJar -PcheckErrorQueue
+
+      - name: Upload test JAR with dependencies
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v2
+        with:
+          name: testjar
+          path: openjdk/build/libs/conscrypt-openjdk-*-tests.jar
+          if-no-files-found: error
+
   uberjar:
     needs: build
 
@@ -232,3 +245,64 @@ jobs:
         with:
           name: m2repo-uber
           path: ${{ runner.temp }}/m2
+
+  openjdk-test:
+    needs: uberjar
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        java: [8, 9, 11]
+        include:
+          - java: 8
+            suite_class: "org.conscrypt.Conscrypt(OpenJdk)?Suite"
+          - java: 9
+            suite_class: "org.conscrypt.Conscrypt(OpenJdk)?Suite"
+          - java: 11
+            suite_class: "org.conscrypt.Conscrypt(OpenJdk)?Suite"
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: Download UberJAR
+        uses: actions/download-artifact@v2
+        with:
+          name: m2repo-uber
+          path: m2
+
+      - name: Download Test JAR with Dependencies
+        uses: actions/download-artifact@v2
+        with:
+          name: testjar
+          path: testjar
+
+      - name: Download JUnit runner
+        shell: bash
+        run: mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:copy -Dartifact=org.junit.platform:junit-platform-console-standalone:1.6.2 -DoutputDirectory=. -Dmdep.stripVersion=true
+
+      - name: Run JUnit tests
+        shell: bash
+        run: |
+          DIR="$(find m2/org/conscrypt/conscrypt-openjdk-uber -maxdepth 1 -mindepth 1 -type d -print)"
+          VERSION="${DIR##*/}"
+          TESTJAR="$(find testjar -name '*-tests.jar')"
+          java -jar junit-platform-console-standalone.jar -cp "$DIR/conscrypt-openjdk-uber-$VERSION.jar:$TESTJAR" -n='${{ matrix.suite_class }}' --scan-classpath --reports-dir=results
+
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-${{ matrix.platform }}-${{ matrix.java }}
+          path: results
+
+      - name: Publish test results
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: OpenJDK Test Report (${{ matrix.platform }}, ${{ matrix.java }})
+          report_paths: 'results/**/TEST-*.xml'

--- a/benchmark-android/build.gradle
+++ b/benchmark-android/build.gradle
@@ -69,7 +69,7 @@ if (androidSdkInstalled) {
                    libraries.bouncycastle_apis
 
         depsJarImplementation project(':conscrypt-benchmark-base'),
-                              project(':conscrypt-testing'),
+                              project(path: ":conscrypt-testing", configuration: "runtime"),
                               project(':conscrypt-libcore-stub')
 
         implementation 'com.google.caliper:caliper:1.0-beta-2'

--- a/benchmark-base/build.gradle
+++ b/benchmark-base/build.gradle
@@ -5,6 +5,6 @@ sourceCompatibility = androidMinJavaVersion
 targetCompatibility = androidMinJavaVersion
 
 dependencies {
-    compile project(':conscrypt-testing'),
+    compile project(path: ":conscrypt-testing", configuration: "runtime"),
             libraries.junit
 }

--- a/benchmark-jmh/build.gradle
+++ b/benchmark-jmh/build.gradle
@@ -69,7 +69,7 @@ sourceSets {
 }
 
 dependencies {
-    compile project(':conscrypt-openjdk'),
+    compile project(path: ":conscrypt-openjdk", configuration: "runtime"),
             project(':conscrypt-benchmark-base'),
             // Add the preferred native openjdk configuration for this platform.
             project(':conscrypt-openjdk').sourceSets["$preferredSourceSet"].output,

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -1,4 +1,9 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version '6.0.0'
+}
+
 import aQute.bnd.gradle.BundleTaskConvention
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.codehaus.groovy.runtime.InvokerHelper
 
 apply plugin: 'biz.aQute.bnd.builder'
@@ -86,6 +91,12 @@ tasks.register("platformJar", Jar) {
     from sourceSets.platform.output
 }
 
+tasks.register("testJar", ShadowJar) {
+    classifier = 'tests'
+    configurations = [project.configurations.testRuntime]
+    from sourceSets.test.output
+}
+
 if (isExecutableOnPath('cpplint')) {
     def cpplint = tasks.register("cpplint", Exec) {
         executable = 'cpplint'
@@ -168,8 +179,8 @@ dependencies {
     // This is listed as compile-only, but we absorb its contents.
     compileOnly project(':conscrypt-constants')
 
-    testImplementation project(':conscrypt-constants'),
-            project(':conscrypt-testing'),
+    testCompile project(':conscrypt-constants'),
+            project(path: ':conscrypt-testing', configuration: 'shadow'),
             libraries.junit,
             libraries.mockito
 

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -99,7 +99,7 @@ if (androidSdkInstalled) {
             exclude module: 'appcompat-v7'
             exclude module: 'design'
         })
-        testImplementation project(':conscrypt-testing'),
+        testImplementation project(path: ":conscrypt-testing", configuration: "runtime"),
                            libraries.junit
         compileOnly project(':conscrypt-android-stub'),
                     project(':conscrypt-libcore-stub')

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version '6.0.0'
+}
+
 description = 'Conscrypt: Testing'
 
 sourceSets {


### PR DESCRIPTION
This pull request creates a JAR with all the dependencies necessary to run JUnit tests with the [JUnit ConsoleLauncher](https://junit.org/junit5/docs/current/user-guide/#running-tests-console-launcher). This reduces the time needed per testing matrix target by eliminating all the Gradle build times.