### PR TITLE
Compare precalculated ByteArray.hashCode-s before comparing byte arrays

### DIFF
--- a/common/src/main/java/org/conscrypt/ByteArray.java
+++ b/common/src/main/java/org/conscrypt/ByteArray.java
@@ -41,6 +41,9 @@ final class ByteArray {
             return false;
         }
         ByteArray lhs = (ByteArray) o;
+        if (hashCode != lhs.hashCode) {
+            return false;
+        }
         return Arrays.equals(bytes, lhs.bytes);
     }
 }


### PR DESCRIPTION
No need to compare byte arrays if hash codes are different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/conscrypt/925)
<!-- Reviewable:end -->
