### PR TITLE
Inline ErrnoException.rethrowAsSocketException().

### DIFF
--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -130,7 +130,9 @@ final class Platform {
         try {
             Os.setsockoptTimeval(s.getFileDescriptor$(), SOL_SOCKET, SO_SNDTIMEO, tv);
         } catch (ErrnoException errnoException) {
-            throw errnoException.rethrowAsSocketException();
+            // Equivalent to errnoException.rethrowAsSocketException() but that causes
+            // lint issues on AOSP.
+            throw new SocketException(errnoException.getMessage(), errnoException);
         }
     }
 


### PR DESCRIPTION
This used to be a platform API on Android but was made
public in Android R, however we have straightforward way of
explaining that to the NewApi linter so simpler to just avoid
it, especially as the method calling it will be removed in
the future.