### PR TITLE
Use i2d_X509_CRL_tbs to encode the TBSCertList.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4995,7 +4995,7 @@ static jbyteArray NativeCrypto_get_X509_CRL_crl_enc(JNIEnv* env, jclass, jlong x
     CHECK_ERROR_QUEUE_ON_RETURN;
     X509_CRL* crl = reinterpret_cast<X509_CRL*>(static_cast<uintptr_t>(x509CrlRef));
     JNI_TRACE("get_X509_CRL_crl_enc(%p)", crl);
-    return ASN1ToByteArray<X509_CRL_INFO>(env, crl->crl, i2d_X509_CRL_INFO);
+    return ASN1ToByteArray<X509_CRL>(env, crl, i2d_X509_CRL_tbs);
 }
 
 static void NativeCrypto_X509_CRL_verify(JNIEnv* env, jclass, jlong x509CrlRef,

--- a/common/src/test/java/org/conscrypt/java/security/cert/X509CRLTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/cert/X509CRLTest.java
@@ -16,6 +16,7 @@
 
 package org.conscrypt.java.security.cert;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -32,6 +33,7 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509CRLEntry;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
+import org.conscrypt.TestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -91,6 +93,12 @@ public class X509CRLTest {
             + "nDN0LLg=\n"
             + "-----END X509 CRL-----\n";
 
+    private static final String CRL_TBS_BASE64 =
+            "MIG7AgEBMA0GCSqGSIb3DQEBCwUAMFUxCzAJBgNVBAYTAkdCMSQwIgYDVQQKExtD"
+            + "ZXJ0aWZpY2F0ZSBUcmFuc3BhcmVuY3kgQ0ExDjAMBgNVBAgTBVdhbGVzMRAwDgYD"
+            + "VQQHEwdFcncgV2VuFw0xOTA4MDcxMDI3MTBaFw0xOTA5MDYxMDI3MTBaMCIwIAIB"
+            + "BxcNMTkwODA3MTAyNjU0WjAMMAoGA1UdFQQDCgEBoA4wDDAKBgNVHRQEAwIBAg==";
+
     private static final String UNKNOWN_SIGNATURE_OID =
         "-----BEGIN X509 CRL-----\n"
             + "MIIBVzCBvgIBATAQBgwqhkiG9xIEAYS3CQIFADBVMQswCQYDVQQGEwJHQjEkMCIG\n"
@@ -126,6 +134,9 @@ public class X509CRLTest {
                         fail();
                     } catch (SignatureException expected) {
                     }
+
+                    byte[] expectedTBSCertList = TestUtils.decodeBase64(CRL_TBS_BASE64);
+                    assertArrayEquals(expectedTBSCertList, crl.getTBSCertList());
 
                     assertTrue(crl.isRevoked(revoked));
                     X509CRLEntry entry = crl.getRevokedCertificate(revoked);


### PR DESCRIPTION
Avoids another direct struct access.

Also add a test for OpenSSLX509CRL.getTBSCertList() because we didn't
actually have coverage. (While it is reachable from verify(), it's only
reachable when verifying against a non-OpenSSL key. Which we probably
should also test.)