### PR TITLE
Minor Scrypt tidy-ups.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -10293,7 +10293,7 @@ static jboolean NativeCrypto_usesBoringSsl_FIPS_mode() {
  */
 
 static jbyteArray NativeCrypto_Scrypt_generate_key(JNIEnv* env, jclass, jbyteArray password, jbyteArray salt,
-                                                   jlong n, jlong r, jlong p, jint key_len) {
+                                                   jint n, jint r, jint p, jint key_len) {
     CHECK_ERROR_QUEUE_ON_RETURN;
     JNI_TRACE("Scrypt_generate_key(%p, %p, %ld, %ld, %ld, %d)", password, salt, n, r, p, key_len);
 
@@ -10793,7 +10793,7 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_force_read, "(J" REF_SSL SSL_CALLBACKS ")V"),
         CONSCRYPT_NATIVE_METHOD(ENGINE_SSL_shutdown, "(J" REF_SSL SSL_CALLBACKS ")V"),
         CONSCRYPT_NATIVE_METHOD(usesBoringSsl_FIPS_mode, "()Z"),
-        CONSCRYPT_NATIVE_METHOD(Scrypt_generate_key, "([B[BJJJI)[B"),
+        CONSCRYPT_NATIVE_METHOD(Scrypt_generate_key, "([B[BIIII)[B"),
 
         // Used for testing only.
         CONSCRYPT_NATIVE_METHOD(BIO_read, "(J[B)I"),

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -10295,7 +10295,7 @@ static jboolean NativeCrypto_usesBoringSsl_FIPS_mode() {
 static jbyteArray NativeCrypto_Scrypt_generate_key(JNIEnv* env, jclass, jbyteArray password, jbyteArray salt,
                                                    jint n, jint r, jint p, jint key_len) {
     CHECK_ERROR_QUEUE_ON_RETURN;
-    JNI_TRACE("Scrypt_generate_key(%p, %p, %ld, %ld, %ld, %d)", password, salt, n, r, p, key_len);
+    JNI_TRACE("Scrypt_generate_key(%p, %p, %d, %d, %d, %d)", password, salt, n, r, p, key_len);
 
     if (password == nullptr) {
         conscrypt::jniutil::throwNullPointerException(env, "password == null");

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1446,7 +1446,7 @@ public final class NativeCrypto {
     /**
      * Generates a key from a password and salt using Scrypt.
      */
-    static native byte[] Scrypt_generate_key(byte[] password, byte[] salt, long n, long r, long p, int key_len);
+    static native byte[] Scrypt_generate_key(byte[] password, byte[] salt, int n, int r, int p, int key_len);
 
     /**
      * Return {@code true} if BoringSSL has been built in FIPS mode.

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -211,9 +211,9 @@ public final class OpenSSLProvider extends Provider {
         /* == SecretKeyFactory == */
         put("SecretKeyFactory.DESEDE", PREFIX + "DESEDESecretKeyFactory");
         put("Alg.Alias.SecretKeyFactory.TDEA", "DESEDE");
-        put("SecretKeyFactory.Scrypt", PREFIX + "ScryptSecretKeyFactory");
-        put("SecretKeyFactory.1.3.6.1.4.1.11591.4.11", PREFIX + "ScryptSecretKeyFactory");
-        put("SecretKeyFactory.OID.1.3.6.1.4.1.11591.4.11", PREFIX + "ScryptSecretKeyFactory");
+        put("SecretKeyFactory.SCRYPT", PREFIX + "ScryptSecretKeyFactory");
+        put("Alg.Alias.SecretKeyFactory.1.3.6.1.4.1.11591.4.11", "SCRYPT");
+        put("Alg.Alias.SecretKeyFactory.OID.1.3.6.1.4.1.11591.4.11", "SCRYPT");
 
         /* == KeyAgreement == */
         putECDHKeyAgreementImplClass("OpenSSLECDHKeyAgreement");

--- a/common/src/main/java/org/conscrypt/ScryptSecretKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/ScryptSecretKeyFactory.java
@@ -44,8 +44,8 @@ public class ScryptSecretKeyFactory extends SecretKeyFactorySpi {
             p = spec.getParallelizationParameter();
             keyOutputBits = spec.getKeyLength();
         } else {
-            // Extract parameters from any `KeySpec` that has getters with the correct name. This allows,
-            // for example, code to use BouncyCastle's KeySpec with the conscrypt provider.
+            // Extract parameters from any `KeySpec` that has getters with the correct name. This
+            // allows, for example, code to use BouncyCastle's KeySpec with the Conscrypt provider.
             try {
                 password = (char[]) getValue(inKeySpec, "getPassword");
                 salt = (byte[]) getValue(inKeySpec, "getSalt");
@@ -65,10 +65,11 @@ public class ScryptSecretKeyFactory extends SecretKeyFactorySpi {
         try {
         return new ScryptKey(
                 NativeCrypto.Scrypt_generate_key(
-                        new String(password).getBytes("UTF-8"), salt, n, r, p, keyOutputBits / 8));
+                        new String(password).getBytes("UTF-8"),
+                        salt, n, r, p, keyOutputBits / 8));
         } catch (UnsupportedEncodingException e) {
                 // Impossible according to the Java docs: UTF-8 is always supported.
-                throw new RuntimeException(e);
+                throw new IllegalStateException(e);
         }
     }
 
@@ -106,7 +107,7 @@ public class ScryptSecretKeyFactory extends SecretKeyFactorySpi {
 
         @Override
         public String getAlgorithm() {
-            // capitalised because BouncyCastle does it.
+            // Capitalised because BouncyCastle does it.
             return "SCRYPT";
         }
 


### PR DESCRIPTION
Update native method signatures to match ScryptKeySpec types, factor constants out of tests and test all aliases at least once.

No functional change in this CL over @agl 's one.

More tests and implementation to come in a future CL.