### PR TITLE
Make tests agnostic about TLS v1.x.

### DIFF
--- a/benchmark-base/src/main/java/org/conscrypt/ServerSocketBenchmark.java
+++ b/benchmark-base/src/main/java/org/conscrypt/ServerSocketBenchmark.java
@@ -16,7 +16,7 @@
 
 package org.conscrypt;
 
-import static org.conscrypt.TestUtils.getProtocols;
+import static org.conscrypt.TestUtils.getCommonProtocolSuites;
 import static org.conscrypt.TestUtils.newTextMessage;
 import static org.junit.Assert.assertEquals;
 
@@ -62,7 +62,7 @@ public final class ServerSocketBenchmark {
         final ChannelType channelType = config.channelType();
 
         server = config.serverFactory().newServer(
-            channelType, config.messageSize(), getProtocols(), ciphers(config));
+            channelType, config.messageSize(), getCommonProtocolSuites(), ciphers(config));
         server.setMessageProcessor(new MessageProcessor() {
             @Override
             public void processMessage(byte[] inMessage, int numBytes, OutputStream os) {
@@ -86,7 +86,7 @@ public final class ServerSocketBenchmark {
 
         // Always use the same client for consistency across the benchmarks.
         client = config.clientFactory().newClient(
-                ChannelType.CHANNEL, server.port(), getProtocols(), ciphers(config));
+                ChannelType.CHANNEL, server.port(), getCommonProtocolSuites(), ciphers(config));
         client.start();
 
         // Wait for the initial connection to complete.

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -72,6 +72,7 @@ import org.conscrypt.tlswire.handshake.EllipticCurvesHelloExtension;
 import org.conscrypt.tlswire.handshake.HelloExtension;
 import org.conscrypt.tlswire.util.TlsProtocolVersion;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -384,6 +385,8 @@ public class SSLSocketTest {
     public void test_SSLSocket_noncontiguousProtocols_useLower() throws Exception {
         TestSSLContext c = TestSSLContext.create();
         SSLContext clientContext = c.clientContext;
+        // Can't test fallback without at least 3 protocol versions enabled.
+        TestUtils.assumeTlsV11Enabled(clientContext);
         SSLSocket client = (SSLSocket)
                 clientContext.getSocketFactory().createSocket(c.host, c.port);
         client.setEnabledProtocols(new String[] {"TLSv1.3", "TLSv1.1"});
@@ -413,6 +416,8 @@ public class SSLSocketTest {
     public void test_SSLSocket_noncontiguousProtocols_canNegotiate() throws Exception {
         TestSSLContext c = TestSSLContext.create();
         SSLContext clientContext = c.clientContext;
+        // Can't test fallback without at least 3 protocol versions enabled.
+        TestUtils.assumeTlsV11Enabled(clientContext);
         SSLSocket client = (SSLSocket)
                 clientContext.getSocketFactory().createSocket(c.host, c.port);
         client.setEnabledProtocols(new String[] {"TLSv1.3", "TLSv1.1"});
@@ -926,6 +931,8 @@ public class SSLSocketTest {
     @Test
     public void test_SSLSocket_sendsNoTlsFallbackScsv_Fallback_Success() throws Exception {
         TestSSLContext context = TestSSLContext.create();
+        // TLS_FALLBACK_SCSV is only applicable to TLS <= 1.2
+        TestUtils.assumeTlsV11Enabled(context.clientContext);
         final SSLSocket client = (SSLSocket) context.clientContext.getSocketFactory().createSocket(
                 context.host, context.port);
         final SSLSocket server = (SSLSocket) context.serverSocket.accept();
@@ -959,6 +966,8 @@ public class SSLSocketTest {
     public void test_SSLSocket_sendsTlsFallbackScsv_InappropriateFallback_Failure()
             throws Exception {
         TestSSLContext context = TestSSLContext.create();
+        // TLS_FALLBACK_SCSV is only applicable to TLS <= 1.2
+        TestUtils.assumeTlsV11Enabled(context.clientContext);
         final SSLSocket client = (SSLSocket) context.clientContext.getSocketFactory().createSocket(
                 context.host, context.port);
         final SSLSocket server = (SSLSocket) context.serverSocket.accept();

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -72,7 +72,6 @@ import org.conscrypt.tlswire.handshake.EllipticCurvesHelloExtension;
 import org.conscrypt.tlswire.handshake.HelloExtension;
 import org.conscrypt.tlswire.util.TlsProtocolVersion;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptEngineTest.java
@@ -18,7 +18,7 @@ package org.conscrypt;
 
 import static org.conscrypt.TestUtils.getConscryptProvider;
 import static org.conscrypt.TestUtils.getJdkProvider;
-import static org.conscrypt.TestUtils.getProtocols;
+import static org.conscrypt.TestUtils.highestCommonProtocol;
 import static org.conscrypt.TestUtils.initSslContext;
 import static org.conscrypt.TestUtils.newTextMessage;
 import static org.junit.Assert.assertArrayEquals;
@@ -569,7 +569,7 @@ public class ConscryptEngineTest {
 
     private static SSLContext newContext(Provider provider, TestKeyStore keyStore) {
         try {
-            SSLContext ctx = SSLContext.getInstance(getProtocols()[0], provider);
+            SSLContext ctx = SSLContext.getInstance(highestCommonProtocol(), provider);
             return initSslContext(ctx, keyStore);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);

--- a/openjdk/src/test/java/org/conscrypt/MockSessionBuilder.java
+++ b/openjdk/src/test/java/org/conscrypt/MockSessionBuilder.java
@@ -77,7 +77,7 @@ final class MockSessionBuilder {
         when(session.getId()).thenReturn(id);
         when(session.isValid()).thenReturn(valid);
         when(session.isSingleUse()).thenReturn(singleUse);
-        when(session.getProtocol()).thenReturn(TestUtils.getProtocols()[0]);
+        when(session.getProtocol()).thenReturn(TestUtils.highestCommonProtocol());
         when(session.getPeerHost()).thenReturn(host);
         when(session.getPeerPort()).thenReturn(port);
         when(session.getCipherSuite()).thenReturn(cipherSuite);

--- a/openjdk/src/test/java/org/conscrypt/RenegotiationTest.java
+++ b/openjdk/src/test/java/org/conscrypt/RenegotiationTest.java
@@ -144,7 +144,7 @@ public class RenegotiationTest {
                 Conscrypt.setUseEngineSocket(socketFactory, useEngineSocket);
                 socket = (SSLSocket) socketFactory.createSocket(
                         TestUtils.getLoopbackAddress(), port);
-                socket.setEnabledProtocols(TestUtils.getProtocols());
+                socket.setEnabledProtocols(TestUtils.getCommonProtocolSuites());
                 socket.setEnabledCipherSuites(TestUtils.getCommonCipherSuites());
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -234,7 +234,7 @@ public class RenegotiationTest {
             serverChannel = ServerSocketChannel.open();
             serverChannel.socket().bind(new InetSocketAddress(TestUtils.getLoopbackAddress(), 0));
             engine = newJdkServerContext().createSSLEngine();
-            engine.setEnabledProtocols(TestUtils.getProtocols());
+            engine.setEnabledProtocols(TestUtils.getCommonProtocolSuites());
             engine.setEnabledCipherSuites(TestUtils.getCommonCipherSuites());
             engine.setUseClientMode(false);
 

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -45,14 +45,12 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -413,7 +411,6 @@ public final class TestUtils {
             .filter(predicate)
             .toArray(String[]::new);
     }
-
 
     public static List<String> getSupportedProtocols(SSLContext ctx) {
         return Arrays.asList(ctx.getDefaultSSLParameters().getProtocols());

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -393,8 +393,7 @@ public final class TestUtils {
         Predicate<String> predicate = p -> conscryptProtocols.contains(p)
             // TODO(prb): Certificate auth fails when connecting Conscrypt and JDK's TLS 1.3.
             && !p.equals(PROTOCOL_TLS_V1_3);
-        List<String> supported = filter(getSupportedProtocols(jdkContext), predicate);
-        return supported.toArray(new String[0]);
+        return getSupportedProtocols(jdkContext, predicate);
     }
 
     public static String[] getCommonCipherSuites() {
@@ -402,23 +401,28 @@ public final class TestUtils {
         SSLContext conscryptContext = newClientSslContext(getConscryptProvider());
         Set<String> conscryptCiphers =  new HashSet<>(getSupportedCiphers(conscryptContext));
         Predicate<String> predicate = c -> isTlsCipherSuite(c) && conscryptCiphers.contains(c);
-        List<String> common = filter(getSupportedCiphers(jdkContext), predicate);
-        return common.toArray(new String[0]);
+        return getSupportedCiphers(jdkContext, predicate);
     }
 
     public static List<String> getSupportedCiphers(SSLContext ctx) {
         return Arrays.asList(ctx.getDefaultSSLParameters().getCipherSuites());
     }
 
+    public static String[] getSupportedCiphers(SSLContext ctx, Predicate<String> predicate) {
+        return Arrays.stream(ctx.getDefaultSSLParameters().getCipherSuites())
+            .filter(predicate)
+            .toArray(String[]::new);
+    }
+
+
     public static List<String> getSupportedProtocols(SSLContext ctx) {
         return Arrays.asList(ctx.getDefaultSSLParameters().getProtocols());
     }
 
-    private static <T> List<T> filter(List<T> input, Predicate<T> predicate) {
-        return input
-            .stream()
+    public static String[] getSupportedProtocols(SSLContext ctx, Predicate<String> predicate) {
+        return Arrays.stream(ctx.getDefaultSSLParameters().getProtocols())
             .filter(predicate)
-            .collect(Collectors.toList());
+            .toArray(String[]::new);
     }
 
     private static boolean isTlsCipherSuite(String cipher) {

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -45,12 +45,14 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
-import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
@@ -70,16 +72,16 @@ import org.junit.Assume;
  */
 public final class TestUtils {
     public static final Charset UTF_8 = StandardCharsets.UTF_8;
+    private static final String PROTOCOL_TLS_V1_3 = "TLSv1.3";
     private static final String PROTOCOL_TLS_V1_2 = "TLSv1.2";
     private static final String PROTOCOL_TLS_V1_1 = "TLSv1.1";
-    private static final String PROTOCOL_TLS_V1 = "TLSv1";
-    private static final String[] DESIRED_PROTOCOLS =
-        new String[] {PROTOCOL_TLS_V1_2, PROTOCOL_TLS_V1_1, PROTOCOL_TLS_V1};
+    // For interop testing we need a JDK Provider that can do TLS 1.2 as 1.x may be disabled
+    // in Conscrypt and 1.3 does not (yet) handle interoperability with the JDK Provider.
+    private static final String[] DESIRED_JDK_PROTOCOLS = new String[] { PROTOCOL_TLS_V1_2 };
     private static final Provider JDK_PROVIDER = getNonConscryptTlsProvider();
     private static final byte[] CHARS =
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".getBytes(UTF_8);
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocateDirect(0);
-    private static final String[] PROTOCOLS = getProtocolsInternal();
 
     static final String TEST_CIPHER = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
 
@@ -121,10 +123,10 @@ public final class TestUtils {
     private TestUtils() {}
 
     private static Provider getNonConscryptTlsProvider() {
-        for (String protocol : DESIRED_PROTOCOLS) {
+        for (String protocol : DESIRED_JDK_PROTOCOLS) {
             for (Provider p : Security.getProviders()) {
                 if (!p.getClass().getPackage().getName().contains("conscrypt")
-                        && hasProtocol(p, protocol)) {
+                        && hasSslContext(p, protocol)) {
                     return p;
                 }
             }
@@ -132,7 +134,7 @@ public final class TestUtils {
         return new BouncyCastleProvider();
     }
 
-    private static boolean hasProtocol(Provider p, String protocol) {
+    private static boolean hasSslContext(Provider p, String protocol) {
         return p.get("SSLContext." + protocol) != null;
     }
 
@@ -309,23 +311,6 @@ public final class TestUtils {
         throw ex;
     }
 
-    /**
-     * Returns an array containing only {@link #PROTOCOL_TLS_V1_2}.
-     */
-    public static String[] getProtocols() {
-        return PROTOCOLS;
-    }
-
-    private static String[] getProtocolsInternal() {
-        List<String> protocols = new ArrayList<>();
-        for (String protocol : DESIRED_PROTOCOLS) {
-            if (hasProtocol(getJdkProvider(), protocol)) {
-                protocols.add(protocol);
-            }
-        }
-        return protocols.toArray(new String[0]);
-    }
-
     static SSLSocketFactory setUseEngineSocket(
             SSLSocketFactory conscryptFactory, boolean useEngineSocket) {
         try {
@@ -393,32 +378,61 @@ public final class TestUtils {
         }
     }
 
-    static String[] getCommonCipherSuites() {
-        SSLContext jdkContext =
-                TestUtils.initSslContext(newContext(getJdkProvider()), TestKeyStore.getClient());
-        SSLContext conscryptContext = TestUtils.initSslContext(
-                newContext(getConscryptProvider()), TestKeyStore.getClient());
-        Set<String> supported = new LinkedHashSet<>(supportedCiphers(jdkContext));
-        supported.retainAll(supportedCiphers(conscryptContext));
-        filterCiphers(supported);
+    public static String highestCommonProtocol() {
+        String[] common = getCommonProtocolSuites();
+        Arrays.sort(common);
+        return common[common.length - 1];
+    }
 
+    public static String[] getCommonProtocolSuites() {
+        SSLContext jdkContext = newClientSslContext(getJdkProvider());
+        SSLContext conscryptContext = newClientSslContext(getConscryptProvider());
+        List<String> supported = getSupportedProtocols(jdkContext);
+        // TODO(prb): Certificate authentication fails when connecting Conscrypt and JDK's TLS 1.3.
+        supported = filter(supported, p -> !p.equals(PROTOCOL_TLS_V1_3));
+        // No point building a Set here due to small list sizes.
+        supported = intersect(supported, getSupportedProtocols(conscryptContext));
         return supported.toArray(new String[0]);
     }
 
-    private static List<String> supportedCiphers(SSLContext ctx) {
+    public static String[] getCommonCipherSuites() {
+        SSLContext jdkContext = newClientSslContext(getJdkProvider());
+        SSLContext conscryptContext = newClientSslContext(getConscryptProvider());
+        List<String> jdkCiphers = getSupportedCiphers(jdkContext);
+        jdkCiphers = filter(jdkCiphers, TestUtils::isTlsCipherSuite);
+        List<String> common =
+            intersect(jdkCiphers, new HashSet<>(getSupportedCiphers(conscryptContext)));
+        return common.toArray(new String[0]);
+    }
+
+    public static List<String> getSupportedCiphers(SSLContext ctx) {
         return Arrays.asList(ctx.getDefaultSSLParameters().getCipherSuites());
     }
 
-    private static void filterCiphers(Iterable<String> ciphers) {
-        // Filter all non-TLS ciphers.
-        Iterator<String> iter = ciphers.iterator();
-        while (iter.hasNext()) {
-            String cipher = iter.next();
-            if (cipher.startsWith("SSL_") || cipher.startsWith("TLS_EMPTY")
-                    || cipher.contains("_RC4_")) {
-                iter.remove();
-            }
-        }
+    public static List<String> getSupportedProtocols(SSLContext ctx) {
+        return Arrays.asList(ctx.getDefaultSSLParameters().getProtocols());
+    }
+
+    private static <T> List<T> filter(List<T> input, Predicate<T> predicate) {
+        return input
+            .stream()
+            .filter(predicate)
+            .collect(Collectors.toList());
+    }
+
+    // Intersects an initial List and a Collection, preserving the order of the List.
+    private static <T> List<T> intersect(List<T> initial, Collection<T> other) {
+        return filter(initial, other::contains);
+    }
+
+    private static boolean isTlsCipherSuite(String cipher) {
+        return !cipher.startsWith("SSL_")
+            && !cipher.startsWith("TLS_EMPTY")
+            && !cipher.contains("_RC4_");
+    }
+
+    public static void assumeTlsV11Enabled(SSLContext context) {
+        Assume.assumeTrue(getSupportedProtocols(context).contains(PROTOCOL_TLS_V1_1));
     }
 
     /**

--- a/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
+++ b/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
@@ -415,9 +415,7 @@ public final class StandardNames {
     private static void assertSupportedProtocols(Set<String> valid, String[] protocols) {
         Set<String> remainingProtocols = assertValidProtocols(valid, protocols);
 
-        Set<String> expected = new HashSet<>(valid);
         // TODO(prb) Temporarily ignore TLSv1.x: See comment for assertSSLContextEnabledProtocols()
-        expected.removeAll(SSL_CONTEXT_PROTOCOLS_DEPRECATED);
         remainingProtocols.removeAll(SSL_CONTEXT_PROTOCOLS_DEPRECATED);
 
         assertEquals("Missing protocols", Collections.EMPTY_SET, remainingProtocols);

--- a/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
+++ b/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
@@ -163,6 +163,9 @@ public final class StandardNames {
             Arrays.asList(SSL_CONTEXT_PROTOCOLS_DEFAULT, "TLS", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"));
     public static final Set<String> SSL_CONTEXT_PROTOCOLS_WITH_DEFAULT_CONFIG = new HashSet<String>(
             Arrays.asList(SSL_CONTEXT_PROTOCOLS_DEFAULT, "TLS", "TLSv1.3"));
+    // Deprecated TLS protocols... May or may not be present or enabled.
+    public static final Set<String> SSL_CONTEXT_PROTOCOLS_DEPRECATED = new HashSet<>(
+        Arrays.asList("TLSv1", "TLSv1.1"));
 
     public static final Set<String> KEY_TYPES = new HashSet<String>(
             Arrays.asList("RSA", "DSA", "DH_RSA", "DH_DSA", "EC", "EC_EC", "EC_RSA"));
@@ -409,10 +412,15 @@ public final class StandardNames {
      * assertSupportedProtocols additionally verifies that all
      * supported protocols where in the input array.
      */
-    private static void assertSupportedProtocols(Set<String> expected, String[] protocols) {
-        Set<String> remainingProtocols = assertValidProtocols(expected, protocols);
+    private static void assertSupportedProtocols(Set<String> valid, String[] protocols) {
+        Set<String> remainingProtocols = assertValidProtocols(valid, protocols);
+
+        Set<String> expected = new HashSet<>(valid);
+        // TODO(prb) Temporarily ignore TLSv1.x: See comment for assertSSLContextEnabledProtocols()
+        expected.removeAll(SSL_CONTEXT_PROTOCOLS_DEPRECATED);
+        remainingProtocols.removeAll(SSL_CONTEXT_PROTOCOLS_DEPRECATED);
+
         assertEquals("Missing protocols", Collections.EMPTY_SET, remainingProtocols);
-        assertEquals(expected.size(), protocols.length);
     }
 
     /**
@@ -453,9 +461,18 @@ public final class StandardNames {
     }
 
     public static void assertSSLContextEnabledProtocols(String version, String[] protocols) {
-        assertEquals("For protocol \"" + version + "\"",
-                Arrays.toString(SSL_CONTEXT_PROTOCOLS_ENABLED.get(version)),
-                Arrays.toString(protocols));
+        Set<String> expected = new HashSet<>(
+            Arrays.asList(SSL_CONTEXT_PROTOCOLS_ENABLED.get(version)));
+        Set<String> actual = new HashSet<>(Arrays.asList(protocols));
+
+        // TODO(prb): Temporary measure - just ignore deprecated protocols.  Allows
+        // testing on source trees where these have been disabled in unknown ways.
+        // Future work will provide a supported API for disabling protocols, but for
+        // now we need to work with what's in the field.
+        expected.removeAll(SSL_CONTEXT_PROTOCOLS_DEPRECATED);
+        actual.removeAll(SSL_CONTEXT_PROTOCOLS_DEPRECATED);
+
+        assertEquals("For protocol \"" + version + "\"", expected, actual);
     }
 
     /**


### PR DESCRIPTION
Test only change. Ensures tests neither use nor assume anything about whether TLSv.1 are enabled or supported.  As such it is suitable for backporting to historic Android test suites where vendors may have disabled TLS v1.x by editing the default arrays.

However by being agnostic it does not enforce that TLS v1.x are available if expected. A further change will provide an API for that, but which is not suitable for backporting as it will require non-test changes.

A lot of the tidy-up is around RenegotiationTest and its TestUtils methods, which are only tested on OpenJDK builds.