### PR TITLE
Make SSLServerSessionCache public.

### DIFF
--- a/common/src/main/java/org/conscrypt/SSLClientSessionCache.java
+++ b/common/src/main/java/org/conscrypt/SSLClientSessionCache.java
@@ -29,7 +29,6 @@ import javax.net.ssl.SSLSession;
  * session data is dependent upon the caller's implementation and is opaque to
  * the {@code SSLClientSessionCache} implementation.
  */
-@Internal
 public interface SSLClientSessionCache {
     /**
      * Gets data from a pre-existing session for a given server host and port.

--- a/common/src/main/java/org/conscrypt/SSLServerSessionCache.java
+++ b/common/src/main/java/org/conscrypt/SSLServerSessionCache.java
@@ -30,7 +30,7 @@ import javax.net.ssl.SSLSession;
  * session data is dependent upon the caller's implementation and is opaque to
  * the {@code SSLServerSessionCache} implementation.
  */
-interface SSLServerSessionCache {
+public interface SSLServerSessionCache {
     /**
      * Gets the session data for given session ID.
      *


### PR DESCRIPTION
Otherwise it cannot be used by non-Conscrypt code calling setServerSessionCache().

Similarly SSLClientSessionCache should not be annotated with @Internal

Inspired by #1050 which didn't get merged due to CLA issues.