### PR TITLE
No support for javax X509Certificate on OpenJDK 15+

### DIFF
--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -1054,4 +1054,8 @@ final class Platform {
         ConscryptStatsLog.write(
                 ConscryptStatsLog.TLS_HANDSHAKE_REPORTED, success, protocol, cipherSuite, duration);
     }
+
+    public static boolean isJavaxCertificateSupported() {
+        return true;
+    }
 }

--- a/common/src/main/java/org/conscrypt/ActiveSession.java
+++ b/common/src/main/java/org/conscrypt/ActiveSession.java
@@ -207,6 +207,10 @@ final class ActiveSession implements ConscryptSession {
     @Override
     public javax.security.cert.X509Certificate[] getPeerCertificateChain()
             throws SSLPeerUnverifiedException {
+        if (!Platform.isJavaxCertificateSupported()) {
+            throw new UnsupportedOperationException("Use getPeerCertificates() instead");
+        }
+
         checkPeerCertificatesPresent();
         // TODO(nathanmittler): Should we clone?
         javax.security.cert.X509Certificate[] result = peerCertificateChain;

--- a/common/src/main/java/org/conscrypt/SessionSnapshot.java
+++ b/common/src/main/java/org/conscrypt/SessionSnapshot.java
@@ -143,6 +143,10 @@ final class SessionSnapshot implements ConscryptSession {
     @Override
     public javax.security.cert.X509Certificate[] getPeerCertificateChain()
         throws SSLPeerUnverifiedException {
+        if (!Platform.isJavaxCertificateSupported()) {
+            throw new UnsupportedOperationException("Use getPeerCertificates() instead");
+        }
+
         throw new SSLPeerUnverifiedException("No peer certificates");
     }
 

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSessionTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSessionTest.java
@@ -198,14 +198,22 @@ public class SSLSessionTest {
             fail();
         } catch (SSLPeerUnverifiedException expected) {
             // Ignored.
+        } catch (UnsupportedOperationException e) {
+            if (!StandardNames.IS_15_OR_UP) {
+                fail("Should only throw UnsupportedOperationException on OpenJDK 15 or up");
+            }
         }
         assertNotNull(s.client.getPeerCertificates());
-        TestKeyStore.assertChainLength(s.client.getPeerCertificateChain());
+        TestKeyStore.assertChainLength(s.client.getPeerCertificates());
         try {
             assertNull(s.server.getPeerCertificateChain());
             fail();
         } catch (SSLPeerUnverifiedException expected) {
             // Ignored.
+        } catch (UnsupportedOperationException e) {
+            if (!StandardNames.IS_15_OR_UP) {
+                fail("Should only throw UnsupportedOperationException on OpenJDK 15 or up");
+            }
         }
         s.close();
     }

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -798,4 +798,8 @@ final class Platform {
     @SuppressWarnings("unused")
     static void countTlsHandshake(
             boolean success, String protocol, String cipherSuite, long duration) {}
+
+    public static boolean isJavaxCertificateSupported() {
+        return JAVA_VERSION < 15;
+    }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
+++ b/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
@@ -65,7 +65,7 @@ public final class StandardNames {
     public static final String KEY_STORE_ALGORITHM = IS_RI ? "JKS" : "BKS";
 
     public static final boolean IS_15_OR_UP =
-            Integer.parseInt(System.getProperty("java.specification.version")) >= 15;
+            Integer.parseInt(System.getProperty("java.vm.specification.version")) >= 15;
 
     /**
      * RFC 5746's Signaling Cipher Suite Value to indicate a request for secure renegotiation

--- a/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
+++ b/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
@@ -64,8 +64,26 @@ public final class StandardNames {
 
     public static final String KEY_STORE_ALGORITHM = IS_RI ? "JKS" : "BKS";
 
-    public static final boolean IS_15_OR_UP =
-            Integer.parseInt(System.getProperty("java.vm.specification.version")) >= 15;
+    public static final boolean IS_15_OR_UP = majorVersionFromJavaSpecificationVersion() >= 15;
+
+    private static int majorVersionFromJavaSpecificationVersion() {
+        return majorVersion(System.getProperty("java.specification.version", "1.6"));
+    }
+
+    private static int majorVersion(final String javaSpecVersion) {
+        final String[] components = javaSpecVersion.split("\\.", -1);
+        final int[] version = new int[components.length];
+        for (int i = 0; i < components.length; i++) {
+            version[i] = Integer.parseInt(components[i]);
+        }
+
+        if (version[0] == 1) {
+            assert version[1] >= 6;
+            return version[1];
+        } else {
+            return version[0];
+        }
+    }
 
     /**
      * RFC 5746's Signaling Cipher Suite Value to indicate a request for secure renegotiation

--- a/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
+++ b/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
@@ -64,6 +64,9 @@ public final class StandardNames {
 
     public static final String KEY_STORE_ALGORITHM = IS_RI ? "JKS" : "BKS";
 
+    public static final boolean IS_15_OR_UP =
+            Integer.parseInt(System.getProperty("java.specification.version")) >= 15;
+
     /**
      * RFC 5746's Signaling Cipher Suite Value to indicate a request for secure renegotiation
      */


### PR DESCRIPTION
OpenJDK 15+ dropped support for javax.security.cert.X509Certificate and
associated calls such as SSLSession#getPeerCertificateChain by throwing
UnsupportedOperationException when it is called. Mirror this behavior in
our implementation. Otherwise trying to construct that type of
certificate ends up with a ClassNotFound exception from within OpenJDK's
default implementation.