### PR TITLE
Make testing of handshake session cipher suite consistent.

### DIFF
--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -32,6 +32,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.KeyManager;
@@ -554,7 +555,7 @@ public class SSLEngineTest {
         final TestSSLContext referenceContext = TestSSLContext.create();
         final SSLEngine referenceEngine = referenceContext.clientContext.createSSLEngine();
 
-        final boolean[] wasCalled = new boolean[1];
+        final AtomicInteger checkServerTrustedWasCalled = new AtomicInteger(0);
         TestSSLContext c = TestSSLContext.newBuilder()
             .clientTrustManager(new X509ExtendedTrustManager() {
                 @Override
@@ -591,9 +592,11 @@ public class SSLEngineTest {
                         String sessionSuite = session.getCipherSuite();
                         List<String> enabledSuites =
                             Arrays.asList(referenceEngine.getEnabledCipherSuites());
-                        assertTrue(enabledSuites.contains(sessionSuite));
+                        String message = "Handshake session has invalid cipher suite: "
+                                + (sessionSuite == null ? "(null)" : sessionSuite);
+                        assertTrue(message, enabledSuites.contains(sessionSuite));
 
-                        wasCalled[0] = true;
+                        checkServerTrustedWasCalled.incrementAndGet();
                     } catch (Exception e) {
                         throw new CertificateException("Something broke", e);
                     }
@@ -618,7 +621,7 @@ public class SSLEngineTest {
             }).build();
         TestSSLEnginePair pair = TestSSLEnginePair.create(c);
         pair.close();
-        assertTrue(wasCalled[0]);
+        assertEquals(1, checkServerTrustedWasCalled.get());
     }
 
     @Test
@@ -629,7 +632,7 @@ public class SSLEngineTest {
         final TestSSLContext referenceContext = TestSSLContext.create();
         final SSLEngine referenceEngine = referenceContext.clientContext.createSSLEngine();
 
-        final boolean[] wasCalled = new boolean[1];
+        final AtomicInteger checkClientTrustedWasCalled = new AtomicInteger(0);
         TestSSLContext c = TestSSLContext.newBuilder()
             .client(TestKeyStore.getClientCertificate())
             .serverTrustManager(new X509ExtendedTrustManager() {
@@ -654,8 +657,17 @@ public class SSLEngineTest {
                         // By the point of the handshake where we're validating client certificates,
                         // the cipher suite should be agreed and the server's own certificates
                         // should have been delivered
-                        assertEquals(referenceEngine.getEnabledCipherSuites()[0],
-                            session.getCipherSuite());
+
+                        // The negotiated cipher suite should be one of the enabled ones, but
+                        // BoringSSL may have reordered them based on things like hardware support,
+                        // so we don't know which one may have been negotiated.
+                        String sessionSuite = session.getCipherSuite();
+                        List<String> enabledSuites =
+                                Arrays.asList(referenceEngine.getEnabledCipherSuites());
+                        String message = "Handshake session has invalid cipher suite: "
+                                + (sessionSuite == null ? "(null)" : sessionSuite);
+                        assertTrue(message, enabledSuites.contains(sessionSuite));
+
                         assertNotNull(session.getLocalCertificates());
                         assertEquals("CN=localhost",
                             ((X509Certificate) session.getLocalCertificates()[0])
@@ -663,7 +675,7 @@ public class SSLEngineTest {
                         assertEquals("CN=Test Intermediate Certificate Authority",
                             ((X509Certificate) session.getLocalCertificates()[0])
                                 .getIssuerDN().getName());
-                        wasCalled[0] = true;
+                        checkClientTrustedWasCalled.incrementAndGet();
                     } catch (Exception e) {
                         throw new CertificateException("Something broke", e);
                     }
@@ -699,7 +711,7 @@ public class SSLEngineTest {
             }
         });
         pair.close();
-        assertTrue(wasCalled[0]);
+        assertEquals(1, checkClientTrustedWasCalled.get());
     }
 
     @Test


### PR DESCRIPTION
These tests should be agnostic about which suite is selected
provided that it is in the enabled set, however when the test was
duplicated into client and server versions it became opinionated
again. Similarly the error message became inconsistent during
upstreaming from AOSP.

Changed use of `final boolean[1]` to the preferred
`AtomicInteger` while I was there.

Test: gradlew check