### PR TITLE
Reduce exposure to the deprecated for-removal javax.security.cert APIs

### DIFF
--- a/common/src/main/java/org/conscrypt/ActiveSession.java
+++ b/common/src/main/java/org/conscrypt/ActiveSession.java
@@ -41,8 +41,6 @@ final class ActiveSession implements ConscryptSession {
     private String peerHost;
     private int peerPort = -1;
     private long lastAccessedTime = 0;
-    @SuppressWarnings("deprecation")
-    private volatile javax.security.cert.X509Certificate[] peerCertificateChain;
     private X509Certificate[] localCertificates;
     private X509Certificate[] peerCertificates;
     private byte[] peerCertificateOcspData;
@@ -191,36 +189,6 @@ final class ActiveSession implements ConscryptSession {
             }
         }
         return localCertificates == null ? null : localCertificates.clone();
-    }
-
-    /**
-     * Returns the certificate(s) of the peer in this SSL session
-     * used in the handshaking phase of the connection.
-     * Please notice hat this method is superseded by
-     * <code>getPeerCertificates()</code>.
-     * @return an array of X509 certificates (the peer's one first and then
-     *         eventually that of the certification authority) or null if no
-     *         certificate were used during the SSL connection.
-     * @throws SSLPeerUnverifiedException if either a non-X.509 certificate
-     *         was used (i.e. Kerberos certificates) or the peer could not
-     *         be verified.
-     */
-    @Override
-    @SuppressWarnings("deprecation") // Public API
-    public javax.security.cert.X509Certificate[] getPeerCertificateChain()
-            throws SSLPeerUnverifiedException {
-        if (!Platform.isJavaxCertificateSupported()) {
-            throw new UnsupportedOperationException("Use getPeerCertificates() instead");
-        }
-
-        checkPeerCertificatesPresent();
-        // TODO(nathanmittler): Should we clone?
-        javax.security.cert.X509Certificate[] result = peerCertificateChain;
-        if (result == null) {
-            // single-check idiom
-            peerCertificateChain = result = SSLUtils.toCertificateChain(peerCertificates);
-        }
-        return result;
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/ConscryptSession.java
+++ b/common/src/main/java/org/conscrypt/ConscryptSession.java
@@ -53,5 +53,14 @@ interface ConscryptSession extends SSLSession {
   @Override
   X509Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException;
 
+  @Override
+  @SuppressWarnings("deprecation")
+  default javax.security.cert.X509Certificate[] getPeerCertificateChain()
+          throws SSLPeerUnverifiedException {
+    throw new UnsupportedOperationException(
+            "This method is deprecated and marked for removal. Use the " +
+                    "getPeerCertificates() method instead.");
+  }
+
   String getApplicationProtocol();
 }

--- a/common/src/main/java/org/conscrypt/ExternalSession.java
+++ b/common/src/main/java/org/conscrypt/ExternalSession.java
@@ -111,12 +111,6 @@ final class ExternalSession implements ConscryptSession {
   }
 
   @Override
-  @SuppressWarnings("deprecation") // Public API
-  public javax.security.cert.X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
-    return provider.provideSession().getPeerCertificateChain();
-  }
-
-  @Override
   public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
     return provider.provideSession().getPeerPrincipal();
   }

--- a/common/src/main/java/org/conscrypt/Java7ExtendedSSLSession.java
+++ b/common/src/main/java/org/conscrypt/Java7ExtendedSSLSession.java
@@ -133,12 +133,6 @@ class Java7ExtendedSSLSession extends ExtendedSSLSession implements ConscryptSes
     }
 
     @Override
-    @SuppressWarnings("deprecation") // Public API
-    public final javax.security.cert.X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
-        return delegate.getPeerCertificateChain();
-    }
-
-    @Override
     public final Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
         return delegate.getPeerPrincipal();
     }

--- a/common/src/main/java/org/conscrypt/SSLNullSession.java
+++ b/common/src/main/java/org/conscrypt/SSLNullSession.java
@@ -116,13 +116,6 @@ final class SSLNullSession implements ConscryptSession, Cloneable {
     }
 
     @Override
-    @SuppressWarnings("deprecation") // Public API
-    public javax.security.cert.X509Certificate[] getPeerCertificateChain()
-            throws SSLPeerUnverifiedException {
-        throw new SSLPeerUnverifiedException("No peer certificate");
-    }
-
-    @Override
     public X509Certificate[] getPeerCertificates() throws SSLPeerUnverifiedException {
         throw new SSLPeerUnverifiedException("No peer certificate");
     }

--- a/common/src/main/java/org/conscrypt/SSLUtils.java
+++ b/common/src/main/java/org/conscrypt/SSLUtils.java
@@ -314,28 +314,6 @@ final class SSLUtils {
     }
 
     /**
-     * Converts the peer certificates into a cert chain.
-     */
-    @SuppressWarnings("deprecation") // Used in public Conscrypt APIs
-    static javax.security.cert.X509Certificate[] toCertificateChain(X509Certificate[] certificates)
-            throws SSLPeerUnverifiedException {
-        try {
-            javax.security.cert.X509Certificate[] chain =
-                    new javax.security.cert.X509Certificate[certificates.length];
-
-            for (int i = 0; i < certificates.length; i++) {
-                byte[] encoded = certificates[i].getEncoded();
-                chain[i] = javax.security.cert.X509Certificate.getInstance(encoded);
-            }
-            return chain;
-        } catch (CertificateEncodingException | javax.security.cert.CertificateException e) {
-            SSLPeerUnverifiedException exception = new SSLPeerUnverifiedException(e.getMessage());
-            exception.initCause(e);
-            throw exception;
-        }
-    }
-
-    /**
      * Calculates the minimum bytes required in the encrypted output buffer for the given number of
      * plaintext source bytes.
      */

