### PR TITLE
Add stats values for failed handshakes.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -312,10 +312,10 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl implements SSLParametersIm
 
                 case STATE_CLOSED:
                     if (handshakeStartedMillis > 0) {
-                        // Handshake must have failed.
+                        // Handshake was in progress and so must have failed.
                         Platform.countTlsHandshake(false,
-                            engine.getSession().getProtocol(),
-                            engine.getSession().getCipherSuite(),
+                            "TLS_PROTO_FAILED",
+                            "TLS_CIPHER_FAILED",
                             Platform.getMillisSinceBoot() - handshakeStartedMillis);
                         handshakeStartedMillis = 0;
                     }

--- a/common/src/main/java/org/conscrypt/metrics/CipherSuite.java
+++ b/common/src/main/java/org/conscrypt/metrics/CipherSuite.java
@@ -59,6 +59,8 @@ public enum CipherSuite {
     TLS_AES_128_GCM_SHA256(0x1301),
     TLS_AES_256_GCM_SHA384(0x1302),
     TLS_CHACHA20_POLY1305_SHA256(0x1303),
+
+    TLS_CIPHER_FAILED(0xFFFF),
     ;
 
     final short id;
@@ -68,6 +70,10 @@ public enum CipherSuite {
     }
 
     public static CipherSuite forName(String name) {
+        if ("SSL_RSA_WITH_3DES_EDE_CBC_SHA".equals(name)) {
+            // JCA StandardNames shenanigans.
+            return TLS_RSA_WITH_3DES_EDE_CBC_SHA;
+        }
         try {
             return CipherSuite.valueOf(name);
         } catch (IllegalArgumentException e) {

--- a/common/src/main/java/org/conscrypt/metrics/Protocol.java
+++ b/common/src/main/java/org/conscrypt/metrics/Protocol.java
@@ -30,6 +30,7 @@ public enum Protocol {
     TLSv1_1(3),
     TLSv1_2(4),
     TLSv1_3(5),
+    TLS_PROTO_FAILED(0xFFFF),
     ;
 
     final byte id;
@@ -50,6 +51,8 @@ public enum Protocol {
                 return TLSv1_2;
             case "TLSv1.3":
                 return TLSv1_3;
+            case "TLS_PROTO_FAILED":
+                return TLS_PROTO_FAILED;
             default:
                 return UNKNOWN_PROTO;
         }

--- a/common/src/test/java/org/conscrypt/metrics/ProtocolTest.java
+++ b/common/src/test/java/org/conscrypt/metrics/ProtocolTest.java
@@ -11,6 +11,9 @@ public class ProtocolTest {
     @Test
     public void consistency() {
         for (Protocol protocol : Protocol.values()) {
+            if (protocol == Protocol.TLS_PROTO_FAILED) {
+                continue;
+            }
             String name = protocol.name().replace('_', '.');
             assertSame(protocol, Protocol.forName(name));
         }


### PR DESCRIPTION
Also handles translating ciphersuite names starting with the old JSSE standard of SSL_ to TLS_  which is used everywhere else.  The last remaining such ciphersuite in Conscrypt is SSL_RSA_WITH_3DES_EDE_CBC_SHA so just test for it directly.