### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,6 @@ jobs:
       - name: Setup macOS environment
         if: runner.os == 'macOS'
         run: |
-          # Workaround for https://github.com/actions/virtual-environments/issues/1811
-          # Remove broken openssl and python packages, not used by Conscrypt builds
-          # TODO(prb): remove when no longer required.
-          brew uninstall --ignore-dependencies openssl
-          brew uninstall --ignore-dependencies python
           brew update || echo update failed
           brew install ninja || echo update failed
 


### PR DESCRIPTION
I was able to fix the macOS CI by removing a workaround that was needed in the past to get hombrew to work properly. I checked and saw that github had already fixed this, and that still using the workaround causes the builds to fail.
I believe according the comments this was supposed to be removed anyway once github patched it on their end.

I tested it and the mac os build seems to have succeeded (See https://github.com/unlucku/conscrypt/actions/runs/1990892406) without any new issues.