### PR TITLE
Update Go version to 1.19.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.2'
+          go-version: '1.19.3'
 
       - name: Setup Windows environment
         if: runner.os == 'Windows'


### PR DESCRIPTION
Needed for BoringSSL tests.