### PR TITLE
Move most reflective JNI calls to initialization time

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -176,9 +176,11 @@ int throwRuntimeException(JNIEnv* env, const char* msg) {
     return conscrypt::jniutil::throwException(env, "java/lang/RuntimeException", msg);
 }
 
+#ifdef CONSCRYPT_CHECK_ERROR_QUEUE
 int throwAssertionError(JNIEnv* env, const char* msg) {
     return conscrypt::jniutil::throwException(env, "java/lang/AssertionError", msg);
 }
+#endif
 
 int throwNullPointerException(JNIEnv* env, const char* msg) {
     return conscrypt::jniutil::throwException(env, "java/lang/NullPointerException", msg);

--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -38,11 +38,12 @@ jclass inputStreamClass;
 jclass outputStreamClass;
 jclass stringClass;
 jclass byteBufferClass;
-jclass bufferClass;
-jclass fileDescriptorClass;
+static jclass bufferClass;
+static jclass fileDescriptorClass;
+static jclass sslHandshakeCallbacksClass;
 
 jfieldID nativeRef_address;
-jfieldID fileDescriptor_fd;
+static jfieldID fileDescriptor_fd;
 
 jmethodID calendar_setMethod;
 jmethodID inputStream_readMethod;
@@ -55,6 +56,15 @@ jmethodID buffer_limitMethod;
 jmethodID cryptoUpcallsClass_rawSignMethod;
 jmethodID cryptoUpcallsClass_rsaSignMethod;
 jmethodID cryptoUpcallsClass_rsaDecryptMethod;
+jmethodID sslHandshakeCallbacks_verifyCertificateChain;
+jmethodID sslHandshakeCallbacks_onSSLStateChange;
+jmethodID sslHandshakeCallbacks_clientCertificateRequested;
+jmethodID sslHandshakeCallbacks_serverCertificateRequested;
+jmethodID sslHandshakeCallbacks_clientPSKKeyRequested;
+jmethodID sslHandshakeCallbacks_serverPSKKeyRequested;
+jmethodID sslHandshakeCallbacks_onNewSessionEstablished;
+jmethodID sslHandshakeCallbacks_selectApplicationProtocol;
+jmethodID sslHandshakeCallbacks_serverSessionRequested;
 
 void init(JavaVM* vm, JNIEnv* env) {
     gJavaVM = vm;
@@ -77,6 +87,8 @@ void init(JavaVM* vm, JNIEnv* env) {
             env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeRef");
     openSslInputStreamClass = getGlobalRefToClass(
             env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/OpenSSLBIOInputStream");
+    sslHandshakeCallbacksClass = getGlobalRefToClass(
+            env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/NativeCrypto$SSLHandshakeCallbacks");
 
     nativeRef_address = getFieldRef(env, nativeRefClass, "address", "J");
 #if defined(ANDROID) && !defined(CONSCRYPT_OPENJDK)
@@ -95,6 +107,24 @@ void init(JavaVM* vm, JNIEnv* env) {
     outputStream_flushMethod = getMethodRef(env, outputStreamClass, "flush", "()V");
     buffer_positionMethod = getMethodRef(env, bufferClass, "position", "()I");
     buffer_limitMethod = getMethodRef(env, bufferClass, "limit", "()I");
+    sslHandshakeCallbacks_verifyCertificateChain =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "verifyCertificateChain", "([[BLjava/lang/String;)V");
+    sslHandshakeCallbacks_onSSLStateChange =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "onSSLStateChange", "(II)V");
+    sslHandshakeCallbacks_clientCertificateRequested =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "clientCertificateRequested", "([B[I[[B)V");
+    sslHandshakeCallbacks_serverCertificateRequested =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "serverCertificateRequested", "()V");
+    sslHandshakeCallbacks_clientPSKKeyRequested =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "clientPSKKeyRequested", "(Ljava/lang/String;[B[B)I");
+    sslHandshakeCallbacks_serverPSKKeyRequested =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "serverPSKKeyRequested", "(Ljava/lang/String;Ljava/lang/String;[B)I");
+    sslHandshakeCallbacks_onNewSessionEstablished =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "onNewSessionEstablished", "(J)V");
+    sslHandshakeCallbacks_serverSessionRequested =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "serverSessionRequested", "([B)J");
+    sslHandshakeCallbacks_selectApplicationProtocol =
+	    getMethodRef(env, sslHandshakeCallbacksClass, "selectApplicationProtocol", "([B)I");
     cryptoUpcallsClass_rawSignMethod = env->GetStaticMethodID(cryptoUpcallsClass,
                                                      "ecSignDigestWithPrivateKey",
                                                      "(Ljava/security/PrivateKey;[B)[B");

