### PR TITLE
Update Cmake in Docker image to 3.5.2.

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -46,9 +46,9 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 # Build and install CMake from source.
 WORKDIR /usr/src
-RUN git clone git://cmake.org/cmake.git CMake && \
+RUN git clone https://gitlab.kitware.com/cmake/cmake.git CMake && \
   cd CMake && \
-  git checkout v3.4.1 && \
+  git checkout tags/v3.5.2 && \
   mkdir /usr/src/CMake-build && \
   cd /usr/src/CMake-build && \
   /usr/src/CMake/bootstrap \


### PR DESCRIPTION
Minimum required for BoringSSL is now 3.5.  Sticking with the bare
minimum upgrade for now but we should revisit these Docker choices
and upgrade where needed and where it won't affect ABI compat with
older Linuxes (which Cmake changes obvs won't)

Also updated Cmake git repository address as it's moved.