### PR TITLE
Return empty list if requestedServerName is null.

### DIFF
--- a/common/src/main/java/org/conscrypt/Java8ExtendedSSLSession.java
+++ b/common/src/main/java/org/conscrypt/Java8ExtendedSSLSession.java
@@ -36,7 +36,7 @@ class Java8ExtendedSSLSession extends Java7ExtendedSSLSession {
   public final List<SNIServerName> getRequestedServerNames() {
       String requestedServerName = delegate.getRequestedServerName();
       if (requestedServerName == null) {
-        return null;
+        return Collections.emptyList();
       }
 
       return Collections.singletonList((SNIServerName) new SNIHostName(requestedServerName));


### PR DESCRIPTION
As documented for ExtendedSSLSession. Fixes #977.