### PR TITLE
Fix the return type of NativeCrypto_X509_check_issued.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4260,9 +4260,9 @@ static jint NativeCrypto_get_X509_ex_flags(JNIEnv* env, jclass, jlong x509Ref,
     return X509_get_extension_flags(x509);
 }
 
-static jboolean NativeCrypto_X509_check_issued(JNIEnv* env, jclass, jlong x509Ref1,
-                                               CONSCRYPT_UNUSED jobject holder, jlong x509Ref2,
-                                               CONSCRYPT_UNUSED jobject holder2) {
+static jint NativeCrypto_X509_check_issued(JNIEnv* env, jclass, jlong x509Ref1,
+                                           CONSCRYPT_UNUSED jobject holder, jlong x509Ref2,
+                                           CONSCRYPT_UNUSED jobject holder2) {
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509* x509_1 = reinterpret_cast<X509*>(static_cast<uintptr_t>(x509Ref1));
     X509* x509_2 = reinterpret_cast<X509*>(static_cast<uintptr_t>(x509Ref2));
@@ -4270,7 +4270,7 @@ static jboolean NativeCrypto_X509_check_issued(JNIEnv* env, jclass, jlong x509Re
 
     int ret = X509_check_issued(x509_1, x509_2);
     JNI_TRACE("X509_check_issued(%p, %p) => %d", x509_1, x509_2, ret);
-    return static_cast<jboolean>(ret);
+    return ret;
 }
 
 static const ASN1_BIT_STRING* get_X509_signature(X509* x509) {


### PR DESCRIPTION
The X509_check_issued C function returns one of the X509_V_* constants,
where X509_V_OK is zero. The JNI C++ wrapper casts that directly to a
jboolean, which is uint8_t and will likely do the wrong thing if
BoringSSL ever allocates a multiple of 256 as a constant.

The NativeCrypto type signature and call site then go back to returning
int and check the result with == 0. Fix the JNI C++ wrapper to match
both what BoringSSL and the NativeCrypto class are actually expecting.