--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -39,8 +39,10 @@ jclass outputStreamClass;
 jclass stringClass;
 jclass byteBufferClass;
 jclass bufferClass;
+jclass fileDescriptorClass;
 
 jfieldID nativeRef_address;
+jfieldID fileDescriptor_fd;
 
 jmethodID calendar_setMethod;
 jmethodID inputStream_readMethod;
@@ -50,6 +52,9 @@ jmethodID outputStream_writeMethod;
 jmethodID outputStream_flushMethod;
 jmethodID buffer_positionMethod;
 jmethodID buffer_limitMethod;
+jmethodID cryptoUpcallsClass_rawSignMethod;
+jmethodID cryptoUpcallsClass_rsaSignMethod;
+jmethodID cryptoUpcallsClass_rsaDecryptMethod;
 
 void init(JavaVM* vm, JNIEnv* env) {
     gJavaVM = vm;
@@ -64,6 +69,7 @@ void init(JavaVM* vm, JNIEnv* env) {
     stringClass = findClass(env, "java/lang/String");
     byteBufferClass = findClass(env, "java/nio/ByteBuffer");
     bufferClass = findClass(env, "java/nio/Buffer");
+    fileDescriptorClass = findClass(env, "java/io/FileDescriptor");
 
     cryptoUpcallsClass = getGlobalRefToClass(
             env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/CryptoUpcalls");
@@ -73,6 +79,11 @@ void init(JavaVM* vm, JNIEnv* env) {
             env, TO_STRING(JNI_JARJAR_PREFIX) "org/conscrypt/OpenSSLBIOInputStream");
 
     nativeRef_address = getFieldRef(env, nativeRefClass, "address", "J");
+#if defined(ANDROID) && !defined(CONSCRYPT_OPENJDK)
+    fileDescriptor_fd = getFieldRef(env, fileDescriptorClass, "descriptor", "I");
+#else /* !ANDROID || CONSCRYPT_OPENJDK */
+    fileDescriptor_fd = getFieldRef(env, fileDescriptorClass, "fd", "I");
+#endif
 
     calendar_setMethod = getMethodRef(env, calendarClass, "set", "(IIIIII)V");
     inputStream_readMethod = getMethodRef(env, inputStreamClass, "read", "([B)I");
@@ -84,6 +95,24 @@ void init(JavaVM* vm, JNIEnv* env) {
     outputStream_flushMethod = getMethodRef(env, outputStreamClass, "flush", "()V");
     buffer_positionMethod = getMethodRef(env, bufferClass, "position", "()I");
     buffer_limitMethod = getMethodRef(env, bufferClass, "limit", "()I");
+    cryptoUpcallsClass_rawSignMethod = env->GetStaticMethodID(cryptoUpcallsClass,
+                                                     "ecSignDigestWithPrivateKey",
+                                                     "(Ljava/security/PrivateKey;[B)[B");
+    if (cryptoUpcallsClass_rawSignMethod == nullptr) {
+        env->FatalError("Could not find ecSignDigestWithPrivateKey");
+    }
+    cryptoUpcallsClass_rsaSignMethod = env->GetStaticMethodID(cryptoUpcallsClass,
+                                                     "rsaSignDigestWithPrivateKey",
+                                                     "(Ljava/security/PrivateKey;I[B)[B");
+    if (cryptoUpcallsClass_rsaSignMethod == nullptr) {
+        env->FatalError("Could not find rsaSignDigestWithPrivateKey");
+    }
+    cryptoUpcallsClass_rsaDecryptMethod = env->GetStaticMethodID(cryptoUpcallsClass,
+						     "rsaDecryptWithPrivateKey",
+						     "(Ljava/security/PrivateKey;I[B)[B");
+    if (cryptoUpcallsClass_rsaDecryptMethod == nullptr) {
+        env->FatalError("Could not find rsaDecryptWithPrivateKey");
+    }
 }
 
 void jniRegisterNativeMethods(JNIEnv* env, const char* className, const JNINativeMethod* gMethods,
@@ -106,14 +135,8 @@ void jniRegisterNativeMethods(JNIEnv* env, const char* className, const JNINativ
 }
 
 int jniGetFDFromFileDescriptor(JNIEnv* env, jobject fileDescriptor) {
-    ScopedLocalRef<jclass> localClass(env, env->FindClass("java/io/FileDescriptor"));
-#if defined(ANDROID) && !defined(CONSCRYPT_OPENJDK)
-    static jfieldID fid = env->GetFieldID(localClass.get(), "descriptor", "I");
-#else /* !ANDROID || CONSCRYPT_OPENJDK */
-    static jfieldID fid = env->GetFieldID(localClass.get(), "fd", "I");
-#endif
     if (fileDescriptor != nullptr) {
-        return env->GetIntField(fileDescriptor, fid);
+        return env->GetIntField(fileDescriptor, fileDescriptor_fd);
     } else {
         return -1;
     }

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -559,16 +559,10 @@ static jbyteArray ecSignDigestWithPrivateKey(JNIEnv* env, jobject privateKey, co
         memcpy(messageBytes.get(), message, message_len);
     }
 
-    jmethodID rawSignMethod = env->GetStaticMethodID(conscrypt::jniutil::cryptoUpcallsClass,
-                                                     "ecSignDigestWithPrivateKey",
-                                                     "(Ljava/security/PrivateKey;[B)[B");
-    if (rawSignMethod == nullptr) {
-        CONSCRYPT_LOG_ERROR("Could not find ecSignDigestWithPrivateKey");
-        return nullptr;
-    }
-
     return reinterpret_cast<jbyteArray>(env->CallStaticObjectMethod(
-            conscrypt::jniutil::cryptoUpcallsClass, rawSignMethod, privateKey, messageArray.get()));
+            conscrypt::jniutil::cryptoUpcallsClass,
+            conscrypt::jniutil::cryptoUpcallsClass_rawSignMethod,
+            privateKey, messageArray.get()));
 }
 
 static jbyteArray rsaSignDigestWithPrivateKey(JNIEnv* env, jobject privateKey, jint padding,
@@ -594,17 +588,11 @@ static jbyteArray rsaSignDigestWithPrivateKey(JNIEnv* env, jobject privateKey, j
         memcpy(messageBytes.get(), message, message_len);
     }
 
-    jmethodID rsaSignMethod = env->GetStaticMethodID(conscrypt::jniutil::cryptoUpcallsClass,
-                                                     "rsaSignDigestWithPrivateKey",
-                                                     "(Ljava/security/PrivateKey;I[B)[B");
-    if (rsaSignMethod == nullptr) {
-        CONSCRYPT_LOG_ERROR("Could not find rsaSignDigestWithPrivateKey");
-        return nullptr;
-    }
-
     return reinterpret_cast<jbyteArray>(
-            env->CallStaticObjectMethod(conscrypt::jniutil::cryptoUpcallsClass, rsaSignMethod,
-                                        privateKey, padding, messageArray.get()));
+            env->CallStaticObjectMethod(
+                conscrypt::jniutil::cryptoUpcallsClass,
+                conscrypt::jniutil::cryptoUpcallsClass_rsaSignMethod,
+                privateKey, padding, messageArray.get()));
 }
 
 // rsaDecryptWithPrivateKey uses privateKey to decrypt |ciphertext_len| bytes
@@ -634,17 +622,11 @@ static jbyteArray rsaDecryptWithPrivateKey(JNIEnv* env, jobject privateKey, jint
         memcpy(ciphertextBytes.get(), ciphertext, ciphertext_len);
     }
 
-    jmethodID rsaDecryptMethod =
-            env->GetStaticMethodID(conscrypt::jniutil::cryptoUpcallsClass,
-                                   "rsaDecryptWithPrivateKey", "(Ljava/security/PrivateKey;I[B)[B");
-    if (rsaDecryptMethod == nullptr) {
-        CONSCRYPT_LOG_ERROR("Could not find rsaDecryptWithPrivateKey");
-        return nullptr;
-    }
-
     return reinterpret_cast<jbyteArray>(
-            env->CallStaticObjectMethod(conscrypt::jniutil::cryptoUpcallsClass, rsaDecryptMethod,
-                                        privateKey, padding, ciphertextArray.get()));
+            env->CallStaticObjectMethod(
+                conscrypt::jniutil::cryptoUpcallsClass,
+                conscrypt::jniutil::cryptoUpcallsClass_rsaDecryptMethod,
+                privateKey, padding, ciphertextArray.get()));
 }
 
 // *********************************************

