### PR TITLE
Revert "Flip isAssignableFrom checks in OpenSSLECKeyFactory and OpenSSLRSAKeyFactory"

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLECKeyFactory.java
@@ -87,12 +87,12 @@ public final class OpenSSLECKeyFactory extends KeyFactorySpi {
             throw new InvalidKeySpecException("Key must be an EC key");
         }
 
-        if (key instanceof ECPublicKey && keySpec.isAssignableFrom(ECPublicKeySpec.class)) {
+        if (key instanceof ECPublicKey && ECPublicKeySpec.class.isAssignableFrom(keySpec)) {
             ECPublicKey ecKey = (ECPublicKey) key;
             @SuppressWarnings("unchecked")
             T result = (T) new ECPublicKeySpec(ecKey.getW(), ecKey.getParams());
             return result;
-        } else if (key instanceof PublicKey && keySpec.isAssignableFrom(ECPublicKeySpec.class)) {
+        } else if (key instanceof PublicKey && ECPublicKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"X.509".equals(key.getFormat()) || encoded == null) {
                 throw new InvalidKeySpecException("Not a valid X.509 encoding");
@@ -102,12 +102,12 @@ public final class OpenSSLECKeyFactory extends KeyFactorySpi {
             T result = (T) new ECPublicKeySpec(ecKey.getW(), ecKey.getParams());
             return result;
         } else if (key instanceof ECPrivateKey
-                && keySpec.isAssignableFrom(ECPrivateKeySpec.class)) {
+                && ECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             ECPrivateKey ecKey = (ECPrivateKey) key;
             @SuppressWarnings("unchecked")
             T result = (T) new ECPrivateKeySpec(ecKey.getS(), ecKey.getParams());
             return result;
-        } else if (key instanceof PrivateKey && keySpec.isAssignableFrom(ECPrivateKeySpec.class)) {
+        } else if (key instanceof PrivateKey && ECPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"PKCS#8".equals(key.getFormat()) || encoded == null) {
                 throw new InvalidKeySpecException("Not a valid PKCS#8 encoding");
@@ -118,7 +118,7 @@ public final class OpenSSLECKeyFactory extends KeyFactorySpi {
             T result = (T) new ECPrivateKeySpec(ecKey.getS(), ecKey.getParams());
             return result;
         } else if (key instanceof PrivateKey
-                && keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)) {
+                && PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"PKCS#8".equals(key.getFormat())) {
                 throw new InvalidKeySpecException("Encoding type must be PKCS#8; was "
@@ -128,7 +128,7 @@ public final class OpenSSLECKeyFactory extends KeyFactorySpi {
             }
             @SuppressWarnings("unchecked") T result = (T) new PKCS8EncodedKeySpec(encoded);
             return result;
-        } else if (key instanceof PublicKey && keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
+        } else if (key instanceof PublicKey && X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"X.509".equals(key.getFormat())) {
                 throw new InvalidKeySpecException("Encoding type must be X.509; was "

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAKeyFactory.java
@@ -88,12 +88,12 @@ public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             throw new InvalidKeySpecException("Key must be a RSA key");
         }
 
-        if (key instanceof RSAPublicKey && keySpec.isAssignableFrom(RSAPublicKeySpec.class)) {
+        if (key instanceof RSAPublicKey && RSAPublicKeySpec.class.isAssignableFrom(keySpec)) {
             RSAPublicKey rsaKey = (RSAPublicKey) key;
             @SuppressWarnings("unchecked")
             T result = (T) new RSAPublicKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent());
             return result;
-        } else if (key instanceof PublicKey && keySpec.isAssignableFrom(RSAPublicKeySpec.class)) {
+        } else if (key instanceof PublicKey && RSAPublicKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"X.509".equals(key.getFormat()) || encoded == null) {
                 throw new InvalidKeySpecException("Not a valid X.509 encoding");
@@ -104,7 +104,7 @@ public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             T result = (T) new RSAPublicKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent());
             return result;
         } else if (key instanceof RSAPrivateCrtKey
-                && keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
+                && RSAPrivateCrtKeySpec.class.isAssignableFrom(keySpec)) {
             RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey) key;
             @SuppressWarnings("unchecked")
             T result = (T) new RSAPrivateCrtKeySpec(rsaKey.getModulus(), rsaKey.getPublicExponent(),
@@ -113,19 +113,19 @@ public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
                     rsaKey.getCrtCoefficient());
             return result;
         } else if (key instanceof RSAPrivateCrtKey
-                && keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
+                && RSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             RSAPrivateCrtKey rsaKey = (RSAPrivateCrtKey) key;
             @SuppressWarnings("unchecked")
             T result = (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
             return result;
         } else if (key instanceof RSAPrivateKey
-                && keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
+                && RSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             RSAPrivateKey rsaKey = (RSAPrivateKey) key;
             @SuppressWarnings("unchecked")
             T result = (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
             return result;
         } else if (key instanceof PrivateKey
-                && keySpec.isAssignableFrom(RSAPrivateCrtKeySpec.class)) {
+                && RSAPrivateCrtKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"PKCS#8".equals(key.getFormat()) || encoded == null) {
                 throw new InvalidKeySpecException("Not a valid PKCS#8 encoding");
@@ -143,7 +143,7 @@ public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             } else {
                 throw new InvalidKeySpecException("Encoded key is not an RSAPrivateCrtKey");
             }
-        } else if (key instanceof PrivateKey && keySpec.isAssignableFrom(RSAPrivateKeySpec.class)) {
+        } else if (key instanceof PrivateKey && RSAPrivateKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"PKCS#8".equals(key.getFormat()) || encoded == null) {
                 throw new InvalidKeySpecException("Not a valid PKCS#8 encoding");
@@ -154,7 +154,7 @@ public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             T result = (T) new RSAPrivateKeySpec(rsaKey.getModulus(), rsaKey.getPrivateExponent());
             return result;
         } else if (key instanceof PrivateKey
-                && keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)) {
+                && PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"PKCS#8".equals(key.getFormat())) {
                 throw new InvalidKeySpecException("Encoding type must be PKCS#8; was "
@@ -164,7 +164,7 @@ public final class OpenSSLRSAKeyFactory extends KeyFactorySpi {
             }
             @SuppressWarnings("unchecked") T result = (T) new PKCS8EncodedKeySpec(encoded);
             return result;
-        } else if (key instanceof PublicKey && keySpec.isAssignableFrom(X509EncodedKeySpec.class)) {
+        } else if (key instanceof PublicKey && X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
             final byte[] encoded = key.getEncoded();
             if (!"X.509".equals(key.getFormat())) {
                 throw new InvalidKeySpecException("Encoding type must be X.509; was "

--- a/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestEC.java
+++ b/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestEC.java
@@ -15,129 +15,54 @@
  */
 package org.conscrypt.java.security;
 
-import static org.junit.Assert.fail;
-
-import java.math.BigInteger;
-import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
-import java.security.Security;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
-import java.security.spec.ECParameterSpec;
-import java.security.spec.ECPoint;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import tests.util.ServiceTester;
 
 @RunWith(JUnit4.class)
-public class KeyFactoryTestEC extends AbstractKeyFactoryTest<ECPublicKeySpec, ECPrivateKeySpec> {
-    public KeyFactoryTestEC() {
-        super("EC", ECPublicKeySpec.class, ECPrivateKeySpec.class);
-    }
+public class KeyFactoryTestEC extends
+    AbstractKeyFactoryTest<ECPublicKeySpec, ECPrivateKeySpec> {
 
-    @Override
-    public ServiceTester customizeTester(ServiceTester tester) {
-        // BC's EC keys always use explicit params, even though it's a bad idea, and we don't
-        // support those, so don't test BC keys
-        return tester.skipProvider("BC");
-    }
+  public KeyFactoryTestEC() {
+    super("EC", ECPublicKeySpec.class, ECPrivateKeySpec.class);
+  }
 
-    @Override
-    protected void check(KeyPair keyPair) throws Exception {
-        new SignatureHelper("SHA256withECDSA").test(keyPair);
-    }
+  @Override
+  public ServiceTester customizeTester(ServiceTester tester) {
+    // BC's EC keys always use explicit params, even though it's a bad idea, and we don't support
+    // those, so don't test BC keys
+    return tester.skipProvider("BC");
+  }
 
-    @Override
-    protected List<KeyPair> getKeys() throws NoSuchAlgorithmException, InvalidKeySpecException {
-        return Arrays.asList(
-                new KeyPair(DefaultKeys.getPublicKey("EC"), DefaultKeys.getPrivateKey("EC")),
-                new KeyPair(new TestPublicKey(DefaultKeys.getPublicKey("EC")),
-                        new TestPrivateKey(DefaultKeys.getPrivateKey("EC"))),
-                new KeyPair(new TestECPublicKey((ECPublicKey) DefaultKeys.getPublicKey("EC")),
-                        new TestECPrivateKey((ECPrivateKey) DefaultKeys.getPrivateKey("EC"))));
-    }
+  @Override
+  protected void check(KeyPair keyPair) throws Exception {
+    new SignatureHelper("SHA256withECDSA").test(keyPair);
+  }
 
-    @Test
-    public void shouldThrowInvalidKeySpecException_whenKeySpecIsOdd() throws Exception {
-        Provider p = Security.getProvider(StandardNames.JSSE_PROVIDER_NAME);
-        final KeyFactory factory = KeyFactory.getInstance("EC", p);
-
-        try {
-            factory.getKeySpec(new TestECPublicKey((ECPublicKey) DefaultKeys.getPublicKey("EC")),
-                    FakeECPublicKeySpec.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(DefaultKeys.getPublicKey("EC"), FakeECPublicKeySpec.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(new TestECPrivateKey((ECPrivateKey) DefaultKeys.getPrivateKey("EC")),
-                    FakeECPrivateKeySpec.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(DefaultKeys.getPrivateKey("EC"), FakeECPrivateKeySpec.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(DefaultKeys.getPrivateKey("EC"), FakePKCS8.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(DefaultKeys.getPublicKey("EC"), FakeX509.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-    }
-
-    private static class FakeECPublicKeySpec extends ECPublicKeySpec {
-        public FakeECPublicKeySpec(ECPoint w, ECParameterSpec params) {
-            super(w, params);
-        }
-    }
-
-    private static class FakeECPrivateKeySpec extends ECPrivateKeySpec {
-        public FakeECPrivateKeySpec(BigInteger s, ECParameterSpec params) {
-            super(s, params);
-        }
-    }
-
-    private static class FakePKCS8 extends PKCS8EncodedKeySpec {
-        public FakePKCS8(byte[] encodedKey) {
-            super(encodedKey);
-        }
-    }
-
-    private static class FakeX509 extends X509EncodedKeySpec {
-        public FakeX509(byte[] encodedKey) {
-            super(encodedKey);
-        }
-    }
+  @Override
+  protected List<KeyPair> getKeys() throws NoSuchAlgorithmException, InvalidKeySpecException {
+    return Arrays.asList(
+        new KeyPair(
+            DefaultKeys.getPublicKey("EC"),
+            DefaultKeys.getPrivateKey("EC")
+        ),
+        new KeyPair(
+            new TestPublicKey(DefaultKeys.getPublicKey("EC")),
+            new TestPrivateKey(DefaultKeys.getPrivateKey("EC"))
+        ),
+        new KeyPair(
+            new TestECPublicKey((ECPublicKey)DefaultKeys.getPublicKey("EC")),
+            new TestECPrivateKey((ECPrivateKey)DefaultKeys.getPrivateKey("EC"))
+        )
+    );
+  }
 }

--- a/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
+++ b/common/src/test/java/org/conscrypt/java/security/KeyFactoryTestRSA.java
@@ -17,15 +17,12 @@ package org.conscrypt.java.security;
 
 import static org.junit.Assert.fail;
 
-import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.PublicKey;
 import java.security.Security;
-import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.RSAPrivateCrtKeySpec;
@@ -37,7 +34,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class KeyFactoryTestRSA extends AbstractKeyFactoryTest<RSAPublicKeySpec, RSAPrivateKeySpec> {
+public class KeyFactoryTestRSA extends
+        AbstractKeyFactoryTest<RSAPublicKeySpec, RSAPrivateKeySpec> {
+
     public KeyFactoryTestRSA() {
         super("RSA", RSAPublicKeySpec.class, RSAPrivateKeySpec.class);
     }
@@ -66,13 +65,13 @@ public class KeyFactoryTestRSA extends AbstractKeyFactoryTest<RSAPublicKeySpec, 
     }
 
     @Test
-    public void shouldThrowInvalidKeySpec_whenKeyIsInvalid() throws Exception {
+    public void testInvalidKeySpec() throws Exception {
         Provider p = Security.getProvider(StandardNames.JSSE_PROVIDER_NAME);
         final KeyFactory factory = KeyFactory.getInstance("RSA", p);
 
         try {
             factory.getKeySpec(new TestPrivateKey(DefaultKeys.getPrivateKey("RSA"), "Invalid"),
-                    RSAPrivateKeySpec.class);
+                RSAPrivateKeySpec.class);
             fail();
         } catch (InvalidKeySpecException e) {
             // expected
@@ -80,7 +79,7 @@ public class KeyFactoryTestRSA extends AbstractKeyFactoryTest<RSAPublicKeySpec, 
 
         try {
             factory.getKeySpec(new TestPrivateKey(DefaultKeys.getPrivateKey("RSA"), "Invalid"),
-                    RSAPrivateCrtKeySpec.class);
+                RSAPrivateCrtKeySpec.class);
             fail();
         } catch (InvalidKeySpecException e) {
             // expected
@@ -88,86 +87,10 @@ public class KeyFactoryTestRSA extends AbstractKeyFactoryTest<RSAPublicKeySpec, 
 
         try {
             factory.getKeySpec(new TestPublicKey(DefaultKeys.getPublicKey("RSA"), "Invalid"),
-                    RSAPublicKeySpec.class);
+                RSAPublicKeySpec.class);
             fail();
         } catch (InvalidKeySpecException e) {
             // expected
-        }
-    }
-
-    @Test
-    public void shouldThrowInvalidKeySpec_whenKeySpecIsOdd() throws Exception {
-        Provider p = Security.getProvider(StandardNames.JSSE_PROVIDER_NAME);
-        final KeyFactory factory = KeyFactory.getInstance("RSA", p);
-
-        try {
-            factory.getKeySpec(DefaultKeys.getPublicKey("RSA"), FakeRSAPublicKeySpec.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(generateRsaKey(), FakeRSAPrivateCrtKeySpec.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(DefaultKeys.getPrivateKey("RSA"), FakeRSAPrivateCrtKeySpec.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(DefaultKeys.getPrivateKey("RSA"), FakePKCS8.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-
-        try {
-            factory.getKeySpec(DefaultKeys.getPublicKey("RSA"), FakeX509.class);
-            fail();
-        } catch (InvalidKeySpecException e) {
-            // expected
-        }
-    }
-
-    private static RSAPrivateCrtKey generateRsaKey() throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(512);
-
-        KeyPair keyPair = kpg.generateKeyPair();
-        return (RSAPrivateCrtKey) keyPair.getPrivate();
-    }
-
-    private static class FakeRSAPublicKeySpec extends RSAPublicKeySpec {
-        public FakeRSAPublicKeySpec(BigInteger modulus, BigInteger publicExponent) {
-            super(modulus, publicExponent);
-        }
-    }
-
-    private static class FakePKCS8 extends PKCS8EncodedKeySpec {
-        public FakePKCS8(byte[] encodedKey) {
-            super(encodedKey);
-        }
-    }
-
-    private static class FakeRSAPrivateCrtKeySpec extends RSAPrivateCrtKeySpec {
-        public FakeRSAPrivateCrtKeySpec(BigInteger modulus, BigInteger publicExponent,
-                BigInteger privateExponent, BigInteger primeP, BigInteger primeQ,
-                BigInteger primeExponentP, BigInteger primeExponentQ, BigInteger crtCoefficient) {
-            super(modulus, publicExponent, privateExponent, primeP, primeQ, primeExponentP,
-                    primeExponentQ, crtCoefficient);
-        }
-    }
-
-    private static class FakeX509 extends X509EncodedKeySpec {
-        public FakeX509(byte[] encodedKey) {
-            super(encodedKey);
         }
     }
 }


### PR DESCRIPTION
Reverts google/conscrypt#920

Reverting this for now (sorry!) to unblock a downstream merge.  There's something a bit more subtle going on here as this breaks two tests on AOSP `com.android.org.conscrypt.java.security.KeyFactoryTestRSACrt` and 
`com.android.org.conscrypt.java.security.KeyFactoryTestRSACustom`, both on the same `isAssignableFrom` check which got flipped, e.g.
```
Failure testing KeyFactory:RSA from provider AndroidOpenSSL:
java.security.spec.InvalidKeySpecException: Encoded key is not an RSAPrivateCrtKey
	at com.android.org.conscrypt.OpenSSLRSAKeyFactory.engineGetKeySpec(OpenSSLRSAKeyFactory.java:147)
	at java.security.KeyFactory.getKeySpec(KeyFactory.java:442)
	at com.android.org.conscrypt.java.security.AbstractKeyFactoryTest$1.test(AbstractKeyFactoryTest.java:67)
	at tests.util.ServiceTester.doTest(ServiceTester.java:171)
	at tests.util.ServiceTester.run(ServiceTester.java:158)
	at com.android.org.conscrypt.java.security.AbstractKeyFactoryTest.testKeyFactory(AbstractKeyFactoryTest.java:60)
```

It's also worth checking if those tests are getting run on OpenJDK as the failure *should* be the same on both platforms.