### PR TITLE
Fix typo in NativeCrypto_EC_GROUP_new_arbitrary

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -1809,7 +1809,7 @@ static jlong NativeCrypto_EC_GROUP_new_arbitrary(JNIEnv* env, jclass, jbyteArray
         return 0;
     }
     bssl::UniquePtr<BIGNUM> cofactor(BN_new());
-    if (cofactor == nullptr || BN_set_word(cofactor.get(), static_cast<uint32_t>(cofactorInt))) {
+    if (cofactor == nullptr || !BN_set_word(cofactor.get(), static_cast<uint32_t>(cofactorInt))) {
         return 0;
     }
 


### PR DESCRIPTION
This fixes the test failures introduced by https://github.com/google/conscrypt/pull/1133. Not sure why the issue manifested the way it did, but this seems to fix it.