--- a/common/src/jni/main/include/conscrypt/jniutil.h
+++ b/common/src/jni/main/include/conscrypt/jniutil.h
@@ -44,6 +44,7 @@ extern jclass byteBufferClass;
 extern jclass bufferClass;
 
 extern jfieldID nativeRef_address;
+extern jfieldID fileDescriptor_fd;
 
 extern jmethodID calendar_setMethod;
 extern jmethodID inputStream_readMethod;
@@ -53,6 +54,9 @@ extern jmethodID outputStream_writeMethod;
 extern jmethodID outputStream_flushMethod;
 extern jmethodID buffer_positionMethod;
 extern jmethodID buffer_limitMethod;
+extern jmethodID cryptoUpcallsClass_rawSignMethod;
+extern jmethodID cryptoUpcallsClass_rsaSignMethod;
+extern jmethodID cryptoUpcallsClass_rsaDecryptMethod;
 
 /**
  * Initializes the JNI constants from the environment.

--- a/common/src/jni/main/include/conscrypt/jniutil.h
+++ b/common/src/jni/main/include/conscrypt/jniutil.h
@@ -163,10 +163,12 @@ extern int throwException(JNIEnv* env, const char* className, const char* msg);
  */
 extern int throwRuntimeException(JNIEnv* env, const char* msg);
 
