### PR TITLE
Support building Conscrypt against musl.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -7058,7 +7058,8 @@ static void debug_print_packet_data(const SSL* ssl, char direction, const char* 
 
     // Packet preamble for text2pcap
     CONSCRYPT_LOG(LOG_INFO, LOG_TAG "-jni", "ssl=%p SSL_DATA: %c %ld.%06ld", ssl, direction,
-                  tv.tv_sec, static_cast<long>(tv.tv_usec));  // NOLINT(runtime/int)
+                  static_cast<long>(tv.tv_sec),
+                  static_cast<long>(tv.tv_usec));  // NOLINT(runtime/int)
 
     char out[kDataWidth * 3 + 1];
     for (size_t i = 0; i < len; i += kDataWidth) {


### PR DESCRIPTION
Support building conscrypt against musl by casting the time_t fields
that have different types between musl and glibc.

This PR upstreams https://r.android.com/1927625