### PR TITLE
Make OptionalMethod return null if invoked on a null receiver.

### DIFF
--- a/common/src/main/java/org/conscrypt/metrics/OptionalMethod.java
+++ b/common/src/main/java/org/conscrypt/metrics/OptionalMethod.java
@@ -61,9 +61,24 @@ public final class OptionalMethod {
         return null;
     }
 
-    public Object invoke(Object target, Object... args) {
+    public Object invokeStatic(Object... args) {
         // no-op if failed to load method in constructor
         if (cachedMethod == null) {
+            return null;
+        }
+        try {
+            return cachedMethod.invoke(null, args);
+        } catch (IllegalAccessException ignored) {
+            // Ignored
+        } catch (InvocationTargetException ignored) {
+            // Ignored
+        }
+        return null;
+    }
+
+    public Object invoke(Object target, Object... args) {
+        // no-op if failed to load method in constructor or target is null
+        if (cachedMethod == null || target == null) {
             return null;
         }
         try {

--- a/common/src/main/java/org/conscrypt/metrics/ReflexiveStatsEvent.java
+++ b/common/src/main/java/org/conscrypt/metrics/ReflexiveStatsEvent.java
@@ -92,7 +92,7 @@ public class ReflexiveStatsEvent {
         private Object builder;
 
         private Builder() {
-            this.builder = newBuilder.invoke(null);
+            this.builder = newBuilder.invokeStatic();
         }
 
         public Builder setAtomId(final int atomId) {

--- a/common/src/main/java/org/conscrypt/metrics/ReflexiveStatsEvent.java
+++ b/common/src/main/java/org/conscrypt/metrics/ReflexiveStatsEvent.java
@@ -38,7 +38,7 @@ public class ReflexiveStatsEvent {
         }
     }
 
-    private Object statsEvent;
+    private final Object statsEvent;
 
     private ReflexiveStatsEvent(Object statsEvent) {
         this.statsEvent = statsEvent;
@@ -89,7 +89,7 @@ public class ReflexiveStatsEvent {
             }
         }
 
-        private Object builder;
+        private final Object builder;
 
         private Builder() {
             this.builder = newBuilder.invokeStatic();

--- a/common/src/main/java/org/conscrypt/metrics/ReflexiveStatsLog.java
+++ b/common/src/main/java/org/conscrypt/metrics/ReflexiveStatsLog.java
@@ -51,6 +51,9 @@ public class ReflexiveStatsLog {
     private ReflexiveStatsLog() {}
 
     public static void write(ReflexiveStatsEvent event) {
-        write.invoke(null, event.getStatsEvent());
+        Object statsEvent = event.getStatsEvent();
+        if (statsEvent != null) {
+            write.invokeStatic(statsEvent);
+        }
     }
 }

--- a/common/src/test/java/org/conscrypt/metrics/OptionalMethodTest.java
+++ b/common/src/test/java/org/conscrypt/metrics/OptionalMethodTest.java
@@ -62,4 +62,13 @@ public class OptionalMethodTest {
 
         assertNull(subwrong.invoke("input", 2, 5));
     }
+
+    @Test
+    public void nullReceiver() {
+        OptionalMethod substring =
+            new OptionalMethod(String.class, "substring", int.class, int.class);
+        assertNotNull(substring);
+
+        assertEquals(null, substring.invoke(null, 2, 5));
+    }
 }


### PR DESCRIPTION
Possibly suboptimal but follows the `OptionalMethod` ethos of failing silently rather than throwing.