+#ifdef CONSCRYPT_CHECK_ERROR_QUEUE
 /**
  * Throw a java.lang.AssertionError, with an optional message.
  */
 extern int throwAssertionError(JNIEnv* env, const char* msg);
+#endif
 
 /*
  * Throw a java.lang.NullPointerException, with an optional message.

--- a/common/src/jni/main/include/conscrypt/jniutil.h
+++ b/common/src/jni/main/include/conscrypt/jniutil.h
@@ -41,10 +41,8 @@ extern jclass inputStreamClass;
 extern jclass outputStreamClass;
 extern jclass stringClass;
 extern jclass byteBufferClass;
-extern jclass bufferClass;
 
 extern jfieldID nativeRef_address;
-extern jfieldID fileDescriptor_fd;
 
 extern jmethodID calendar_setMethod;
 extern jmethodID inputStream_readMethod;
@@ -57,6 +55,15 @@ extern jmethodID buffer_limitMethod;
 extern jmethodID cryptoUpcallsClass_rawSignMethod;
 extern jmethodID cryptoUpcallsClass_rsaSignMethod;
 extern jmethodID cryptoUpcallsClass_rsaDecryptMethod;
+extern jmethodID sslHandshakeCallbacks_verifyCertificateChain;
+extern jmethodID sslHandshakeCallbacks_onSSLStateChange;
+extern jmethodID sslHandshakeCallbacks_clientCertificateRequested;
+extern jmethodID sslHandshakeCallbacks_serverCertificateRequested;
+extern jmethodID sslHandshakeCallbacks_clientPSKKeyRequested;
+extern jmethodID sslHandshakeCallbacks_serverPSKKeyRequested;
+extern jmethodID sslHandshakeCallbacks_onNewSessionEstablished;
+extern jmethodID sslHandshakeCallbacks_selectApplicationProtocol;
+extern jmethodID sslHandshakeCallbacks_serverSessionRequested;
 
 /**
  * Initializes the JNI constants from the environment.


### PR DESCRIPTION
Certain JNI calls rely on reflection internally, which makes them very slow.  Fortunately, these calls are (in the case of Conscrypt) pure functions, so we can perform them during initialization and cache the results afterwards.  This also reduces the likelihood of unrecoverable failures under low memory conditions.