### PR TITLE
Patch for returning empty String if no ALPN extension was read

### DIFF
--- a/common/src/main/java/org/conscrypt/ActiveSession.java
+++ b/common/src/main/java/org/conscrypt/ActiveSession.java
@@ -289,7 +289,7 @@ final class ActiveSession implements ConscryptSession {
             synchronized (ssl) {
                 applicationProtocol = SSLUtils.toProtocolString(ssl.getApplicationProtocol());
             }
-            this.applicationProtocol = applicationProtocol;
+            this.applicationProtocol = applicationProtocol == null ? "" : applicationProtocol;
         }
         return applicationProtocol;
     }


### PR DESCRIPTION
The [Java SSLEngine](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/javax/net/ssl/SSLEngine.html#getApplicationProtocol())
     defines three states: `null`, an empty response and a string for the application protocol.  [getApplicationProtocol](https://github.com/google/conscrypt/blob/1cca353e3133fbd587848a75debaed6eeab0779c/common/src/main/java/org/conscrypt/NativeCrypto.java#L1382) returns just `null` or or value. If no ALPN is found an empty string must be returned.

This fixes issue https://github.com/google/conscrypt/issues/1003