### PR TITLE
Switch more code to X509 accessors and add some tests

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4611,55 +4611,13 @@ static jbyteArray X509Type_get_ext_oid(JNIEnv* env, const T* x509Type, jstring o
                                               i2d_ASN1_OCTET_STRING);
 }
 
-// TODO(davidben): Historically, these functions were not const-correct. Remove these wrappers once
-// https://boringssl-review.googlesource.com/c/boringssl/+/42584 has rolled out sufficiently.
-static X509_EXTENSION* X509_get_ext_const(const X509* x509, int loc) {
-    return X509_get_ext(const_cast<X509*>(x509), loc);
-}
-
-static int X509_get_ext_by_OBJ_const(const X509* x509, const ASN1_OBJECT* obj, int lastpos) {
-    return X509_get_ext_by_OBJ(const_cast<X509*>(x509), const_cast<ASN1_OBJECT*>(obj), lastpos);
-}
-
-static int X509_get_ext_by_critical_const(const X509* x509, int crit, int lastpos) {
-    return X509_get_ext_by_critical(const_cast<X509*>(x509), crit, lastpos);
-}
-
-static X509_EXTENSION* X509_CRL_get_ext_const(const X509_CRL* crl, int loc) {
-    return X509_CRL_get_ext(const_cast<X509_CRL*>(crl), loc);
-}
-
-static int X509_CRL_get_ext_by_OBJ_const(const X509_CRL* crl, const ASN1_OBJECT* obj, int lastpos) {
-    return X509_CRL_get_ext_by_OBJ(const_cast<X509_CRL*>(crl), const_cast<ASN1_OBJECT*>(obj),
-                                   lastpos);
-}
-
-static int X509_CRL_get_ext_by_critical_const(const X509_CRL* crl, int crit, int lastpos) {
-    return X509_CRL_get_ext_by_critical(const_cast<X509_CRL*>(crl), crit, lastpos);
-}
-
-static X509_EXTENSION* X509_REVOKED_get_ext_const(const X509_REVOKED* r, int loc) {
-    return X509_REVOKED_get_ext(const_cast<X509_REVOKED*>(r), loc);
-}
-
-static int X509_REVOKED_get_ext_by_OBJ_const(const X509_REVOKED* r, const ASN1_OBJECT* obj,
-                                             int lastpos) {
-    return X509_REVOKED_get_ext_by_OBJ(const_cast<X509_REVOKED*>(r), const_cast<ASN1_OBJECT*>(obj),
-                                       lastpos);
-}
-
-static int X509_REVOKED_get_ext_by_critical_const(const X509_REVOKED* r, int crit, int lastpos) {
-    return X509_REVOKED_get_ext_by_critical(const_cast<X509_REVOKED*>(r), crit, lastpos);
-}
-
 static jlong NativeCrypto_X509_CRL_get_ext(JNIEnv* env, jclass, jlong x509CrlRef,
                                            CONSCRYPT_UNUSED jobject holder, jstring oid) {
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509_CRL* crl = reinterpret_cast<X509_CRL*>(static_cast<uintptr_t>(x509CrlRef));
     JNI_TRACE("X509_CRL_get_ext(%p, %p)", crl, oid);
     X509_EXTENSION* ext =
-            X509Type_get_ext<X509_CRL, X509_CRL_get_ext_by_OBJ_const, X509_CRL_get_ext_const>(
-                    env, crl, oid);
+            X509Type_get_ext<X509_CRL, X509_CRL_get_ext_by_OBJ, X509_CRL_get_ext>(env, crl, oid);
     JNI_TRACE("X509_CRL_get_ext(%p, %p) => %p", crl, oid, ext);
     return reinterpret_cast<uintptr_t>(ext);
 }
@@ -4669,8 +4627,9 @@ static jlong NativeCrypto_X509_REVOKED_get_ext(JNIEnv* env, jclass, jlong x509Re
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509_REVOKED* revoked = reinterpret_cast<X509_REVOKED*>(static_cast<uintptr_t>(x509RevokedRef));
     JNI_TRACE("X509_REVOKED_get_ext(%p, %p)", revoked, oid);
-    X509_EXTENSION* ext = X509Type_get_ext<X509_REVOKED, X509_REVOKED_get_ext_by_OBJ_const,
-                                           X509_REVOKED_get_ext_const>(env, revoked, oid);
+    X509_EXTENSION* ext =
+            X509Type_get_ext<X509_REVOKED, X509_REVOKED_get_ext_by_OBJ, X509_REVOKED_get_ext>(
+                    env, revoked, oid);
     JNI_TRACE("X509_REVOKED_get_ext(%p, %p) => %p", revoked, oid, ext);
     return reinterpret_cast<uintptr_t>(ext);
 }
