### PR TITLE
GitHub Actions: try to fix MacOS checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Clone BoringSSL repo
         run: |
-          git clone --depth 1 --filter=blob:none --no-checkout https://boringssl.googlesource.com/boringssl.git "${{ runner.temp }}/boringssl"
+          git clone --depth 1 --filter=blob:none --no-checkout https://github.com/google/boringssl.git "${{ runner.temp }}/boringssl"
           echo Using BoringSSL commit: $(cd "${{ runner.temp }}/boringssl"; git rev-parse HEAD)
 
       - name: Archive BoringSSL source
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           cd "$BORINGSSL_HOME"
-          git checkout master
+          git checkout --progress --force -B master
 
       - name: Build BoringSSL 64-bit Linux and MacOS
         if: runner.os != 'Windows'


### PR DESCRIPTION
Git is timing out checking out the BoringSSL repo, so try to use the
GitHub mirror of BoringSSL instead.

Also add --progress to get a little bit more feedback in case it does
fail again.