### PR TITLE
Fix getSigAlgOID() for unknown OIDs

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4512,8 +4512,11 @@ static jstring NativeCrypto_get_X509_CRL_sig_alg_oid(JNIEnv* env, jclass, jlong 
         return nullptr;
     }
 
-    int nid = X509_CRL_get_signature_nid(crl);
-    return ASN1_OBJECT_to_OID_string(env, OBJ_nid2obj(nid));
+    const X509_ALGOR *sig_alg;
+    X509_CRL_get0_signature(crl, nullptr, &sig_alg);
+    const ASN1_OBJECT *oid;
+    X509_ALGOR_get0(&oid, nullptr, nullptr, sig_alg);
+    return ASN1_OBJECT_to_OID_string(env, oid);
 }
 
 static jbyteArray NativeCrypto_get_X509_CRL_sig_alg_parameter(JNIEnv* env, jclass, jlong x509CrlRef,
@@ -5779,8 +5782,11 @@ static jstring NativeCrypto_get_X509_sig_alg_oid(JNIEnv* env, jclass, jlong x509
         return nullptr;
     }
 
-    int nid = X509_get_signature_nid(x509);
-    return ASN1_OBJECT_to_OID_string(env, OBJ_nid2obj(nid));
+    const X509_ALGOR *sig_alg;
+    X509_get0_signature(nullptr, &sig_alg, x509);
+    const ASN1_OBJECT *oid;
+    X509_ALGOR_get0(&oid, nullptr, nullptr, sig_alg);
+    return ASN1_OBJECT_to_OID_string(env, oid);
 }
 
 static jbyteArray NativeCrypto_get_X509_sig_alg_parameter(JNIEnv* env, jclass, jlong x509Ref,

--- a/common/src/test/java/org/conscrypt/java/security/cert/X509CRLTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/cert/X509CRLTest.java
@@ -91,6 +91,18 @@ public class X509CRLTest {
             + "nDN0LLg=\n"
             + "-----END X509 CRL-----\n";
 
+    private static final String UNKNOWN_SIGNATURE_OID =
+        "-----BEGIN X509 CRL-----\n"
+            + "MIIBVzCBvgIBATAQBgwqhkiG9xIEAYS3CQIFADBVMQswCQYDVQQGEwJHQjEkMCIG\n"
+            + "A1UEChMbQ2VydGlmaWNhdGUgVHJhbnNwYXJlbmN5IENBMQ4wDAYDVQQIEwVXYWxl\n"
+            + "czEQMA4GA1UEBxMHRXJ3IFdlbhcNMTkwODA3MTAyNzEwWhcNMTkwOTA2MTAyNzEw\n"
+            + "WjAiMCACAQcXDTE5MDgwNzEwMjY1NFowDDAKBgNVHRUEAwoBAaAOMAwwCgYDVR0U\n"
+            + "BAMCAQIwEAYMKoZIhvcSBAGEtwkCBQADgYEAzF/DLiIvZDX4FpSjNCnwKRblnhJL\n"
+            + "Z1NNBAHxcRbfFY3psobvbGGOjxzCQW/03gkngG5VrSfdVOLMmQDrAxpKqeYqFDj0\n"
+            + "HAenWugbCCHWAw8WN9XSJ4nGxdRiacG/5vEIx00ICUGCeGcnqWsSnFtagDtvry2c\n"
+            + "4MMexbSPnDN0LLg=\n"
+            + "-----END X509 CRL-----\n";
+
     @Test
     public void testCrl() throws Exception {
         ServiceTester.test("CertificateFactory")
@@ -126,6 +138,21 @@ public class X509CRLTest {
                     assertNull(crl.getRevokedCertificate(ca));
 
                     assertEquals(Collections.singleton(entry), crl.getRevokedCertificates());
+                }
+            });
+    }
+
+    @Test
+    public void testUnknownSigAlgOID() throws Exception {
+        ServiceTester.test("CertificateFactory")
+            .withAlgorithm("X509")
+            .run(new ServiceTester.Test() {
+                @Override
+                public void test(Provider p, String algorithm) throws Exception {
+                    CertificateFactory cf = CertificateFactory.getInstance("X509", p);
+                    X509CRL crl = (X509CRL) cf.generateCRL(new ByteArrayInputStream(
+                            UNKNOWN_SIGNATURE_OID.getBytes(StandardCharsets.US_ASCII)));
+                    assertEquals("1.2.840.113554.4.1.72585.2", crl.getSigAlgOID());
                 }
             });
     }

