### PR TITLE
Add a method to check FIPS status of BoringSSL.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -37,6 +37,7 @@
 #include <openssl/aead.h>
 #include <openssl/asn1.h>
 #include <openssl/chacha.h>
+#include <openssl/crypto.h>
 #include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
@@ -9960,6 +9961,13 @@ static int NativeCrypto_ENGINE_SSL_write_direct(JNIEnv* env, jclass, jlong ssl_a
     return result;
 }
 
+/**
+ * public static native bool BoringSSL_FIPS_mode();
+ */
+static jboolean NativeCrypto_usesBoringSSL_FIPS_mode() {
+    return FIPS_mode();
+}
+
 // TESTING METHODS BEGIN
 
 static int NativeCrypto_BIO_read(JNIEnv* env, jclass, jlong bioRef, jbyteArray outputJavaBytes) {
@@ -10403,6 +10411,7 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_read_BIO_direct, "(J" REF_SSL "JJI" SSL_CALLBACKS ")I"),
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_force_read, "(J" REF_SSL SSL_CALLBACKS ")V"),
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_shutdown, "(J" REF_SSL SSL_CALLBACKS ")V"),
+        CONSCRYPT_NATIVE_METHOD(usesBoringSSL_FIPS_mode, "()Z"),
 
         // Used for testing only.
         CONSCRYPT_NATIVE_METHOD(BIO_read, "(J[B)I"),

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -9962,9 +9962,9 @@ static int NativeCrypto_ENGINE_SSL_write_direct(JNIEnv* env, jclass, jlong ssl_a
 }
 
 /**
- * public static native bool BoringSSL_FIPS_mode();
+ * public static native bool usesBoringSsl_FIPS_mode();
  */
-static jboolean NativeCrypto_usesBoringSSL_FIPS_mode() {
+static jboolean NativeCrypto_usesBoringSsl_FIPS_mode() {
     return FIPS_mode();
 }
 
@@ -10411,7 +10411,7 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_read_BIO_direct, "(J" REF_SSL "JJI" SSL_CALLBACKS ")I"),
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_force_read, "(J" REF_SSL SSL_CALLBACKS ")V"),
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_shutdown, "(J" REF_SSL SSL_CALLBACKS ")V"),
-        CONSCRYPT_NATIVE_METHOD(usesBoringSSL_FIPS_mode, "()Z"),
+        CONSCRYPT_NATIVE_METHOD(usesBoringSsl_FIPS_mode, "()Z"),
 
         // Used for testing only.
         CONSCRYPT_NATIVE_METHOD(BIO_read, "(J[B)I"),

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -61,9 +61,9 @@ public final class Conscrypt {
     /**
      * Return {@code true} if BoringSSL has been built in FIPS mode.
      */
-    public static boolean isBoringSSLFIPSBuild() {
+    public static boolean isBoringSslFIPSBuild() {
         try {
-            return NativeCrypto.usesBoringSSL_FIPS_mode();
+            return NativeCrypto.usesBoringSsl_FIPS_mode();
         } catch (Throwable e) {
             return false;
         }

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -58,6 +58,17 @@ public final class Conscrypt {
         }
     }
 
+    /**
+     * Return {@code true} if BoringSSL has been built in FIPS mode.
+     */
+    public static boolean isBoringSSLFIPSBuild() {
+        try {
+            return NativeCrypto.usesBoringSSL_FIPS_mode();
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
     public static class Version {
         private final int major;
         private final int minor;

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1426,6 +1426,11 @@ public final class NativeCrypto {
             throws IOException;
 
     /**
+     * Return {@code true} if BoringSSL has been built in FIPS mode.
+     */
+    static native boolean usesBoringSSL_FIPS_mode();
+
+    /**
      * Used for testing only.
      */
     static native int BIO_read(long bioRef, byte[] buffer) throws IOException;

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1428,7 +1428,7 @@ public final class NativeCrypto {
     /**
      * Return {@code true} if BoringSSL has been built in FIPS mode.
      */
-    static native boolean usesBoringSSL_FIPS_mode();
+    static native boolean usesBoringSsl_FIPS_mode();
 
     /**
      * Used for testing only.


### PR DESCRIPTION
This adds a method to call the FIPS_mode() function from BoringSSL, in
order to check if BoringSSL has been built in FIPS mode.