### PR TITLE
Fix NPE in OptionalMethod.

### DIFF
--- a/common/src/main/java/org/conscrypt/metrics/OptionalMethod.java
+++ b/common/src/main/java/org/conscrypt/metrics/OptionalMethod.java
@@ -28,17 +28,20 @@ import org.conscrypt.Internal;
 final class OptionalMethod {
     private final Method cachedMethod;
 
-    public OptionalMethod(Class<?> clazz, String methodName, Class... methodParams) {
+    public OptionalMethod(Class<?> clazz, String methodName, Class<?>... methodParams) {
         this.cachedMethod = initializeMethod(clazz, methodName, methodParams);
     }
 
     private static Method initializeMethod(
-            Class<?> clazz, String methodName, Class... methodParams) {
+            Class<?> clazz, String methodName, Class<?>... methodParams) {
         try {
-            return clazz.getMethod(methodName, methodParams);
+            if (clazz != null) {
+                return clazz.getMethod(methodName, methodParams);
+            }
         } catch (NoSuchMethodException ignored) {
-            return null;
+            // Ignored
         }
+        return null;
     }
 
     public Object invoke(Object target, Object... args) {


### PR DESCRIPTION
Make the constructor tolerant of a null Class being passed.
Not ideal, but makes the usage cleaner and saves multiple class
lookups.

Previously submitted in AOSP as https://r.android.com/1542470.