### PR TITLE
Use shadow JAR in OpenJDK tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,9 +314,10 @@ jobs:
           DIR="$(find m2/org/conscrypt/conscrypt-openjdk-uber -maxdepth 1 -mindepth 1 -type d -print)"
           VERSION="${DIR##*/}"
           TESTJAR="$(find testjar -name '*-tests.jar')"
-          java -jar junit-platform-console-standalone.jar -cp "$DIR/conscrypt-openjdk-uber-$VERSION.jar:$TESTJAR" -n='${{ matrix.suite_class }}' --scan-classpath --reports-dir=results
+          java -jar junit-platform-console-standalone.jar -cp "$DIR/conscrypt-openjdk-uber-$VERSION.jar:$TESTJAR" -n='${{ matrix.suite_class }}' --scan-classpath --reports-dir=results --fail-if-no-tests
 
       - name: Archive test results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: test-results-${{ matrix.platform }}-${{ matrix.java }}

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -180,7 +180,7 @@ dependencies {
     compileOnly project(':conscrypt-constants')
 
     testCompile project(':conscrypt-constants'),
-            project(path: ':conscrypt-testing', configuration: 'runtime'),
+            project(path: ':conscrypt-testing', configuration: 'shadow'),
             libraries.junit,
             libraries.mockito
 


### PR DESCRIPTION
The last commit changed from "shadow" to "runtime" mistakenly. Revert
that change. Otherwise the testJar target does not contain the classes
needed to run the tests correctly.