### PR TITLE
Bump RSA key size tested in KeyPairGeneratorTest

### DIFF
--- a/common/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
@@ -140,8 +140,8 @@ public class KeyPairGeneratorTest {
         putKeySize("DSA", 512);
         putKeySize("DSA", 512+64);
         putKeySize("DSA", 1024);
-        putKeySize("RSA", 512);
-        putKeySize("RSASSA-PSS", 512);
+        putKeySize("RSA", 2048);
+        putKeySize("RSASSA-PSS", 2048);
         putKeySize("DH", 512);
         putKeySize("DH", 512+64);
         putKeySize("DH", 1024);


### PR DESCRIPTION
BoringSSL is looking to set minimum RSA key sizes. 512-bit RSA was factored in 1999, so it is (one hopes!) not reflective of real input anymore. Bump the test size to 2048-bit, which is much more realistic for this decade.