--- a/common/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
@@ -124,6 +124,24 @@ public class X509CertificateTest {
             + "Qhy0YgIgYWr0qSCLqxUQv3oQHMUpSmfHtP0Pwvb3DbbH6lY7TkI=\n"
             + "-----END CERTIFICATE-----\n";
 
+    /**
+     * This cert is signed with OID 1.2.840.113554.4.1.72585.2 instead of a
+     * standard one.
+     */
+    private static final String UNKNOWN_SIGNATURE_OID =
+            "-----BEGIN CERTIFICATE-----\n"
+            + "MIIB2TCCAXugAwIBAgIJANlMBNpJfb/rMA4GDCqGSIb3EgQBhLcJAjBFMQswCQYD\n"
+            + "VQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQg\n"
+            + "V2lkZ2l0cyBQdHkgTHRkMB4XDTE0MDQyMzIzMjE1N1oXDTE0MDUyMzIzMjE1N1ow\n"
+            + "RTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGElu\n"
+            + "dGVybmV0IFdpZGdpdHMgUHR5IEx0ZDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA\n"
+            + "BOYraeK/ZZ+Xvi8eDZSKTNWXa7epHg1G+92pqR6d3LpaAefWl6gKGPnDxKMeVuJ8\n"
+            + "g0jbFhoc9R1+8ZQtS89yIsGjUDBOMB0GA1UdDgQWBBSrhNKsq5Xwgk4WeAdVV1/k\n"
+            + "Jo2C0TAfBgNVHSMEGDAWgBSrhNKsq5Xwgk4WeAdVV1/kJo2C0TAMBgNVHRMEBTAD\n"
+            + "AQH/MA4GDCqGSIb3EgQBhLcJAgNIADBFAiEA8qA1XlE6NsOCeZvuJ1CFjnAGdJVX\n"
+            + "0il0APS+FYddxAcCIHweeRRqIYPwenRoeV8UmZpotPHLnhVe5h8yUmFedckU\n"
+            + "-----END CERTIFICATE-----\n";
+
     // See issue #539.
     @Test
     public void testMismatchedAlgorithm() throws Exception {
@@ -184,6 +202,22 @@ public class X509CertificateTest {
                         VALID_CERT.getBytes(Charset.forName("US-ASCII"))));
                     assertEquals("SHA256WITHRSA",
                         ((X509Certificate) c).getSigAlgName().toUpperCase());
+                }
+            });
+    }
+
+    @Test
+    public void testUnknownSigAlgOID() throws Exception {
+        ServiceTester.test("CertificateFactory")
+            .withAlgorithm("X509")
+            .run(new ServiceTester.Test() {
+                @Override
+                public void test(Provider p, String algorithm) throws Exception {
+                    CertificateFactory cf = CertificateFactory.getInstance("X509", p);
+                    Certificate c = cf.generateCertificate(new ByteArrayInputStream(
+                            UNKNOWN_SIGNATURE_OID.getBytes(Charset.forName("US-ASCII"))));
+                    assertEquals(
+                            "1.2.840.113554.4.1.72585.2", ((X509Certificate) c).getSigAlgOID());
                 }
             });
     }


### PR DESCRIPTION
b5fc93b8bf7e8cbdd765200e06d7f54a72514f69 switched the certificate and CRL getSigAlgOID() methods to using X509_get_signature_nid() and X509_CRL_get_signature_nid(). This is *almost* the same but, by roundtripping through NIDs, it only handles OIDs that BoringSSL knows about.

Instead, grab the actual ASN1_OBJECT which, alas, uses some of OpenSSL's more tedious accessors. Add tests to cover this case.