### PR TITLE
Don't allow revocation check fallback from stapled OCSP to CRL download.

### DIFF
--- a/common/src/main/java/org/conscrypt/TrustManagerImpl.java
+++ b/common/src/main/java/org/conscrypt/TrustManagerImpl.java
@@ -93,6 +93,9 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
     private static final TrustAnchorComparator TRUST_ANCHOR_COMPARATOR =
             new TrustAnchorComparator();
 
+    private static final Set<Option> REVOCATION_CHECK_OPTIONS =
+            revocationOptions();
+
     private static ConscryptHostnameVerifier defaultHostnameVerifier;
 
     /**
@@ -767,9 +770,10 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
             /*
              * If we add a new revocation checker, we should set the option for
              * end-entity verification only. Otherwise the CertPathValidator will
-             * throw an exception when it can't verify the entire chain.
+             * throw an exception when it can't verify the entire chain. We
+             * also set the option to prevent falling back from OCSP to CRL download.
              */
-            revChecker.setOptions(Collections.singleton(Option.ONLY_END_ENTITY));
+            revChecker.setOptions(REVOCATION_CHECK_OPTIONS);
         }
 
         revChecker.setOcspResponses(Collections.singletonMap(cert, ocspData));
@@ -803,6 +807,13 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
             X509Certificate rhsCert = rhs.getTrustedCert();
             return CERT_COMPARATOR.compare(lhsCert, rhsCert);
         }
+    }
+
+    private static Set<Option> revocationOptions() {
+        Set<Option> options = new HashSet<>();
+        options.add(Option.ONLY_END_ENTITY); // Only check end entity
+        options.add(Option.NO_FALLBACK);     // Don't fall back from OCSP to CRL download
+        return Collections.unmodifiableSet(options);
     }
 
     /**


### PR DESCRIPTION
Fixes #520.

If stapled OCSP is present, TrustmanagerImpl.setOcspResponses()
adds a PKIXRevocationChecker to the list in the current
PKIXParameters to check it, with option END_ENTITY_ONLY set to
ensure only the end entity certificate is checked.

However unless the NO_FALLBACK option is also set then if the
OCSP check fails (e.g. because the date on the device is wrong)
then the Sun PKIXRevocationChecker will fall back to downloading
a CRL and checking that.  On Android 8.0/8.1 this causes large
latency and possible OOM.  On later Androids, the CRL download
fails if the CRL distribution URL is plain HTTP, avoiding the
issue but potentially causing confusing errors.

I don't *yet* have a regression test for this as it turns
out we don't have _any_ tests for the OCSP path, but confirmed
by single stepping that adding NO_FALLBACK prevents CRL download
when the OCSP data is rejected.