### PR TITLE
Static link to libstdc++ and libgcc for Linux

### DIFF
--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -339,10 +339,18 @@ model {
                         // Static link to BoringSSL
                         linker.args "-O3",
                                 "-fvisibility=hidden",
-                                "-lstdc++",
                                 "-lpthread",
                                 libPath + "/ssl/libssl.a",
                                 libPath + "/crypto/libcrypto.a"
+                        if (targetPlatform.operatingSystem.isLinux()) {
+                            // Static link libstdc++ and libgcc because
+                            // they are not available in some restrictive Linux
+                            // environments.
+                            linker.args "-static-libstdc++",
+                                    "-static-libgcc"
+                        } else {
+                            linker.args "-lstdc++"
+                        }
                     } else if (toolChain in VisualCpp) {
                         cppCompiler.define "DLL_EXPORT"
                         cppCompiler.define "WIN32_LEAN_AND_MEAN"


### PR DESCRIPTION
Some restricted environments do not have libgcc and libstdc++ available.
Instead, statically link them in for maximal compatibility.

The tradeoff is that this increases the final size of the jar by around
500k. Longer term it may be possible to remove the dependency on these
libraries altogether.

Fixes #874