--- a/common/src/main/java/org/conscrypt/SessionSnapshot.java
+++ b/common/src/main/java/org/conscrypt/SessionSnapshot.java
@@ -141,17 +141,6 @@ final class SessionSnapshot implements ConscryptSession {
     }
 
     @Override
-    @SuppressWarnings("deprecation") // Public API
-    public javax.security.cert.X509Certificate[] getPeerCertificateChain()
-        throws SSLPeerUnverifiedException {
-        if (!Platform.isJavaxCertificateSupported()) {
-            throw new UnsupportedOperationException("Use getPeerCertificates() instead");
-        }
-
-        throw new SSLPeerUnverifiedException("No peer certificates");
-    }
-
-    @Override
     public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {
         throw new SSLPeerUnverifiedException("No peer certificates");
     }

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSessionTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSessionTest.java
@@ -191,34 +191,6 @@ public class SSLSessionTest {
     }
 
     @Test
-    public void test_SSLSession_getPeerCertificateChain() throws Exception {
-        TestSSLSessions s = TestSSLSessions.create();
-        try {
-            s.invalid.getPeerCertificateChain();
-            fail();
-        } catch (SSLPeerUnverifiedException expected) {
-            // Ignored.
-        } catch (UnsupportedOperationException e) {
-            if (!StandardNames.IS_15_OR_UP) {
-                fail("Should only throw UnsupportedOperationException on OpenJDK 15 or up");
-            }
-        }
-        assertNotNull(s.client.getPeerCertificates());
-        TestKeyStore.assertChainLength(s.client.getPeerCertificates());
-        try {
-            assertNull(s.server.getPeerCertificateChain());
-            fail();
-        } catch (SSLPeerUnverifiedException expected) {
-            // Ignored.
-        } catch (UnsupportedOperationException e) {
-            if (!StandardNames.IS_15_OR_UP) {
-                fail("Should only throw UnsupportedOperationException on OpenJDK 15 or up");
-            }
-        }
-        s.close();
-    }
-
-    @Test
     public void test_SSLSession_getPeerCertificates() throws Exception {
         TestSSLSessions s = TestSSLSessions.create();
         try {

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketVersionCompatibilityTest.java
@@ -371,8 +371,6 @@ public class SSLSocketVersionCompatibilityTest {
                     String cipherSuite = event.getCipherSuite();
                     Certificate[] localCertificates = event.getLocalCertificates();
                     Certificate[] peerCertificates = event.getPeerCertificates();
-                    javax.security.cert.X509Certificate[] peerCertificateChain =
-                        event.getPeerCertificateChain();
                     Principal peerPrincipal = event.getPeerPrincipal();
                     Principal localPrincipal = event.getLocalPrincipal();
                     socket = event.getSocket();
@@ -401,11 +399,6 @@ public class SSLSocketVersionCompatibilityTest {
                         .assertServerCertificateChain(c.clientTrustManager, peerCertificates);
                     TestSSLContext
                         .assertCertificateInKeyStore(peerCertificates[0], c.serverKeyStore);
-                    assertNotNull(peerCertificateChain);
-                    TestKeyStore.assertChainLength(peerCertificateChain);
-                    assertNotNull(peerCertificateChain[0]);
-                    TestSSLContext.assertCertificateInKeyStore(
-                        peerCertificateChain[0].getSubjectDN(), c.serverKeyStore);
                     assertNotNull(peerPrincipal);
                     TestSSLContext.assertCertificateInKeyStore(peerPrincipal, c.serverKeyStore);
                     assertNull(localPrincipal);


### PR DESCRIPTION
Efforts are underway in the OpenJDK project to remove the long deprecated-for-removal classes in the package javax.security.cert. These classes were introduced for backwards compatibility concerns with the unbundled JSSE release for JDK 1.2/1.3, but their use have been discouraged since they were introduced.

It would be good to update Conscrypt to reduce and contain dependencies on these archaic APIs.

See https://bugs.openjdk.org/browse/JDK-8227024 and the corresponding CSR https://bugs.openjdk.org/browse/JDK-8227395

Changes:

- Adding default method `ConscryptSession.getPeerCertificateChain` which throws an `UnsupportedOperationException` like Java 15.
- Update `ActiveSession`, `ExternalSession`, `Java7ExtendedSSLSession`, `SessionSnapshot`, `SSLNullSession` to remove the `getPeerCertificateChain` implementations.
- Remove the now unsed `SSLUtils.toCertificateChain` utility method
- Remove the `SSLSessionTest.test_SSLSession_getPeerCertificateChain` test method
- Update `SSLSocketVersionCompatibilityTest` to not call `HandshakeCompletedEvent.getPeerCertificateChain` and to not assert on the results obtain by calling this method.