### PR TITLE
Add a stub for android.util.StatsEvent.

### DIFF
--- a/android-stub/src/main/java/android/util/StatsEvent.java
+++ b/android-stub/src/main/java/android/util/StatsEvent.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.util;
+
+public final class StatsEvent {
+    private StatsEvent(int atomId, StatsEvent.Buffer buffer, byte[] payload, int numBytes) {
+        throw new RuntimeException("Stub!");
+    }
+
+    public static StatsEvent.Builder newBuilder() {
+        throw new RuntimeException("Stub!");
+    }
+
+    public int getAtomId() {
+        throw new RuntimeException("Stub!");
+    }
+
+    public byte[] getBytes() {
+        throw new RuntimeException("Stub!");
+    }
+
+    public int getNumBytes() {
+        throw new RuntimeException("Stub!");
+    }
+
+    public void release() {
+        throw new RuntimeException("Stub!");
+    }
+
+    private static final class Buffer {
+        private static StatsEvent.Buffer obtain() {
+            throw new RuntimeException("Stub!");
+        }
+
+        private Buffer() {
+            throw new RuntimeException("Stub!");
+        }
+    }
+
+    public static final class Builder {
+        private Builder(StatsEvent.Buffer buffer) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder setAtomId(int atomId) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder writeBoolean(boolean value) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder writeInt(int value) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder writeLong(long value) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder writeFloat(float value) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder writeString(String value) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder writeByteArray(byte[] value) {
+            throw new RuntimeException("Stub!");
+        }
+
+        private void writeByteArray(byte[] value, byte typeId) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder writeAttributionChain(int[] uids, String[] tags) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder addBooleanAnnotation(byte annotationId, boolean value) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder addIntAnnotation(byte annotationId, int value) {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent.Builder usePooledBuffer() {
+            throw new RuntimeException("Stub!");
+        }
+
+        public StatsEvent build() {
+            throw new RuntimeException("Stub!");
+        }
+
+        private void writeTypeId(byte typeId) {
+            throw new RuntimeException("Stub!");
+        }
+
+        private void writeAnnotationCount() {
+            throw new RuntimeException("Stub!");
+        }
+
+        private static byte[] stringToBytes(String value) {
+            throw new RuntimeException("Stub!");
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.util.VersionNumber
 
 buildscript {
     ext.android_tools = 'com.android.tools.build:gradle:4.0.0'
-    ext.errorproneVersion = '2.3.3'
+    ext.errorproneVersion = '2.4.0'
     ext.errorproneJavacVersion = '9+181-r4173-1'
     repositories {
         google()
@@ -20,7 +20,7 @@ plugins {
     // Add dependency for build script so we can access Git from our
     // build script.
     id 'org.ajoberstar.grgit' version '3.1.1'
-    id 'net.ltgt.errorprone' version '1.1.1'
+    id 'net.ltgt.errorprone' version '1.3.0'
 }
 
 subprojects {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compileOnly project(':conscrypt-constants')
 
     compile project(':conscrypt-libcore-stub'),
+            project(':conscrypt-android-stub'),
             libraries.bouncycastle_apis,
             libraries.bouncycastle_provider
 }


### PR DESCRIPTION
Needed for compile checks of platform tests in gradle, e.g.
for the Continuous Integration.  The actual test will only run
against the Android platform so a throwing stub is sufficient.
Should unblock #930 

Also updated the errorprone plugin as the older one is
crashing for me.