### PR TITLE
Rework TBSCertificate (re)encoding bindings.

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -442,8 +442,6 @@ public final class NativeCrypto {
 
     static native void X509_free(long x509ctx, OpenSSLX509Certificate holder);
 
-    static native long X509_dup(long x509ctx, OpenSSLX509Certificate holder);
-
     static native int X509_cmp(long x509ctx1, OpenSSLX509Certificate holder, long x509ctx2, OpenSSLX509Certificate holder2);
 
     static native void X509_print_ex(long bioCtx, long x509ctx, OpenSSLX509Certificate holder, long nmflag, long certflag);
@@ -489,7 +487,9 @@ public final class NativeCrypto {
     static native void X509_verify(long x509ctx, OpenSSLX509Certificate holder, NativeRef.EVP_PKEY pkeyCtx)
             throws BadPaddingException;
 
-    static native byte[] get_X509_cert_info_enc(long x509ctx, OpenSSLX509Certificate holder);
+    static native byte[] get_X509_tbs_cert(long x509ctx, OpenSSLX509Certificate holder);
+
+    static native byte[] get_X509_tbs_cert_without_ext(long x509ctx, OpenSSLX509Certificate holder, String oid);
 
     static native byte[] get_X509_signature(long x509ctx, OpenSSLX509Certificate holder);
 
@@ -546,8 +546,6 @@ public final class NativeCrypto {
     static native String[] get_X509_CRL_ext_oids(long x509Crlctx, OpenSSLX509CRL holder, int critical);
 
     static native byte[] X509_CRL_get_ext_oid(long x509CrlCtx, OpenSSLX509CRL holder, String oid);
-
-    static native void X509_delete_ext(long x509, OpenSSLX509Certificate holder, String oid);
 
     static native long X509_CRL_get_version(long x509CrlCtx, OpenSSLX509CRL holder);
 

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -301,7 +301,7 @@ public final class OpenSSLX509Certificate extends X509Certificate {
 
     @Override
     public byte[] getTBSCertificate() throws CertificateEncodingException {
-        return NativeCrypto.get_X509_cert_info_enc(mContext, this);
+        return NativeCrypto.get_X509_tbs_cert(mContext, this);
     }
 
     @Override
@@ -569,16 +569,10 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     }
 
     /**
-     * Delete an extension.
-     *
-     * A modified copy of the certificate is returned. The original object
-     * is unchanged.
-     * If the extension is not present, an unmodified copy is returned.
+     * Returns a re-encoded TBSCertificate with the extension identified by oid removed.
      */
-    public OpenSSLX509Certificate withDeletedExtension(String oid) {
-        OpenSSLX509Certificate copy = new OpenSSLX509Certificate(NativeCrypto.X509_dup(mContext, this), notBefore, notAfter);
-        NativeCrypto.X509_delete_ext(copy.getContext(), copy, oid);
-        return copy;
+    public byte[] getTBSCertificateWithoutExtension(String oid) {
+        return NativeCrypto.get_X509_tbs_cert_without_ext(mContext, this, oid);
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/ct/CertificateEntry.java
+++ b/common/src/main/java/org/conscrypt/ct/CertificateEntry.java
@@ -87,8 +87,7 @@ public class CertificateEntry {
                 throw new CertificateException("Certificate does not contain embedded signed timestamps");
             }
 
-            OpenSSLX509Certificate preCert = leaf.withDeletedExtension(CTConstants.X509_SCT_LIST_OID);
-            byte[] tbs = preCert.getTBSCertificate();
+            byte[] tbs = leaf.getTBSCertificateWithoutExtension(CTConstants.X509_SCT_LIST_OID);
 
             byte[] issuerKey = issuer.getPublicKey().getEncoded();
             MessageDigest md = MessageDigest.getInstance("SHA-256");

--- a/openjdk/src/test/java/org/conscrypt/OpenSSLX509CertificateTest.java
+++ b/openjdk/src/test/java/org/conscrypt/OpenSSLX509CertificateTest.java
@@ -126,31 +126,31 @@ public class OpenSSLX509CertificateTest extends TestCase {
                 cert.getTBSCertificate()));
 
         assertTrue(Arrays.equals(
-                certPoisoned.withDeletedExtension(CT_POISON_EXTENSION).getTBSCertificate(),
+                certPoisoned.getTBSCertificateWithoutExtension(CT_POISON_EXTENSION),
                 cert.getTBSCertificate()));
     }
 
     public void test_deletingExtensionMakesCopy() throws Exception {
-        /* Calling withDeletedExtension should not modify the original certificate, only make a copy.
+        /* Calling getTBSCertificateWithoutExtension should not modify the original certificate.
          * Make sure the extension is still present in the original object.
          */
         OpenSSLX509Certificate certPoisoned = loadTestCertificate("cert-ct-poisoned.pem");
         assertTrue(certPoisoned.getCriticalExtensionOIDs().contains(CT_POISON_EXTENSION));
 
-        OpenSSLX509Certificate certWithoutExtension = certPoisoned.withDeletedExtension(CT_POISON_EXTENSION);
-
+        certPoisoned.getTBSCertificateWithoutExtension(CT_POISON_EXTENSION);
         assertTrue(certPoisoned.getCriticalExtensionOIDs().contains(CT_POISON_EXTENSION));
-        assertFalse(certWithoutExtension.getCriticalExtensionOIDs().contains(CT_POISON_EXTENSION));
     }
 
     public void test_deletingMissingExtension() throws Exception {
-        /* withDeletedExtension should be safe to call on a certificate without the extension, and
-         * return an identical copy.
+        /* getTBSCertificateWithoutExtension should throw on a certificate without the extension.
          */
         OpenSSLX509Certificate cert = loadTestCertificate("cert.pem");
         assertFalse(cert.getCriticalExtensionOIDs().contains(CT_POISON_EXTENSION));
 
-        OpenSSLX509Certificate cert2 = cert.withDeletedExtension(CT_POISON_EXTENSION);
-        assertEquals(cert, cert2);
+        try {
+            cert.getTBSCertificateWithoutExtension(CT_POISON_EXTENSION);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
     }
 }


### PR DESCRIPTION
An X.509 certificate contains of a TBSCertificate ("to be signed"), a
signature algorithm, and a signature. Although, in theory, DER
guarantees that re-encoding a parsed TBSCertificate gives back the same
bytes, it is safer and more robust to verify the encoded TBSCertificate
directly. (Also OpenSSL's parser is very lax and definitely not DER.)

Conscrypt needs the encoded TBSCertificate in two places: first to
implement getTBSCertificate(), used in signature verification, and
second as part of removing the CT poison extension in precertificate
handling.

OpenSSL's X509 type handles TBSCertificate a little strangely. It has a
cached encoded TBSCertificate that is populated on parse. But, to
support certificate issuance, one can also create an empty X509 object
and mutate it to make a certificate. These two use cases don't combine
very well; mutating a certificate silently puts the cached encoding in
an inconsistent state.

Upstream OpenSSL, when making X509 opaque, decided not to expose the
TBSCertificate or the cached encoding directly (X509_CINF or cert_info).
I think that was probably the right move as the cached data is a little
weird. Also X509_CINF_set_modified changes the thread-safety properties
of the X509 which seems especially poor. For CT, they have
i2d_X509_re_tbs which bundles together extracting the TBSCertificate and
forcing a re-encode. I've generalized it to also have i2d_X509_tbs,
which extracts TBSCertificate without a re-encode.

This PR switches Conscrypt to these APIs. Specifically:

- getTBSCertificate() uses the non-re-encoding version, because, except
  where it is called in CertificateEntry, it wants the original
  encoding.

- The CertificateEntry logic calls a new
  getTBSCertificateWithoutExtension() method. This method bundles
  together all the steps.

- getTBSCertificateWithoutExtension() has a single corresponding
  NativeCrypto method. This means that, while we still internally have
  an X509 object in the funny inconsistent state, it is never exposed to
  Java or OpenSSLX509Certificate. (If the modified bit is set on an
  X509, serializing it is no longer thread-safe.)

- Now unused bindings are removed. I've also renamed
  get_X509_cert_info_enc to get_X509_tbs_cert since "cert_info" no
  longer appears in the public API.