### PR TITLE
Update MacOS CI workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
       - name: Setup macOS environment
         if: runner.os == 'macOS'
         run: |
-          brew update
           brew install ninja
           echo "::set-env name=JAVA_HOME::$(/usr/libexec/java_home -v 1.8)"
 


### PR DESCRIPTION
Looks like `brew update` is not required before `brew install
ninja` and in our case actively breaks CI.