### PR TITLE
OpenSSLX509CertificateTest on OpenJDK 12+

### DIFF
--- a/openjdk/src/test/java/org/conscrypt/OpenSSLX509CertificateTest.java
+++ b/openjdk/src/test/java/org/conscrypt/OpenSSLX509CertificateTest.java
@@ -47,7 +47,7 @@ public class OpenSSLX509CertificateTest extends TestCase {
             try {
                 Field modifiersField = null;
                 try {
-                    Field.class.getDeclaredField("modifiers");
+                    modifiersField = Field.class.getDeclaredField("modifiers");
                 } catch (NoSuchFieldException e) {
                     try {
                         Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);

--- a/openjdk/src/test/java/org/conscrypt/OpenSSLX509CertificateTest.java
+++ b/openjdk/src/test/java/org/conscrypt/OpenSSLX509CertificateTest.java
@@ -25,6 +25,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import junit.framework.TestCase;
@@ -43,10 +45,28 @@ public class OpenSSLX509CertificateTest extends TestCase {
 
             // Mark the field as non-final on JVM that need it.
             try {
-                Field modifiersField = Field.class.getDeclaredField("modifiers");
-                modifiersField.setAccessible(true);
-                modifiersField.setInt(targetUID, targetUID.getModifiers() & ~Modifier.FINAL);
-            } catch (NoSuchFieldException ignored) {
+                Field modifiersField = null;
+                try {
+                    Field.class.getDeclaredField("modifiers");
+                } catch (NoSuchFieldException e) {
+                    try {
+                        Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
+                        getDeclaredFields0.setAccessible(true);
+                        Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
+                        for (Field field : fields) {
+                            if ("modifiers".equals(field.getName())) {
+                                modifiersField = field;
+                                break;
+                            }
+                        }
+                    } catch (NoSuchMethodException | InvocationTargetException ignored) {
+                    }
+                }
+                if (modifiersField != null) {
+                    modifiersField.setAccessible(true);
+                    modifiersField.setInt(targetUID, targetUID.getModifiers() & ~Modifier.FINAL);
+                }
+            } catch (Exception ignored) {
             }
 
             targetUID.set(null, clDesc.getSerialVersionUID());


### PR DESCRIPTION
This "fixes" the test to check whether serialization works by making
the "modifiers" field of reflective access on Field accessible on
Open JDK 12+. This should probably use a VarHandle or something like
that in newer versions of the Java language.