### PR TITLE
Add isJavaxCertificateSupported() to platform build.

### DIFF
--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -557,4 +557,8 @@ final class Platform {
         ConscryptStatsLog.write(ConscryptStatsLog.TLS_HANDSHAKE_REPORTED, success, proto.getId(),
                 suite.getId(), dur);
     }
+
+    public static boolean isJavaxCertificateSupported() {
+        return true;
+    }
 }


### PR DESCRIPTION
Accidentally omitted in #959 :)