@@ -5935,8 +5894,7 @@ static jbyteArray NativeCrypto_X509_get_ext_oid(JNIEnv* env, jclass, jlong x509R
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509* x509 = reinterpret_cast<X509*>(static_cast<uintptr_t>(x509Ref));
     JNI_TRACE("X509_get_ext_oid(%p, %p)", x509, oidString);
-    return X509Type_get_ext_oid<X509, X509_get_ext_by_OBJ_const, X509_get_ext_const>(env, x509,
-                                                                                     oidString);
+    return X509Type_get_ext_oid<X509, X509_get_ext_by_OBJ, X509_get_ext>(env, x509, oidString);
 }
 
 static jbyteArray NativeCrypto_X509_CRL_get_ext_oid(JNIEnv* env, jclass, jlong x509CrlRef,
@@ -5945,8 +5903,8 @@ static jbyteArray NativeCrypto_X509_CRL_get_ext_oid(JNIEnv* env, jclass, jlong x
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509_CRL* crl = reinterpret_cast<X509_CRL*>(static_cast<uintptr_t>(x509CrlRef));
     JNI_TRACE("X509_CRL_get_ext_oid(%p, %p)", crl, oidString);
-    return X509Type_get_ext_oid<X509_CRL, X509_CRL_get_ext_by_OBJ_const, X509_CRL_get_ext_const>(
-            env, crl, oidString);
+    return X509Type_get_ext_oid<X509_CRL, X509_CRL_get_ext_by_OBJ, X509_CRL_get_ext>(env, crl,
+                                                                                     oidString);
 }
 
 static jbyteArray NativeCrypto_X509_REVOKED_get_ext_oid(JNIEnv* env, jclass, jlong x509RevokedRef,
@@ -5954,8 +5912,8 @@ static jbyteArray NativeCrypto_X509_REVOKED_get_ext_oid(JNIEnv* env, jclass, jlo
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509_REVOKED* revoked = reinterpret_cast<X509_REVOKED*>(static_cast<uintptr_t>(x509RevokedRef));
     JNI_TRACE("X509_REVOKED_get_ext_oid(%p, %p)", revoked, oidString);
-    return X509Type_get_ext_oid<X509_REVOKED, X509_REVOKED_get_ext_by_OBJ_const,
-                                X509_REVOKED_get_ext_const>(env, revoked, oidString);
+    return X509Type_get_ext_oid<X509_REVOKED, X509_REVOKED_get_ext_by_OBJ, X509_REVOKED_get_ext>(
+            env, revoked, oidString);
 }
 
 template <typename T, int (*get_ext_by_critical_func)(const T*, int, int),
@@ -6008,8 +5966,8 @@ static jobjectArray NativeCrypto_get_X509_ext_oids(JNIEnv* env, jclass, jlong x5
     CHECK_ERROR_QUEUE_ON_RETURN;
     // NOLINTNEXTLINE(runtime/int)
     JNI_TRACE("get_X509_ext_oids(0x%llx, %d)", (long long)x509Ref, critical);
-    return get_X509Type_ext_oids<X509, X509_get_ext_by_critical_const, X509_get_ext_const>(
-            env, x509Ref, critical);
+    return get_X509Type_ext_oids<X509, X509_get_ext_by_critical, X509_get_ext>(env, x509Ref,
+                                                                               critical);
 }
 
 static jobjectArray NativeCrypto_get_X509_CRL_ext_oids(JNIEnv* env, jclass, jlong x509CrlRef,
@@ -6018,8 +5976,8 @@ static jobjectArray NativeCrypto_get_X509_CRL_ext_oids(JNIEnv* env, jclass, jlon
     CHECK_ERROR_QUEUE_ON_RETURN;
     // NOLINTNEXTLINE(runtime/int)
     JNI_TRACE("get_X509_CRL_ext_oids(0x%llx, %d)", (long long)x509CrlRef, critical);
-    return get_X509Type_ext_oids<X509_CRL, X509_CRL_get_ext_by_critical_const,
-                                 X509_CRL_get_ext_const>(env, x509CrlRef, critical);
+    return get_X509Type_ext_oids<X509_CRL, X509_CRL_get_ext_by_critical, X509_CRL_get_ext>(
+            env, x509CrlRef, critical);
 }
 
 static jobjectArray NativeCrypto_get_X509_REVOKED_ext_oids(JNIEnv* env, jclass,
@@ -6027,8 +5985,8 @@ static jobjectArray NativeCrypto_get_X509_REVOKED_ext_oids(JNIEnv* env, jclass,
     CHECK_ERROR_QUEUE_ON_RETURN;
     // NOLINTNEXTLINE(runtime/int)
     JNI_TRACE("get_X509_CRL_ext_oids(0x%llx, %d)", (long long)x509RevokedRef, critical);
-    return get_X509Type_ext_oids<X509_REVOKED, X509_REVOKED_get_ext_by_critical_const,
-                                 X509_REVOKED_get_ext_const>(env, x509RevokedRef, critical);
+    return get_X509Type_ext_oids<X509_REVOKED, X509_REVOKED_get_ext_by_critical,
+                                 X509_REVOKED_get_ext>(env, x509RevokedRef, critical);
 }
 
 /**

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -427,7 +427,7 @@ static jobjectArray CryptoBuffersToObjectArray(JNIEnv* env,
 /**
  * Converts ASN.1 BIT STRING to a jbooleanArray.
  */
-jbooleanArray ASN1BitStringToBooleanArray(JNIEnv* env, ASN1_BIT_STRING* bitStr) {
+jbooleanArray ASN1BitStringToBooleanArray(JNIEnv* env, const ASN1_BIT_STRING* bitStr) {
     int size = ASN1_STRING_length(bitStr) * 8;
     if (bitStr->flags & ASN1_STRING_FLAG_BITS_LEFT) {
         size -= bitStr->flags & 0x07;
@@ -4172,8 +4172,8 @@ static long NativeCrypto_X509_get_version(JNIEnv* env, jclass, jlong x509Ref,
 }
 
 template <typename T>
-static jbyteArray get_X509Type_serialNumber(JNIEnv* env, T* x509Type,
-                                            ASN1_INTEGER* (*get_serial_func)(T*)) {
+static jbyteArray get_X509Type_serialNumber(JNIEnv* env, const T* x509Type,
+                                            const ASN1_INTEGER* (*get_serial_func)(const T*)) {
     JNI_TRACE("get_X509Type_serialNumber(%p)", x509Type);
 
     if (x509Type == nullptr) {
@@ -4182,7 +4182,7 @@ static jbyteArray get_X509Type_serialNumber(JNIEnv* env, T* x509Type,
         return nullptr;
     }
 
-    ASN1_INTEGER* serialNumber = get_serial_func(x509Type);
+    const ASN1_INTEGER* serialNumber = get_serial_func(x509Type);
     bssl::UniquePtr<BIGNUM> serialBn(ASN1_INTEGER_to_BN(serialNumber, nullptr));
     if (serialBn.get() == nullptr) {
         JNI_TRACE("X509_get_serialNumber(%p) => threw exception", x509Type);
@@ -4199,19 +4199,12 @@ static jbyteArray get_X509Type_serialNumber(JNIEnv* env, T* x509Type,
     return serialArray.release();
 }
 
-/* OpenSSL includes set_serialNumber but not get. */
-#if !defined(X509_REVOKED_get_serialNumber)
-static ASN1_INTEGER* X509_REVOKED_get_serialNumber(X509_REVOKED* x) {
-    return x->serialNumber;
-}
-#endif
-
 static jbyteArray NativeCrypto_X509_get_serialNumber(JNIEnv* env, jclass, jlong x509Ref,
                                                      CONSCRYPT_UNUSED jobject holder) {
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509* x509 = reinterpret_cast<X509*>(static_cast<uintptr_t>(x509Ref));
     JNI_TRACE("X509_get_serialNumber(%p)", x509);
-    return get_X509Type_serialNumber<X509>(env, x509, X509_get_serialNumber);
+    return get_X509Type_serialNumber<X509>(env, x509, X509_get0_serialNumber);
 }
 
 static jbyteArray NativeCrypto_X509_REVOKED_get_serialNumber(JNIEnv* env, jclass,
@@ -4219,7 +4212,7 @@ static jbyteArray NativeCrypto_X509_REVOKED_get_serialNumber(JNIEnv* env, jclass
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509_REVOKED* revoked = reinterpret_cast<X509_REVOKED*>(static_cast<uintptr_t>(x509RevokedRef));
     JNI_TRACE("X509_REVOKED_get_serialNumber(%p)", revoked);
-    return get_X509Type_serialNumber<X509_REVOKED>(env, revoked, X509_REVOKED_get_serialNumber);
+    return get_X509Type_serialNumber<X509_REVOKED>(env, revoked, X509_REVOKED_get0_serialNumber);
 }
 
 static void NativeCrypto_X509_verify(JNIEnv* env, jclass, jlong x509Ref,
@@ -4519,6 +4512,27 @@ static jstring NativeCrypto_get_X509_CRL_sig_alg_oid(JNIEnv* env, jclass, jlong 
     return ASN1_OBJECT_to_OID_string(env, oid);
 }
 
+static jbyteArray get_X509_ALGOR_parameter(JNIEnv* env, const X509_ALGOR *algor) {
+    int param_type;
+    const void* param_value;
+    X509_ALGOR_get0(nullptr, &param_type, &param_value, algor);
+
+    if (param_type == V_ASN1_UNDEF) {
+        JNI_TRACE("get_X509_ALGOR_parameter(%p) => no parameters", algor);
+        return nullptr;
+    }
+
+    // The OpenSSL 1.1.x API lacks a function to get the ASN1_TYPE out of X509_ALGOR directly, so
+    // recreate it from the returned components.
+    bssl::UniquePtr<ASN1_TYPE> param(ASN1_TYPE_new());
+    if (!param || !ASN1_TYPE_set1(param.get(), param_type, param_value)) {
+        conscrypt::jniutil::throwOutOfMemory(env, "Unable to serialize parameter");
+        return nullptr;
+    }
+
+    return ASN1ToByteArray<ASN1_TYPE>(env, param.get(), i2d_ASN1_TYPE);
+}
+
 static jbyteArray NativeCrypto_get_X509_CRL_sig_alg_parameter(JNIEnv* env, jclass, jlong x509CrlRef,
                                                               CONSCRYPT_UNUSED jobject holder) {
     CHECK_ERROR_QUEUE_ON_RETURN;
@@ -4533,12 +4547,7 @@ static jbyteArray NativeCrypto_get_X509_CRL_sig_alg_parameter(JNIEnv* env, jclas
 
     const X509_ALGOR *sig_alg;
     X509_CRL_get0_signature(crl, nullptr, &sig_alg);
-    if (sig_alg->parameter == nullptr) {
-        JNI_TRACE("get_X509_CRL_sig_alg_parameter(%p) => null", crl);
-        return nullptr;
-    }
-
-    return ASN1ToByteArray<ASN1_TYPE>(env, sig_alg->parameter, i2d_ASN1_TYPE);
+    return get_X509_ALGOR_parameter(env, sig_alg);
 }
 
 static jbyteArray NativeCrypto_X509_CRL_get_issuer_name(JNIEnv* env, jclass, jlong x509CrlRef,
@@ -4691,11 +4700,18 @@ static void NativeCrypto_X509_REVOKED_print(JNIEnv* env, jclass, jlong bioRef,
     }
 
     BIO_printf(bio, "Serial Number: ");
-    i2a_ASN1_INTEGER(bio, revoked->serialNumber);
+    i2a_ASN1_INTEGER(bio, X509_REVOKED_get0_serialNumber(revoked));
     BIO_printf(bio, "\nRevocation Date: ");
-    ASN1_TIME_print(bio, revoked->revocationDate);
+    ASN1_TIME_print(bio, X509_REVOKED_get0_revocationDate(revoked));
     BIO_printf(bio, "\n");
-    X509V3_extensions_print(bio, "CRL entry extensions", revoked->extensions, 0, 0);
+    // TODO(davidben): Remove the const_cast after
+    // https://boringssl-review.googlesource.com/c/boringssl/+/43565 has landed.
+    //
+    // TODO(davidben): Should the flags parameter be |X509V3_EXT_DUMP_UNKNOWN| so we don't error on
+    // unknown extensions. Alternatively, maybe we can use a simpler toString() implementation.
+    X509V3_extensions_print(bio, "CRL entry extensions",
+                            const_cast<X509_EXTENSIONS*>(X509_REVOKED_get0_extensions(revoked)), 0,
+                            0);
 }
 #ifndef _WIN32
 #pragma GCC diagnostic pop
@@ -5726,7 +5742,9 @@ static jstring NativeCrypto_get_X509_pubkey_oid(JNIEnv* env, jclass, jlong x509R
     }
 
     X509_PUBKEY* pubkey = X509_get_X509_PUBKEY(x509);
-    return ASN1_OBJECT_to_OID_string(env, pubkey->algor->algorithm);
+    ASN1_OBJECT* algorithm;
+    X509_PUBKEY_get0_param(&algorithm, nullptr, nullptr, nullptr, pubkey);
+    return ASN1_OBJECT_to_OID_string(env, algorithm);
 }
 
 static jstring NativeCrypto_get_X509_sig_alg_oid(JNIEnv* env, jclass, jlong x509Ref,
@@ -5762,12 +5780,7 @@ static jbyteArray NativeCrypto_get_X509_sig_alg_parameter(JNIEnv* env, jclass, j
 
     const X509_ALGOR *sig_alg;
     X509_get0_signature(nullptr, &sig_alg, x509);
-    if (sig_alg->parameter == nullptr) {
-        JNI_TRACE("get_X509_sig_alg_parameter(%p) => null", x509);
-        return nullptr;
-    }
-
-    return ASN1ToByteArray<ASN1_TYPE>(env, sig_alg->parameter, i2d_ASN1_TYPE);
+    return get_X509_ALGOR_parameter(env, sig_alg);
 }
 
 static jbooleanArray NativeCrypto_get_X509_issuerUID(JNIEnv* env, jclass, jlong x509Ref,
@@ -5782,12 +5795,14 @@ static jbooleanArray NativeCrypto_get_X509_issuerUID(JNIEnv* env, jclass, jlong 
         return nullptr;
     }
 
-    if (x509->cert_info->issuerUID == nullptr) {
+    const ASN1_BIT_STRING *issuer_uid;
+    X509_get0_uids(x509, &issuer_uid, /*out_subject_uid=*/nullptr);
+    if (issuer_uid == nullptr) {
         JNI_TRACE("get_X509_issuerUID(%p) => null", x509);
         return nullptr;
     }
 
-    return ASN1BitStringToBooleanArray(env, x509->cert_info->issuerUID);
+    return ASN1BitStringToBooleanArray(env, issuer_uid);
 }
 
 static jbooleanArray NativeCrypto_get_X509_subjectUID(JNIEnv* env, jclass, jlong x509Ref,
@@ -5802,12 +5817,14 @@ static jbooleanArray NativeCrypto_get_X509_subjectUID(JNIEnv* env, jclass, jlong
         return nullptr;
     }
 
-    if (x509->cert_info->subjectUID == nullptr) {
+    const ASN1_BIT_STRING *subject_uid;
+    X509_get0_uids(x509, /*out_issuer_uid=*/nullptr, &subject_uid);
+    if (subject_uid == nullptr) {
         JNI_TRACE("get_X509_subjectUID(%p) => null", x509);
         return nullptr;
     }
 
-    return ASN1BitStringToBooleanArray(env, x509->cert_info->subjectUID);
+    return ASN1BitStringToBooleanArray(env, subject_uid);
 }
 
 static jbooleanArray NativeCrypto_get_X509_ex_kusage(JNIEnv* env, jclass, jlong x509Ref,
@@ -5881,11 +5898,13 @@ static jint NativeCrypto_get_X509_ex_pathlen(JNIEnv* env, jclass, jlong x509Ref,
         return 0;
     }
 
-    /* Just need to do this to cache the ex_* values. */
-    X509_check_ca(x509);
-
-    JNI_TRACE("get_X509_ex_pathlen(%p) => %ld", x509, x509->ex_pathlen);
-    return x509->ex_pathlen;
+    // TODO(davidben): It is possible for |x509| to have an invalid basicConstraints extension, in
+    // which case |X509_get_pathlen| will report the extension is missing. The |EXFLAG_INVALID| can
+    // be checked for error, but Java's X509Certificate API does not allow for getBasicConstraints()
+    // to throw an exception, so we'd have to check this extension at parse time.
+    long pathlen = X509_get_pathlen(x509);
+    JNI_TRACE("get_X509_ex_pathlen(%p) => %ld", x509, pathlen);
+    return pathlen;
 }
 
 static jbyteArray NativeCrypto_X509_get_ext_oid(JNIEnv* env, jclass, jlong x509Ref,
@@ -5948,7 +5967,8 @@ static jobjectArray get_X509Type_ext_oids(JNIEnv* env, jlong x509Ref, jint criti
     while ((lastPos = get_ext_by_critical_func(x509, critical, lastPos)) != -1) {
         X509_EXTENSION* ext = get_ext_func(x509, lastPos);
 
-        ScopedLocalRef<jstring> extOid(env, ASN1_OBJECT_to_OID_string(env, ext->object));
+        ScopedLocalRef<jstring> extOid(
+                env, ASN1_OBJECT_to_OID_string(env, X509_EXTENSION_get_object(ext)));
         if (extOid.get() == nullptr) {
             JNI_TRACE("get_X509Type_ext_oids(%p) => couldn't get OID", x509);
             return nullptr;

--- a/common/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/cert/X509CertificateTest.java
@@ -16,18 +16,26 @@
 
 package org.conscrypt.java.security.cert;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
+import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.Provider;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import javax.security.auth.x500.X500Principal;
+import org.conscrypt.TestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -142,6 +150,174 @@ public class X509CertificateTest {
             + "0il0APS+FYddxAcCIHweeRRqIYPwenRoeV8UmZpotPHLnhVe5h8yUmFedckU\n"
             + "-----END CERTIFICATE-----\n";
 
+    /**
+     * This is an X.509v1 certificatea, so most fields are missing. It exists to test accessors
+     * correctly handle the lack of fields. It was constructed by hand, so the signature itself is
+     * invalid.
+     */
+    private static final String X509V1_CERT = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBGjCBwgIJANlMBNpJfb/rMAkGByqGSM49BAEwFjEUMBIGA1UEAwwLVGVzdCBJ\n"
+            + "c3N1ZXIwHhcNMTQwNDIzMjMyMTU3WhcNMTQwNTIzMjMyMTU3WjAXMRUwEwYDVQQD\n"
+            + "DAxUZXN0IFN1YmplY3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATmK2niv2Wf\n"
+            + "l74vHg2UikzVl2u3qR4NRvvdqakendy6WgHn1peoChj5w8SjHlbifINI2xYaHPUd\n"
+            + "fvGULUvPciLBMAkGByqGSM49BAEDSAAwRQIhAPKgNV5ROjbDgnmb7idQhY5wBnSV\n"
+            + "V9IpdAD0vhWHXcQHAiB8HnkUaiGD8Hp0aHlfFJmaaLTxy54VXuYfMlJhXnXJFA==\n"
+            + "-----END CERTIFICATE-----\n";
+
+    /**
+     * This is a certificate with many extensions filled it. It exists to test accessors correctly
+     * report fields. It was constructed by hand, so the signature itself is invalid. Add more
+     * fields as necessary with https://github.com/google/der-ascii.
+     */
+    private static final String MANY_EXTENSIONS = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIEVDCCAzygAwIBAgIJALW2IrlaBKUhMA0GCSqGSIb3DQEBCwUAMBYxFDASBgNV\n"
+            + "BAMMC1Rlc3QgSXNzdWVyMB4XDTE2MDcwOTA0MzgwOVoXDTE2MDgwODA0MzgwOVow\n"
+            + "FzEVMBMGA1UEAwwMVGVzdCBTdWJqZWN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A\n"
+            + "MIIBCgKCAQEAugvahBkSAUF1fC49vb1bvlPrcl80kop1iLpiuYoz4Qptwy57+EWs\n"
+            + "sZBcHprZ5BkWf6PeGZ7F5AX1PyJbGHZLqvMCvViP6pd4MFox/igESISEHEixoiXC\n"
+            + "zepBrhtp5UQSjHD4D4hKtgdMgVxX+LRtwgW3mnu/vBu7rzpr/DS8io99p3lqZ1Ak\n"
+            + "y+aNlcMj6MYy8U+YFEevb/V0lRY9oqwmW7BHnXikm/vi6sjIS350U8zb/mRzYeIs\n"
+            + "2R65LUduTL50+UMgat9ocewI2dv8aO9Dph+8NdGtg8LFYyTTHcUxJoMr1PTOgnmE\n"
+            + "T19WJH4PrFwk7ZE1QJQQ1L4iKmPeQistuQIDAQABgQIEoIICA1CjggGaMIIBljAP\n"
+            + "BgNVHRMECDAGAQH/AgEKMCEGA1UdJQQaMBgGCCsGAQUFBwMBBgwqhkiG9xIEAYS3\n"
+            + "CQIwgagGA1UdEQSBoDCBnaATBgwqhkiG9xIEAYS3CQKgAwIBAIETc3ViamVjdEBl\n"
+            + "eGFtcGxlLmNvbYITc3ViamVjdC5leGFtcGxlLmNvbaQZMBcxFTATBgNVBAMMDFRl\n"
+            + "c3QgU3ViamVjdIYbaHR0cHM6Ly9leGFtcGxlLmNvbS9zdWJqZWN0hwR/AAABhxAA\n"
+            + "AAAAAAAAAAAAAAAAAAABiAwqhkiG9xIEAYS3CQIwgaQGA1UdEgSBnDCBmaATBgwq\n"
+            + "hkiG9xIEAYS3CQKgAwIBAYESaXNzdWVyQGV4YW1wbGUuY29tghJpc3N1ZXIuZXhh\n"
+            + "bXBsZS5jb22kGDAWMRQwEgYDVQQDDAtUZXN0IElzc3VlcoYaaHR0cHM6Ly9leGFt\n"
+            + "cGxlLmNvbS9pc3N1ZXKHBH8AAAGHEAAAAAAAAAAAAAAAAAAAAAGIDCqGSIb3EgQB\n"
+            + "hLcJAjAOBgNVHQ8BAf8EBAMCBaAwDQYJKoZIhvcNAQELBQADggEBAD7Jg68SArYW\n"
+            + "lcoHfZAB90Pmyrt5H6D8LRi+W2Ri1fBNxREELnezWJ2scjl4UMcsKYp4Pi950gVN\n"
+            + "+62IgrImcCNvtb5I1Cfy/MNNur9ffas6X334D0hYVIQTePyFk3umI+2mJQrtZZyM\n"
+            + "PIKSY/sYGQHhGGX6wGK+GO/og0PQk/Vu6D+GU2XRnDV0YZg1lsAsHd21XryK6fDm\n"
+            + "NkEMwbIWrts4xc7scRrGHWy+iMf6/7p/Ak/SIicM4XSwmlQ8pPxAZPr+E2LoVd9p\n"
+            + "MpWUwpW2UbtO5wsGTrY5sO45tFNN/y+jtUheB1C2ijObG/tXELaiyCdM+S/waeuv\n"
+            + "0MXtI4xnn1A=\n"
+            + "-----END CERTIFICATE-----\n";
+
+    /**
+     * This is a certificate whose basicConstraints extension marks it as a CA, with no pathlen
+     * constraint.
+     */
+    private static final String BASIC_CONSTRAINTS_NO_PATHLEN = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBMzCB2qADAgECAgkA2UwE2kl9v+swCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwL\n"
+            + "VGVzdCBJc3N1ZXIwHhcNMTQwNDIzMjMyMTU3WhcNMTQwNTIzMjMyMTU3WjAXMRUw\n"
+            + "EwYDVQQDDAxUZXN0IFN1YmplY3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATm\n"
+            + "K2niv2Wfl74vHg2UikzVl2u3qR4NRvvdqakendy6WgHn1peoChj5w8SjHlbifINI\n"
+            + "2xYaHPUdfvGULUvPciLBoxAwDjAMBgNVHRMEBTADAQH/MAoGCCqGSM49BAMCA0gA\n"
+            + "MEUCIQDyoDVeUTo2w4J5m+4nUIWOcAZ0lVfSKXQA9L4Vh13EBwIgfB55FGohg/B6\n"
+            + "dGh5XxSZmmi08cueFV7mHzJSYV51yRQ=\n"
+            + "-----END CERTIFICATE-----\n";
+
+    /**
+     * This is a certificate whose basicConstraints extension marks it as a CA with a pathlen
+     * constraint of zero.
+     */
+    private static final String BASIC_CONSTRAINTS_PATHLEN_0 = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBNjCB3aADAgECAgkA2UwE2kl9v+swCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwL\n"
+            + "VGVzdCBJc3N1ZXIwHhcNMTQwNDIzMjMyMTU3WhcNMTQwNTIzMjMyMTU3WjAXMRUw\n"
+            + "EwYDVQQDDAxUZXN0IFN1YmplY3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATm\n"
+            + "K2niv2Wfl74vHg2UikzVl2u3qR4NRvvdqakendy6WgHn1peoChj5w8SjHlbifINI\n"
+            + "2xYaHPUdfvGULUvPciLBoxMwETAPBgNVHRMECDAGAQH/AgEAMAoGCCqGSM49BAMC\n"
+            + "A0gAMEUCIQDyoDVeUTo2w4J5m+4nUIWOcAZ0lVfSKXQA9L4Vh13EBwIgfB55FGoh\n"
+            + "g/B6dGh5XxSZmmi08cueFV7mHzJSYV51yRQ=\n"
+            + "-----END CERTIFICATE-----\n";
+
+    /**
+     * This is a certificate whose basicConstraints extension marks it as a leaf certificate.
+     */
+    private static final String BASIC_CONSTRAINTS_LEAF = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBMDCB16ADAgECAgkA2UwE2kl9v+swCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwL\n"
+            + "VGVzdCBJc3N1ZXIwHhcNMTQwNDIzMjMyMTU3WhcNMTQwNTIzMjMyMTU3WjAXMRUw\n"
+            + "EwYDVQQDDAxUZXN0IFN1YmplY3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATm\n"
+            + "K2niv2Wfl74vHg2UikzVl2u3qR4NRvvdqakendy6WgHn1peoChj5w8SjHlbifINI\n"
+            + "2xYaHPUdfvGULUvPciLBow0wCzAJBgNVHRMEAjAAMAoGCCqGSM49BAMCA0gAMEUC\n"
+            + "IQDyoDVeUTo2w4J5m+4nUIWOcAZ0lVfSKXQA9L4Vh13EBwIgfB55FGohg/B6dGh5\n"
+            + "XxSZmmi08cueFV7mHzJSYV51yRQ=\n"
+            + "-----END CERTIFICATE-----\n";
+
+    /**
+     * This is a certificate whose keyUsage extension has more than nine bits. The getKeyUsage()
+     * method internally rounds up to nine bits, so this tests what happens when it does not need to
+     * round.
+     */
+    private static final String LARGE_KEY_USAGE = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBNjCB3aADAgECAgkA2UwE2kl9v+swCgYIKoZIzj0EAwIwFjEUMBIGA1UEAwwL\n"
+            + "VGVzdCBJc3N1ZXIwHhcNMTQwNDIzMjMyMTU3WhcNMTQwNTIzMjMyMTU3WjAXMRUw\n"
+            + "EwYDVQQDDAxUZXN0IFN1YmplY3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATm\n"
+            + "K2niv2Wfl74vHg2UikzVl2u3qR4NRvvdqakendy6WgHn1peoChj5w8SjHlbifINI\n"
+            + "2xYaHPUdfvGULUvPciLBoxMwETAPBgNVHQ8BAf8EBQMDBaAAMAoGCCqGSM49BAMC\n"
+            + "A0gAMEUCIQDyoDVeUTo2w4J5m+4nUIWOcAZ0lVfSKXQA9L4Vh13EBwIgfB55FGoh\n"
+            + "g/B6dGh5XxSZmmi08cueFV7mHzJSYV51yRQ=\n"
+            + "-----END CERTIFICATE-----\n";
+
+    /*
+     * OpenSSLX509Certificate needs to compensate for OpenSSL's AlgorithmIdentifier representation
+     * by re-encoding the parameter field. Test this behaves correctly against a variety of
+     * different parameter types.
+     */
+    private static final String SIGALG_NO_PARAMETER = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBKTCBzKADAgECAgkA2UwE2kl9v+swDgYMKoZIhvcSBAGEtwkCMBYxFDASBgNV\n"
+            + "BAMMC1Rlc3QgSXNzdWVyMB4XDTE0MDQyMzIzMjE1N1oXDTE0MDUyMzIzMjE1N1ow\n"
+            + "FzEVMBMGA1UEAwwMVGVzdCBTdWJqZWN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcD\n"
+            + "QgAE5itp4r9ln5e+Lx4NlIpM1Zdrt6keDUb73ampHp3culoB59aXqAoY+cPEox5W\n"
+            + "4nyDSNsWGhz1HX7xlC1Lz3IiwTAOBgwqhkiG9xIEAYS3CQIDSAAwRQIhAPKgNV5R\n"
+            + "OjbDgnmb7idQhY5wBnSVV9IpdAD0vhWHXcQHAiB8HnkUaiGD8Hp0aHlfFJmaaLTx\n"
+            + "y54VXuYfMlJhXnXJFA==\n"
+            + "-----END CERTIFICATE-----\n";
+    private static final String SIGALG_NULL_PARAMETER = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBLTCBzqADAgECAgkA2UwE2kl9v+swEAYMKoZIhvcSBAGEtwkCBQAwFjEUMBIG\n"
+            + "A1UEAwwLVGVzdCBJc3N1ZXIwHhcNMTQwNDIzMjMyMTU3WhcNMTQwNTIzMjMyMTU3\n"
+            + "WjAXMRUwEwYDVQQDDAxUZXN0IFN1YmplY3QwWTATBgcqhkjOPQIBBggqhkjOPQMB\n"
+            + "BwNCAATmK2niv2Wfl74vHg2UikzVl2u3qR4NRvvdqakendy6WgHn1peoChj5w8Sj\n"
+            + "HlbifINI2xYaHPUdfvGULUvPciLBMBAGDCqGSIb3EgQBhLcJAgUAA0gAMEUCIQDy\n"
+            + "oDVeUTo2w4J5m+4nUIWOcAZ0lVfSKXQA9L4Vh13EBwIgfB55FGohg/B6dGh5XxSZ\n"
+            + "mmi08cueFV7mHzJSYV51yRQ=\n"
+            + "-----END CERTIFICATE-----\n";
+    private static final String SIGALG_STRING_PARAMETER = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBNzCB06ADAgECAgkA2UwE2kl9v+swFQYMKoZIhvcSBAGEtwkCDAVwYXJhbTAW\n"
+            + "MRQwEgYDVQQDDAtUZXN0IElzc3VlcjAeFw0xNDA0MjMyMzIxNTdaFw0xNDA1MjMy\n"
+            + "MzIxNTdaMBcxFTATBgNVBAMMDFRlc3QgU3ViamVjdDBZMBMGByqGSM49AgEGCCqG\n"
+            + "SM49AwEHA0IABOYraeK/ZZ+Xvi8eDZSKTNWXa7epHg1G+92pqR6d3LpaAefWl6gK\n"
+            + "GPnDxKMeVuJ8g0jbFhoc9R1+8ZQtS89yIsEwFQYMKoZIhvcSBAGEtwkCDAVwYXJh\n"
+            + "bQNIADBFAiEA8qA1XlE6NsOCeZvuJ1CFjnAGdJVX0il0APS+FYddxAcCIHweeRRq\n"
+            + "IYPwenRoeV8UmZpotPHLnhVe5h8yUmFedckU\n"
+            + "-----END CERTIFICATE-----\n";
+    private static final String SIGALG_BOOLEAN_PARAMETER = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBLzCBz6ADAgECAgkA2UwE2kl9v+swEQYMKoZIhvcSBAGEtwkCAQH/MBYxFDAS\n"
+            + "BgNVBAMMC1Rlc3QgSXNzdWVyMB4XDTE0MDQyMzIzMjE1N1oXDTE0MDUyMzIzMjE1\n"
+            + "N1owFzEVMBMGA1UEAwwMVGVzdCBTdWJqZWN0MFkwEwYHKoZIzj0CAQYIKoZIzj0D\n"
+            + "AQcDQgAE5itp4r9ln5e+Lx4NlIpM1Zdrt6keDUb73ampHp3culoB59aXqAoY+cPE\n"
+            + "ox5W4nyDSNsWGhz1HX7xlC1Lz3IiwTARBgwqhkiG9xIEAYS3CQIBAf8DSAAwRQIh\n"
+            + "APKgNV5ROjbDgnmb7idQhY5wBnSVV9IpdAD0vhWHXcQHAiB8HnkUaiGD8Hp0aHlf\n"
+            + "FJmaaLTxy54VXuYfMlJhXnXJFA==\n"
+            + "-----END CERTIFICATE-----\n";
+    private static final String SIGALG_SEQUENCE_PARAMETER = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIBLTCBzqADAgECAgkA2UwE2kl9v+swEAYMKoZIhvcSBAGEtwkCMAAwFjEUMBIG\n"
+            + "A1UEAwwLVGVzdCBJc3N1ZXIwHhcNMTQwNDIzMjMyMTU3WhcNMTQwNTIzMjMyMTU3\n"
+            + "WjAXMRUwEwYDVQQDDAxUZXN0IFN1YmplY3QwWTATBgcqhkjOPQIBBggqhkjOPQMB\n"
+            + "BwNCAATmK2niv2Wfl74vHg2UikzVl2u3qR4NRvvdqakendy6WgHn1peoChj5w8Sj\n"
+            + "HlbifINI2xYaHPUdfvGULUvPciLBMBAGDCqGSIb3EgQBhLcJAjAAA0gAMEUCIQDy\n"
+            + "oDVeUTo2w4J5m+4nUIWOcAZ0lVfSKXQA9L4Vh13EBwIgfB55FGohg/B6dGh5XxSZ\n"
+            + "mmi08cueFV7mHzJSYV51yRQ=\n"
+            + "-----END CERTIFICATE-----\n";
+
+    private static Date dateFromUTC(int year, int month, int day, int hour, int minute, int second)
+            throws Exception {
+        Calendar c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        c.set(year, month, day, hour, minute, second);
+        c.set(Calendar.MILLISECOND, 0);
+        return c.getTime();
+    }
+
+    private static X509Certificate certificateFromPEM(Provider p, String pem)
+            throws CertificateException {
+        CertificateFactory cf = CertificateFactory.getInstance("X509", p);
+        return (X509Certificate) cf.generateCertificate(
+                new ByteArrayInputStream(pem.getBytes(Charset.forName("US-ASCII"))));
+    }
+
     // See issue #539.
     @Test
     public void testMismatchedAlgorithm() throws Exception {
@@ -150,10 +326,8 @@ public class X509CertificateTest {
             .run(new ServiceTester.Test() {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
-                    CertificateFactory cf = CertificateFactory.getInstance("X509", p);
                     try {
-                        Certificate c = cf.generateCertificate(new ByteArrayInputStream(
-                            MISMATCHED_ALGORITHM_CERT.getBytes(Charset.forName("US-ASCII"))));
+                        X509Certificate c = certificateFromPEM(p, MISMATCHED_ALGORITHM_CERT);
                         c.verify(c.getPublicKey());
                         fail();
                     } catch (CertificateException expected) {
@@ -176,9 +350,7 @@ public class X509CertificateTest {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
                     try {
-                        CertificateFactory cf = CertificateFactory.getInstance("X509", p);
-                        Certificate c = cf.generateCertificate(new ByteArrayInputStream(
-                            EC_EXPLICIT_KEY_CERT.getBytes(Charset.forName("US-ASCII"))));
+                        X509Certificate c = certificateFromPEM(p, EC_EXPLICIT_KEY_CERT);
                         c.verify(c.getPublicKey());
                         fail();
                     } catch (InvalidKeyException expected) {
@@ -197,11 +369,8 @@ public class X509CertificateTest {
             .run(new ServiceTester.Test() {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
-                    CertificateFactory cf = CertificateFactory.getInstance("X509", p);
-                    Certificate c = cf.generateCertificate(new ByteArrayInputStream(
-                        VALID_CERT.getBytes(Charset.forName("US-ASCII"))));
-                    assertEquals("SHA256WITHRSA",
-                        ((X509Certificate) c).getSigAlgName().toUpperCase());
+                    X509Certificate c = certificateFromPEM(p, VALID_CERT);
+                    assertEquals("SHA256WITHRSA", c.getSigAlgName().toUpperCase());
                 }
             });
     }
@@ -213,12 +382,176 @@ public class X509CertificateTest {
             .run(new ServiceTester.Test() {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
-                    CertificateFactory cf = CertificateFactory.getInstance("X509", p);
-                    Certificate c = cf.generateCertificate(new ByteArrayInputStream(
-                            UNKNOWN_SIGNATURE_OID.getBytes(Charset.forName("US-ASCII"))));
-                    assertEquals(
-                            "1.2.840.113554.4.1.72585.2", ((X509Certificate) c).getSigAlgOID());
+                    X509Certificate c = certificateFromPEM(p, UNKNOWN_SIGNATURE_OID);
+                    assertEquals("1.2.840.113554.4.1.72585.2", c.getSigAlgOID());
                 }
             });
+    }
+
+    @Test
+    public void testV1Cert() throws Exception {
+        ServiceTester tester = ServiceTester.test("CertificateFactory").withAlgorithm("X509");
+        tester.run(new ServiceTester.Test() {
+            @Override
+            public void test(Provider p, String algorithm) throws Exception {
+                X509Certificate c = certificateFromPEM(p, X509V1_CERT);
+
+                // Check basic certificate properties.
+                assertEquals(1, c.getVersion());
+                assertEquals(new BigInteger("d94c04da497dbfeb", 16), c.getSerialNumber());
+                assertEquals(dateFromUTC(2014, Calendar.APRIL, 23, 23, 21, 57), c.getNotBefore());
+                assertEquals(dateFromUTC(2014, Calendar.MAY, 23, 23, 21, 57), c.getNotAfter());
+                assertEquals(new X500Principal("CN=Test Issuer"), c.getIssuerX500Principal());
+                assertEquals(new X500Principal("CN=Test Subject"), c.getSubjectX500Principal());
+                assertEquals("1.2.840.10045.4.1", c.getSigAlgOID());
+                String signatureHex = "3045022100f2a0355e513a36c382799bee27"
+                        + "50858e7006749557d2297400f4be15875dc4"
+                        + "0702207c1e79146a2183f07a7468795f1499"
+                        + "9a68b4f1cb9e155ee61f3252615e75c914";
+                assertArrayEquals(TestUtils.decodeHex(signatureHex), c.getSignature());
+
+                // ECDSA signature AlgorithmIdentifiers omit parameters.
+                assertNull(c.getSigAlgParams());
+
+                // The certificate does not have UIDs.
+                assertNull(c.getIssuerUniqueID());
+                assertNull(c.getSubjectUniqueID());
+
+                // The certificate does not have any extensions.
+                assertEquals(-1, c.getBasicConstraints());
+                assertNull(c.getExtendedKeyUsage());
+                assertNull(c.getIssuerAlternativeNames());
+                assertNull(c.getKeyUsage());
+                assertNull(c.getSubjectAlternativeNames());
+            }
+        });
+    }
+
+    @Test
+    public void testManyExtensions() throws Exception {
+        ServiceTester tester = ServiceTester.test("CertificateFactory").withAlgorithm("X509");
+        tester.run(new ServiceTester.Test() {
+            @Override
+            public void test(Provider p, String algorithm) throws Exception {
+                X509Certificate c = certificateFromPEM(p, MANY_EXTENSIONS);
+
+                assertEquals(3, c.getVersion());
+                assertEquals(new BigInteger("b5b622b95a04a521", 16), c.getSerialNumber());
+                assertEquals(dateFromUTC(2016, Calendar.JULY, 9, 4, 38, 9), c.getNotBefore());
+                assertEquals(dateFromUTC(2016, Calendar.AUGUST, 8, 4, 38, 9), c.getNotAfter());
+                assertEquals(new X500Principal("CN=Test Issuer"), c.getIssuerX500Principal());
+                assertEquals(new X500Principal("CN=Test Subject"), c.getSubjectX500Principal());
+                assertEquals("1.2.840.113549.1.1.11", c.getSigAlgOID());
+                String signatureHex = "3ec983af1202b61695ca077d9001f743e6ca"
+                        + "bb791fa0fc2d18be5b6462d5f04dc511042e"
+                        + "77b3589dac72397850c72c298a783e2f79d2"
+                        + "054dfbad8882b22670236fb5be48d427f2fc"
+                        + "c34dbabf5f7dab3a5f7df80f485854841378"
+                        + "fc85937ba623eda6250aed659c8c3c829263"
+                        + "fb181901e11865fac062be18efe88343d093"
+                        + "f56ee83f865365d19c357461983596c02c1d"
+                        + "ddb55ebc8ae9f0e636410cc1b216aedb38c5"
+                        + "ceec711ac61d6cbe88c7faffba7f024fd222"
+                        + "270ce174b09a543ca4fc4064fafe1362e855"
+                        + "df69329594c295b651bb4ee70b064eb639b0"
+                        + "ee39b4534dff2fa3b5485e0750b68a339b1b"
+                        + "fb5710b6a2c8274cf92ff069ebafd0c5ed23"
+                        + "8c679f50";
+                assertArrayEquals(TestUtils.decodeHex(signatureHex), c.getSignature());
+
+                // Although documented to only return null when there are no parameters, the SUN
+                // provider also returns null when the algorithm uses an explicit parameter with a
+                // value of ASN.1 NULL.
+                if (c.getSigAlgParams() != null) {
+                    assertArrayEquals(TestUtils.decodeHex("0500"), c.getSigAlgParams());
+                }
+
+                assertArrayEquals(new boolean[] {true, false, true, false}, c.getIssuerUniqueID());
+                assertArrayEquals(
+                        new boolean[] {false, true, false, true, false}, c.getSubjectUniqueID());
+                assertEquals(10, c.getBasicConstraints());
+                assertEquals(Arrays.asList("1.3.6.1.5.5.7.3.1", "1.2.840.113554.4.1.72585.2"),
+                        c.getExtendedKeyUsage());
+
+                // TODO(davidben): Test getSubjectAlternativeNames() and
+                // getIssuerAlternativeNames(), after resolving behavior differences.
+
+                // Although the BIT STRING in the certificate only has three bits, getKeyUsage()
+                // rounds up to at least 9 bits.
+                assertArrayEquals(
+                        new boolean[] {true, false, true, false, false, false, false, false, false},
+                        c.getKeyUsage());
+            }
+        });
+    }
+
+    @Test
+    public void testBasicConstraints() throws Exception {
+        ServiceTester tester = ServiceTester.test("CertificateFactory").withAlgorithm("X509");
+        tester.run(new ServiceTester.Test() {
+            @Override
+            public void test(Provider p, String algorithm) throws Exception {
+                // Test some additional edge cases in getBasicConstraints() beyond that
+                // testManyExtensions() and testV1Cert() covered.
+
+                // If there is no pathLen constraint but the certificate is a CA,
+                // getBasicConstraints() returns Integer.MAX_VALUE.
+                X509Certificate c = certificateFromPEM(p, BASIC_CONSTRAINTS_NO_PATHLEN);
+                assertEquals(Integer.MAX_VALUE, c.getBasicConstraints());
+
+                // If there is a pathLen constraint of zero, getBasicConstraints() returns it.
+                c = certificateFromPEM(p, BASIC_CONSTRAINTS_PATHLEN_0);
+                assertEquals(0, c.getBasicConstraints());
+
+                // If there is basicConstraints extension indicating a leaf certficate,
+                // getBasicConstraints() returns -1. The accessor does not distinguish between no
+                // basicConstraints extension and a leaf one.
+                c = certificateFromPEM(p, BASIC_CONSTRAINTS_LEAF);
+                assertEquals(-1, c.getBasicConstraints());
+            }
+        });
+    }
+
+    @Test
+    public void testLargeKeyUsage() throws Exception {
+        ServiceTester tester = ServiceTester.test("CertificateFactory").withAlgorithm("X509");
+        tester.run(new ServiceTester.Test() {
+            @Override
+            public void test(Provider p, String algorithm) throws Exception {
+                X509Certificate c = certificateFromPEM(p, LARGE_KEY_USAGE);
+                assertArrayEquals(new boolean[] {true, false, true, false, false, false, false,
+                                          false, false, false, false},
+                        c.getKeyUsage());
+            }
+        });
+    }
+
+    @Test
+    public void testSigAlgParams() throws Exception {
+        ServiceTester tester = ServiceTester.test("CertificateFactory").withAlgorithm("X509");
+        tester.run(new ServiceTester.Test() {
+            @Override
+            public void test(Provider p, String algorithm) throws Exception {
+                X509Certificate c = certificateFromPEM(p, SIGALG_NO_PARAMETER);
+                assertNull(c.getSigAlgParams());
+
+                c = certificateFromPEM(p, SIGALG_NULL_PARAMETER);
+                // Although documented to only return null when there are no parameters, the SUN
+                // provider also returns null when the algorithm uses an explicit parameter with a
+                // value of ASN.1 NULL.
+                if (c.getSigAlgParams() != null) {
+                    assertArrayEquals(TestUtils.decodeHex("0500"), c.getSigAlgParams());
+                }
+
+                c = certificateFromPEM(p, SIGALG_STRING_PARAMETER);
+                assertArrayEquals(TestUtils.decodeHex("0c05706172616d"), c.getSigAlgParams());
+
+                c = certificateFromPEM(p, SIGALG_BOOLEAN_PARAMETER);
+                assertArrayEquals(TestUtils.decodeHex("0101ff"), c.getSigAlgParams());
+
+                c = certificateFromPEM(p, SIGALG_SEQUENCE_PARAMETER);
+                assertArrayEquals(TestUtils.decodeHex("3000"), c.getSigAlgParams());
+            }
+        });
     }
 }


### PR DESCRIPTION
Various new accessors have cycled into downstream repositories, so we should be able start using them. In hopes of avoiding a repeat of #901, I've added some tests for X509Certificate accessors while I was there. I've skipped testing the SAN list for now. I have code to test it, and the sample certificate does include a large SAN list for testing, but doing so revealed some discrepancies, so I'll address that in a follow-up PR.