### PR TITLE
Fix ConscryptEngine.wrap() behaviour when multiple buffers passed in.

### DIFF
--- a/common/src/main/java/org/conscrypt/BufferUtils.java
+++ b/common/src/main/java/org/conscrypt/BufferUtils.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static java.lang.Math.min;
+import static org.conscrypt.Preconditions.checkArgument;
+
+import java.nio.ByteBuffer;
+
+final class BufferUtils {
+    private BufferUtils() {}
+
+    /**
+     * Returns {@code true} if none of the buffers in the buffer array are null,
+     * otherwise {@code false}.
+     */
+    static boolean noNulls(ByteBuffer[] buffers) {
+        for (ByteBuffer buffer : buffers) {
+            if (buffer == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the total number of bytes remaining in the buffer array.
+     */
+    static long remaining(ByteBuffer[] buffers) {
+        long size = 0;
+        for (ByteBuffer buffer : buffers) {
+            size += buffer.remaining();
+        }
+        return size;
+    }
+
+    /**
+     * Marks {@code toConsume} bytes of data as consumed from the buffer array.
+     *
+     * @throws IllegalArgumentException if there are fewer than {@code toConsume} bytes remaining
+     */
+    static void consume(ByteBuffer[] sourceBuffers, int toConsume) {
+        for (ByteBuffer sourceBuffer : sourceBuffers) {
+            int amount = min(sourceBuffer.remaining(), toConsume);
+            if (amount > 0) {
+                sourceBuffer.position(sourceBuffer.position() + amount);
+                toConsume -= amount;
+                if (toConsume == 0) {
+                    break;
+                }
+            }
+        }
+        if (toConsume > 0) {
+            throw new IllegalArgumentException("toConsume > data size");
+        }
+    }
+
+    /**
+     * Looks for a buffer in the buffer array which EITHER is larger than {@code minSize} AND
+     * has no preceding non-empty buffers OR is the only non-empty buffer in the array.
+     * because it contains enough data to fill a complete TLS record or because it is the only
+     * remaining buffer which contains data.
+     */
+    static ByteBuffer getBufferLargerThan(ByteBuffer[] buffers, int minSize) {
+        int length = buffers.length;
+        for (int i = 0; i < length; i++) {
+            ByteBuffer buffer = buffers[i];
+            int remaining = buffer.remaining();
+            if (remaining > 0) {
+                if (remaining >= minSize) {
+                    return buffer;
+                }
+                for (int j = i + 1; j < length; j++) {
+                    if (buffers[j].remaining() > 0) {
+                        return null;
+                    }
+                }
+                return buffer;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Copies up to {@code maxAmount} bytes from a buffer array to {@code destination}.
+     * The copied data is <b>not</b> marked as consumed from the source buffers, on the
+     * assumption the copy will be passed to some method which will consume between 0 and
+     * {@code maxAmount} bytes which can then be reflected in the source array using the
+     * {@code consume()} method.
+     *
+     */
+    static ByteBuffer copyNoConsume(ByteBuffer[] buffers, ByteBuffer destination, int maxAmount) {
+	checkArgument(destination.remaining() >= maxAmount, "Destination buffer too small");
+	int needed = maxAmount;
+        for (ByteBuffer buffer : buffers) {
+	    int remaining = buffer.remaining();
+            if (remaining > 0) {
+                // If this buffer can fit completely then copy it all, otherwise temporarily
+                // adjust its limit to fill so as to the output buffer completely
+                int oldPosition = buffer.position();
+                if (remaining <= needed) {
+                    destination.put(buffer);
+                    needed -= remaining;
+                } else {
+                    int oldLimit = buffer.limit();
+                    buffer.limit(buffer.position() + needed);
+                    destination.put(buffer);
+                    buffer.limit(oldLimit);
+                    needed = 0;
+                }
+                // Restore the buffer's position, the data won't get marked as consumed until
+                // outputBuffer has been successfully consumed.
+                buffer.position(oldPosition);
+                if (needed == 0) {
+                    break;
+                }
+            }
+        }
+        destination.flip();
+        return destination;
+    }
+}

--- a/common/src/main/java/org/conscrypt/BufferUtils.java
+++ b/common/src/main/java/org/conscrypt/BufferUtils.java
@@ -25,16 +25,14 @@ final class BufferUtils {
     private BufferUtils() {}
 
     /**
-     * Returns {@code true} if none of the buffers in the buffer array are null,
-     * otherwise {@code false}.
+     * Throws {@link IllegalArgumentException} if any of the buffers in the array are null.
      */
-    static boolean noNulls(ByteBuffer[] buffers) {
+    static void checkNotNull(ByteBuffer[] buffers) {
         for (ByteBuffer buffer : buffers) {
             if (buffer == null) {
-                return false;
+                throw new IllegalArgumentException("Null buffer in array");
             }
         }
-        return true;
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/BufferUtils.java
+++ b/common/src/main/java/org/conscrypt/BufferUtils.java
@@ -72,8 +72,6 @@ final class BufferUtils {
     /**
      * Looks for a buffer in the buffer array which EITHER is larger than {@code minSize} AND
      * has no preceding non-empty buffers OR is the only non-empty buffer in the array.
-     * because it contains enough data to fill a complete TLS record or because it is the only
-     * remaining buffer which contains data.
      */
     static ByteBuffer getBufferLargerThan(ByteBuffer[] buffers, int minSize) {
         int length = buffers.length;

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1459,7 +1459,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
                     // especially if compacting multiple non-direct buffers into a single
                     // direct one.
                     // TODO(): use bufferAllocator if set.
-                    //  https://github.com/google/conscrypt/issues/974
+                    // https://github.com/google/conscrypt/issues/974
                     outputBuffer = BufferUtils.copyNoConsume(
                             srcs, getOrCreateLazyDirectBuffer(), SSL3_RT_MAX_PLAIN_LENGTH);
                     isCopy = true;

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1395,7 +1395,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
         if ((srcsOffset != 0) || (srcsLength != srcs.length)) {
             srcs = Arrays.copyOfRange(srcs, srcsOffset, srcsOffset + srcsLength);
         }
-        checkArgument(BufferUtils.noNulls(srcs), "null source buffer(s)");
+        BufferUtils.checkNotNull(srcs);
 
         synchronized (ssl) {
             switch (state) {

--- a/common/src/test/java/org/conscrypt/BufferUtilsTest.java
+++ b/common/src/test/java/org/conscrypt/BufferUtilsTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import org.conscrypt.TestUtils.BufferType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+
+@RunWith(Parameterized.class)
+public class BufferUtilsTest {
+    private static final int K64 = 64 * 1024;
+    private static final int K16 = 16 * 1024;
+
+    private static final int[][] TEST_SIZES = {
+            // All even numbers as several tests use size/2
+            { 0 },
+            { 0, 0, 0, 0 },
+            { 0, 0, 0, 2 },
+            { 2, 0, 0, 0 },
+            { 100, 200, 300 },
+            { 1000, 2000, 3000 },
+            { K16 },
+            { 0, 0, K16 },
+            { K16, 0, 0 },
+            { K64 },
+            { 0, 0, K64 },
+            { K64, 0, 0 },
+            { 100, 100, K64 },
+            { K64, 100, 100 },
+            { K64, K64, K64 },
+    };
+
+
+    @Parameters(name = "{0}")
+    public static BufferType[] data() {
+        return new BufferType[] { BufferType.HEAP, BufferType.DIRECT };
+    }
+
+    @Parameter
+    public BufferType bufferType;
+
+    @Test
+    public void noNulls() {
+        for (int[] sizes : TEST_SIZES) {
+            assertTrue(BufferUtils.noNulls(bufferType.newRandomBuffers(sizes)));
+        }
+
+        ByteBuffer[] buffers = bufferType.newRandomBuffers(10, 10, 10, 10, 10);
+        buffers[2] = null;
+        assertFalse(BufferUtils.noNulls(buffers));
+    }
+
+    @Test
+    public void remaining() {
+        for (int[] sizes : TEST_SIZES) {
+            assertEquals(arraySum(sizes),
+                    BufferUtils.remaining(bufferType.newRandomBuffers(sizes)));
+        }
+    }
+
+    @Test
+    public void consume() {
+        for (int[] sizes : TEST_SIZES) {
+            ByteBuffer[] buffers = bufferType.newRandomBuffers(sizes);
+            int totalSize = arraySum(sizes);
+
+            BufferUtils.consume(buffers, 0);
+            assertEquals(totalSize, BufferUtils.remaining(buffers));
+
+            BufferUtils.consume(buffers,totalSize / 2);
+            assertEquals(totalSize / 2, BufferUtils.remaining(buffers));
+
+            BufferUtils.consume(buffers,totalSize / 2);
+            assertEquals(0, BufferUtils.remaining(buffers));
+
+            try {
+                BufferUtils.consume(buffers, totalSize / 2);
+            } catch (IllegalArgumentException e) {
+                // Expected
+            }
+        }
+    }
+
+    @Test
+    public void copyNoConsume() {
+        for (BufferType destinationType : BufferType.values()) {
+            for (int[] sizes : TEST_SIZES) {
+                ByteBuffer[] buffers = bufferType.newRandomBuffers(sizes);
+                int totalSize = arraySum(sizes);
+
+		// 
+                ByteBuffer destination = destinationType.newBuffer(totalSize);
+                BufferUtils.copyNoConsume(buffers, destination, totalSize);
+                assertEquals(totalSize, BufferUtils.remaining(buffers));
+
+                assertArrayEquals(toArray(buffers), toArray(destination));
+            }
+        }
+    }
+
+    private static byte[] toArray(ByteBuffer... buffers) {
+        byte[] bytes = new byte[(int) BufferUtils.remaining(buffers)];
+        int offset = 0;
+        for (ByteBuffer buffer : buffers) {
+            int length = buffer.remaining();
+            if (length > 0) {
+                buffer.get(bytes, offset, length);
+                offset += length;
+            }
+        }
+        return bytes;
+    }
+
+    @Test
+    public void getBufferLargerThan_allSmall() {
+        ByteBuffer[] buffers = bufferType.newRandomBuffers(100, 200, 300, 400);
+
+        assertNull(BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 300);
+        assertNull(BufferUtils.getBufferLargerThan(buffers, K16));
+        assertSame(buffers[2], BufferUtils.getBufferLargerThan(buffers, 100));
+
+        BufferUtils.consume(buffers, 300);
+        assertSame(buffers[3], BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 200);
+        assertSame(buffers[3], BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 200);
+        ByteBuffer buffer = BufferUtils.getBufferLargerThan(buffers, K16);
+        assertNull(buffer);
+    }
+
+    @Test
+    public void getBufferLargerThan_oneLarge() {
+        ByteBuffer[] buffers = bufferType.newRandomBuffers(100, K64, 300, 400);
+
+        assertNull(BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 100);
+        assertSame(buffers[1], BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 1024); // 63K remaining in buffers[1]
+        assertSame(buffers[1], BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 60 * 1024); // 3K remaining in buffers[1]
+        assertNull(BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 3 * 1024);
+        assertEquals(0, buffers[1].remaining());
+        assertNull(BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 300);
+        assertSame(buffers[3], BufferUtils.getBufferLargerThan(buffers, K16));
+
+        BufferUtils.consume(buffers, 400);
+        ByteBuffer buffer = BufferUtils.getBufferLargerThan(buffers, K16);
+        assertNull(buffer);
+    }
+
+    @Test
+    public void getBufferLargerThan_onlyOneBuffer() {
+        ByteBuffer[] buffers = bufferType.newRandomBuffers(0, 0, 100, 0, 0);
+
+        assertSame(buffers[2], BufferUtils.getBufferLargerThan(buffers, K16));
+    }
+
+    private int arraySum(int[] sizes) {
+        int sum = 0;
+        for (int i : sizes) {
+            sum += i;
+        }
+        return sum;
+    }
+}

--- a/common/src/test/java/org/conscrypt/ConscryptSuite.java
+++ b/common/src/test/java/org/conscrypt/ConscryptSuite.java
@@ -100,6 +100,7 @@ import org.junit.runners.Suite;
         AlgorithmParametersTestEC.class,
         AlgorithmParametersTestGCM.class,
         AlgorithmParametersTestOAEP.class,
+        BufferUtilsTest.class,
         CipherSuiteTest.class,
         KeyFactoryTestDH.class,
         KeyFactoryTestDSA.class,

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -934,18 +934,21 @@ public class SSLEngineTest {
         // Client/server mode not set => IllegalStateException
         try {
             newUnconnectedEngine().wrap(buffer, buffer);
+            fail();
         } catch (IllegalStateException e) {
             // Expected
         }
 
         try {
             newUnconnectedEngine().wrap(buffers, buffer);
+            fail();
         } catch (IllegalStateException e) {
             // Expected
         }
 
         try {
             newUnconnectedEngine().wrap(buffers, 0, 1, buffer);
+            fail();
         } catch (IllegalStateException e) {
             // Expected
         }

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -17,6 +17,7 @@
 package org.conscrypt.javax.net.ssl;
 
 import static org.conscrypt.TestUtils.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -27,6 +28,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -48,6 +50,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 import org.conscrypt.TestUtils;
+import org.conscrypt.TestUtils.BufferType;
 import org.conscrypt.java.security.StandardNames;
 import org.conscrypt.java.security.TestKeyStore;
 import org.junit.Test;
@@ -920,6 +923,184 @@ public class SSLEngineTest {
             assertFalse(e.getWantClientAuth());
         }
         c.close();
+    }
+
+    @Test
+    public void wrapPreconditions() throws Exception {
+        ByteBuffer buffer = ByteBuffer.allocate(10);
+        ByteBuffer[] buffers = new ByteBuffer[] { buffer, buffer, buffer };
+        ByteBuffer[] badBuffers = new ByteBuffer[] { buffer, buffer, null, buffer };
+
+        // Client/server mode not set => IllegalStateException
+        try {
+            newUnconnectedEngine().wrap(buffer, buffer);
+        } catch (IllegalStateException e) {
+            // Expected
+        }
+
+        try {
+            newUnconnectedEngine().wrap(buffers, buffer);
+        } catch (IllegalStateException e) {
+            // Expected
+        }
+
+        try {
+            newUnconnectedEngine().wrap(buffers, 0, 1, buffer);
+        } catch (IllegalStateException e) {
+            // Expected
+        }
+
+        // Read-only destination => ReadOnlyBufferException
+        try {
+            newConnectedEngine().wrap(buffer, buffer.asReadOnlyBuffer());
+            fail();
+        } catch (ReadOnlyBufferException e) {
+            // Expected
+        }
+
+        try {
+            newConnectedEngine().wrap(buffers, buffer.asReadOnlyBuffer());
+            fail();
+        } catch (ReadOnlyBufferException e) {
+            // Expected
+        }
+
+        try {
+            newConnectedEngine().wrap(buffers, 0, 1, buffer.asReadOnlyBuffer());
+            fail();
+        } catch (ReadOnlyBufferException e) {
+            // Expected
+        }
+
+        // Null destination => IllegalArgumentException
+        try {
+            newConnectedEngine().wrap(buffer, null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            newConnectedEngine().wrap(buffers,  null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            newConnectedEngine().wrap(buffers, 0, 1, null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        // Null source => IllegalArgumentException
+        try {
+            newConnectedEngine().wrap((ByteBuffer) null, buffer);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            newConnectedEngine().wrap((ByteBuffer[]) null, buffer);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            newConnectedEngine().wrap(null, 0, 1, buffer);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        // Null entries in buffer array => IllegalArgumentException
+        try {
+            newConnectedEngine().wrap(badBuffers, buffer);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            newConnectedEngine().wrap(badBuffers, 0, badBuffers.length, buffer);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        // Bad offset or length => IndexOutOfBoundsException
+        try {
+            newConnectedEngine().wrap(buffers, 0, 7, buffer);
+            fail();
+        } catch (IndexOutOfBoundsException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void bufferArrayOffsets() throws Exception{
+        TestSSLEnginePair pair = TestSSLEnginePair.create();
+        ByteBuffer tlsBuffer = ByteBuffer.allocate(600);
+        int bufferSize = 100;
+
+        for (BufferType bufferType : BufferType.values()) {
+            ByteBuffer[] sourceBuffers = bufferType.newRandomBuffers(
+                    bufferSize, bufferSize, bufferSize, bufferSize, bufferSize);
+            for (int offset = 0; offset < sourceBuffers.length; offset++) {
+                for (int length = 1; length < sourceBuffers.length - offset; length++) {
+                    // Reset source buffers
+                    for (ByteBuffer buffer : sourceBuffers) {
+                        if (buffer.remaining() == 0) {
+                            buffer.flip();
+                        }
+                        assertEquals(bufferSize, buffer.remaining());
+                    }
+                    // Make an array copy of what we expect to send
+                    byte[] sourceBytes = copyDataFromBuffers(sourceBuffers, offset, length);
+                    byte[] destinationBytes = new byte[sourceBytes.length];
+                    ByteBuffer destination = ByteBuffer.wrap(destinationBytes);
+                    // Send and compare
+                    tlsBuffer.clear();
+                    pair.client.wrap(sourceBuffers, offset, length, tlsBuffer);
+                    tlsBuffer.flip();
+                    pair.server.unwrap(tlsBuffer, destination);
+                    assertArrayEquals(sourceBytes, destinationBytes);
+                }
+            }
+        }
+    }
+
+    private byte[] copyDataFromBuffers(ByteBuffer[] buffers, int offset, int length) {
+        // NB avoids using Arrays.copyOfRange() to prevent any common bugs with
+        // ConscryptEngine.wrap().
+        int size = 0;
+        for (int i = offset; i < offset + length; i++) {
+            size += buffers[i].remaining();
+        }
+        byte[] data = new byte[size];
+        int dataOffset = 0;
+        for (int i = offset; i < offset + length; i++) {
+            ByteBuffer buffer = buffers[i];
+            int remaining = buffer.remaining();
+            buffer.get(data, dataOffset, remaining);
+            buffer.flip();
+            dataOffset += remaining;
+        }
+        return data;
+    }
+
+    private SSLEngine newUnconnectedEngine() {
+        TestSSLContext context = TestSSLContext.create();
+        return context.clientContext.createSSLEngine();
+    }
+
+    private SSLEngine newConnectedEngine() throws Exception {
+        TestSSLEnginePair pair = TestSSLEnginePair.create();
+        assertConnected(pair);
+        return pair.client;
     }
 
     private void assertConnected(TestSSLEnginePair e) {

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLEngineTest.java
@@ -357,18 +357,15 @@ public class SSLEngineTest {
                 sourceOutRes.getHandshakeStatus());
         SSLSession destSession = dest.getSession();
         ByteBuffer destIn = ByteBuffer.allocate(destSession.getApplicationBufferSize());
-        int numUnwrapCalls = 0;
         while (destIn.position() != sourceBytes.length) {
             SSLEngineResult destRes = dest.unwrap(sourceToDest, destIn);
             assertEquals(sourceCipherSuite, HandshakeStatus.NOT_HANDSHAKING,
                     destRes.getHandshakeStatus());
-            numUnwrapCalls++;
         }
         destIn.flip();
         byte[] actual = new byte[destIn.remaining()];
         destIn.get(actual);
         assertEquals(sourceCipherSuite, Arrays.toString(sourceBytes), Arrays.toString(actual));
-        assertEquals(sourceCipherSuite, 3, numUnwrapCalls);
     }
 
     @Test

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -48,6 +48,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Random;
 import java.util.Set;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -80,6 +81,41 @@ public final class TestUtils {
     private static final String[] PROTOCOLS = getProtocolsInternal();
 
     static final String TEST_CIPHER = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+
+    public enum BufferType {
+        HEAP {
+            @Override
+            ByteBuffer newBuffer(int size) {
+                return ByteBuffer.allocate(size);
+            }
+        },
+        DIRECT {
+            @Override
+            ByteBuffer newBuffer(int size) {
+                return ByteBuffer.allocateDirect(size);
+            }
+        };
+        private static final Random random = new Random(System.currentTimeMillis());
+        abstract ByteBuffer newBuffer(int size);
+
+        public ByteBuffer[] newRandomBuffers(int... sizes) {
+            int numBuffers = sizes.length;
+            ByteBuffer[] result = new ByteBuffer[numBuffers];
+            for (int i = 0; i < numBuffers; i++) {
+                result[i] = newRandomBuffer(sizes[i]);
+            }
+            return result;
+        }
+
+        public ByteBuffer newRandomBuffer(int size) {
+            byte[] data = new byte[size];
+            random.nextBytes(data);
+            ByteBuffer buffer = newBuffer(size);
+            buffer.put(data);
+            buffer.flip();
+            return buffer;
+        }
+    }
 
     private TestUtils() {}
 


### PR DESCRIPTION
Fixes #929.

Behaviour unchanged for the common case of passing a single
buffer to `wrap()`. TODO(prb) Add a test for this.

When passing an array of small buffers, instead of passing them
individually to BoringSSL, which generates one TLS record per buffer,
coalesce theem into a single larger buffer so that a single maximal
sized TLS record is generated, which was the original intent here.

This is a slight behaviour change for apps which aren't hitting #929
but I believe based on commentary on the bug this is closer to
the RI behacviour.

Currently, if an app passes multiple buffers into a single `wrap()`
call, one TLS record is generated for each which means on the
receiving end multiple `unwrap()` calls are required so the app has
to loop, unwrapping until no more records are available.  After
this change only a single unwrap is required so the same code will
still work. However if an app is making assumptions about where TLS
record boundaries lie then it might have issue - such an app is
buggy as `SSLEngine` makes no guarentees in this area.  This assumption
was inadvertently baked into a couple of tests - removed it.