### PR TITLE
Avoid longs when specifying precision in a sprintf argument.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4193,7 +4193,7 @@ static jobject GENERAL_NAME_to_jobject(JNIEnv* env, GENERAL_NAME* gen) {
                 // Converting ASCII to UTF-16 is the identity function.
                 jchars.push_back(data[i]);
             }
-            JNI_TRACE("GENERAL_NAME_to_jobject(%p) => Email/DNS/URI \"%.*s\"", gen, len, data);
+            JNI_TRACE("GENERAL_NAME_to_jobject(%p)=> Email/DNS/URI \"%.*s\"", gen, (int) len, data);
             return env->NewString(jchars.data(), jchars.size());
         }
         case GEN_DIRNAME:


### PR DESCRIPTION
Causes a compiler warning which is treated as error when building
for the Android platform.

Note 1: Simply casting to an int here as no real harm can befall
us if it wraps or gets treated as negative.

Note 2: Given that JNI tracing is a compile time option (there's
a constant in trace.cc) we should probably re-write the JNI_TRACE
macro to expand to nothing unless it is enabled, as currently we
are wasting several k on format strings that will never be used.
This would also improve our coverage metrics for trace messages
that are never reached by tests too ;) I shall do that as a
follow-up