### PR TITLE
Fix R8 compiler warnings

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -24,4 +24,6 @@
 -dontwarn com.android.org.conscrypt.AbstractConscryptSocket
 -dontwarn com.android.org.conscrypt.ConscryptFileDescriptorSocket
 -dontwarn com.android.org.conscrypt.OpenSSLSocketImpl
+-dontwarn com.android.org.conscrypt.SSLParametersImpl
 -dontwarn org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl
+-dontwarn org.apache.harmony.xnet.provider.jsse.SSLParametersImpl


### PR DESCRIPTION
The classes referenced are only present at runtime on Android.

Closes #1045