### PR TITLE
OpenSSLX509CertificateFactory - don't throw on empty inputs.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CertificateFactory.java
@@ -164,8 +164,9 @@ public class OpenSSLX509CertificateFactory extends CertificateFactorySpi {
 
                 final int len = pbis.read(buffer);
                 if (len < 0) {
-                    /* No need to reset here. The stream was empty or EOF. */
-                    throw new ParsingException("inStream is empty");
+                    // No need to reset here. The stream was empty or EOF so we return an empty
+                    // list, making it mutable for consistency with the other code paths.
+                    return new ArrayList<>();
                 }
                 pbis.unread(buffer, 0, len);
 


### PR DESCRIPTION
For consistency with RI and the documented contract, an empty input should generate an empty list of certificates.

This bug was masked until #1069 landed and wasn't noticed at the time because it seems we have no unit tests for this and have been relying on the ones in AOSP.