### PR TITLE
Bump minSdkVersion to 19 for Android build.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ ext {
     androidSdkInstalled = file("$androidHome").exists()
     androidVersionCode = 1
     androidVersionName = "$version"
-    androidMinSdkVersion = 9
+    androidMinSdkVersion = 19
     androidTargetSdkVersion = 26
     androidNdkVersion = "21.3.6528147"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ subprojects {
         }
         jdkIncludeDir = normalizePath("$jdkHome/include")
         // Needs to be binary compatible with androidMinSdkVersion
-        androidMinJavaVersion = JavaVersion.VERSION_1_7
+        androidMinJavaVersion = JavaVersion.VERSION_1_8
 
         build32Bit = file("$boringssl32BuildDir").exists()
         build64Bit = file("$boringssl64BuildDir").exists()


### PR DESCRIPTION
API 19 is Android 4 / KitKat and is also the minimum API level supported by Play Services.

According to apilevels.com, 99.3% of devices are
on API 21 or later, so this change should exclude
very few devices.