### PR TITLE
Throw correct exception on CMAC key size errors.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLMac.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLMac.java
@@ -80,7 +80,11 @@ public abstract class OpenSSLMac extends MacSpi {
             throw new InvalidKeyException("key cannot be encoded");
         }
 
-        resetContext();
+        try {
+            resetContext();
+        } catch (RuntimeException e) {
+            throw new InvalidKeyException("invalid key", e);
+        }
     }
 
     @Override

--- a/common/src/test/java/org/conscrypt/MacTest.java
+++ b/common/src/test/java/org/conscrypt/MacTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -31,6 +32,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.spec.AlgorithmParameterSpec;
 import java.util.HashSet;
@@ -164,7 +166,7 @@ public class MacTest {
     }
 
     @Test
-    public void invalidKeyThrows() {
+    public void invalidKeyTypeThrows() {
         newMacServiceTester()
             // BC actually accepts RSA public keys for these algorithms for some reason.
             .skipCombination("BC", "PBEWITHHMACSHA")
@@ -185,6 +187,16 @@ public class MacTest {
                     }
                 }
             });
+    }
+
+    @Test
+    public void invalidCmacKeySizeThrows() throws Exception {
+        // TODO(prb): extend to other Macs, deal with inconsistencies between providers.
+        Mac mac = Mac.getInstance("AESCMAC", conscryptProvider);
+        byte[] keyBytes = new byte[1];
+        SecretKeySpec key = new SecretKeySpec(keyBytes, "RawBytes");
+
+        assertThrows(InvalidKeyException.class, () -> mac.init(key));
     }
 
     @Test


### PR DESCRIPTION
Previously, any unchecked exception thrown by the JNI code during init would escape from Mac.init() rather than throwing the documented checked exception.