### PR TITLE
Bump Java language level to 1.8.

### DIFF
--- a/android-stub/build.gradle
+++ b/android-stub/build.gradle
@@ -1,9 +1,5 @@
 description = 'Conscrypt: Android-Stub'
 
-// Needs to be binary-compatible with Android minSdkVersion.
-sourceCompatibility = androidMinJavaVersion
-targetCompatibility = androidMinJavaVersion
-
 dependencies {
     compileOnly project(':conscrypt-libcore-stub')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -165,8 +165,8 @@ subprojects {
     }
 
     if (!androidProject) {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
 
         [tasks.named("compileJava"), tasks.named("compileTestJava")].forEach { t ->
             t.configure {


### PR DESCRIPTION
Only affects non-Android builds.  Android builds are still desugared
to be compatible with 1.7 by the SDK in order to run on older desserts.

We announced in the last release that we would be dropping support for 1.7.

Note that the Android-Stub build config previously had a comment that
it needed to be binary compatible with Android minSdkVersion. That
was erroneous, it's used for non-Android builds and so should shouldn't
redefine the source or target language level.

Tested:
./gradlew check
./gradlew conscrypt-android:check