### PR TITLE
Remove broken PEM PKCS#7 support.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
@@ -88,18 +88,13 @@ public class OpenSSLX509CertificateFactory extends CertificateFactorySpi {
                 pbis.unread(buffer, 0, len);
 
                 if (buffer[0] == '-') {
-                    if (len == PKCS7_MARKER.length && Arrays.equals(PKCS7_MARKER, buffer)) {
-                        List<? extends T> items = fromPkcs7PemInputStream(pbis);
-                        if (items.size() == 0) {
-                            return null;
-                        }
-                        items.get(0);
-                    } else {
-                        return fromX509PemInputStream(pbis);
-                    }
+                    return fromX509PemInputStream(pbis);
                 }
 
-                /* PKCS#7 bags have a byte 0x06 at position 4 in the stream. */
+                // PKCS#7 bags have a byte 0x06 at position 4 in the stream.
+                //
+                // TODO(https://github.com/google/conscrypt/issues/987): Consider
+                // deprecating this.
                 if (buffer[4] == 0x06) {
                     List<? extends T> certs = fromPkcs7DerInputStream(pbis);
                     if (certs.size() == 0) {

--- a/common/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
@@ -377,9 +377,7 @@ public class CertificateFactoryTest {
         }
 
         // The RI only supports PKCS#7 blobs with generateCertificates, not
-        // generateCertificate.
-        //
-        // TODO(davidben): Also, PEM support for generateCertificate is broken. Remove it?
+        // generateCertificate. See https://github.com/google/conscrypt/issues/987
         if (!StandardNames.IS_RI) {
             byte[] valid = TestUtils.decodeBase64(VALID_CERTIFICATE_PKCS7_DER_BASE64);
             Certificate c = cf.generateCertificate(new ByteArrayInputStream(valid));
@@ -878,8 +876,7 @@ public class CertificateFactoryTest {
         assertEquals(c, c2);
 
         // The RI only supports PKCS#7 with generateCRLs, not generateCRL.
-        //
-        // TODO(davidben): Also, PEM support for generateCRL is broken. Remove it?
+        // See https://github.com/google/conscrypt/issues/987
         if (!StandardNames.IS_RI) {
             valid = TestUtils.decodeBase64(VALID_CRL_PKCS7_DER_BASE64);
             c2 = cf.generateCRL(new ByteArrayInputStream(valid));


### PR DESCRIPTION
This code never worked because it was missing a return. Updates #987.
This CL retains the DER support, though it doesn't match the docs.