### PR TITLE
Revise GENERAL_NAME_to_jobject.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4167,17 +4167,24 @@ static jobject GENERAL_NAME_to_jobject(JNIEnv* env, GENERAL_NAME* gen) {
         case GEN_EMAIL:
         case GEN_DNS:
         case GEN_URI: {
-            // This must not be a T61String and must not contain NULs.
-            const char* data = reinterpret_cast<const char*>(ASN1_STRING_data(gen->d.ia5));
+            // This must be a valid IA5String and must not contain NULs.
+            // BoringSSL does not currently enforce the former (see
+            // https://crbug.com/boringssl/427). The latter was historically an
+            // issue for parsers that truncate at NUL.
+            const uint8_t* data = ASN1_STRING_get0_data(gen->d.ia5);
             ssize_t len = ASN1_STRING_length(gen->d.ia5);
-            if ((len == static_cast<ssize_t>(strlen(data))) &&
-                (ASN1_PRINTABLE_type(ASN1_STRING_data(gen->d.ia5), len) != V_ASN1_T61STRING)) {
-                JNI_TRACE("GENERAL_NAME_to_jobject(%p) => Email/DNS/URI \"%s\"", gen, data);
-                return env->NewStringUTF(data);
-            } else {
-                JNI_TRACE("GENERAL_NAME_to_jobject(%p) => Email/DNS/URI invalid", gen);
-                return nullptr;
+            std::vector<jchar> jchars;
+            jchars.reserve(len);
+            for (ssize_t i = 0; i < len; i++) {
+                if (data[i] == 0 || data[i] > 127) {
+                    JNI_TRACE("GENERAL_NAME_to_jobject(%p) => Email/DNS/URI invalid", gen);
+                    return nullptr;
+                }
+                // Converting ASCII to UTF-16 is the identity function.
+                jchars.push_back(data[i]);
             }
+            JNI_TRACE("GENERAL_NAME_to_jobject(%p) => Email/DNS/URI \"%.*s\"", gen, len, data);
+            return env->NewString(jchars.data(), jchars.size());
         }
         case GEN_DIRNAME:
             /* Write in RFC 2253 format */


### PR DESCRIPTION
This fixes a few issues. First, the comment is a little confusing. The
value is an IA5String. The issue isn't whether it might accidentally be
a T61String, but that its contents may be invalid for an IA5String.

Next, I've replaced ASN1_PRINTABLE_type with a loop. ASN1_PRINTABLE_type
does actually work, but it's normally used in OpenSSL to auto-detect a
string type for a Latin-1 string, which is a little confusing.

Finally, I've tweaked this so it does not rely on the ASN1_STRING being
NUL-terminated. The ASN1_STRING is almost always NUL-terminated, but
best not to rely on this. (See CVE-2021-3712.)