### PR TITLE
Deal with partially constructed objects during finalize().

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1681,7 +1681,11 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     @SuppressWarnings("deprecation")
     protected void finalize() throws Throwable {
         try {
-            closeAndFreeResources();
+            if (ssl != null) {
+                synchronized (ssl) {
+                    closeAndFreeResources();
+                }
+            }
         } finally {
             super.finalize();
         }

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1681,7 +1681,9 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     @SuppressWarnings("deprecation")
     protected void finalize() throws Throwable {
         try {
+            // If ssl is null, object must not be fully constructed so nothing for us to do here.
             if (ssl != null) {
+                // Otherwise closeAndFreeResources() and callees expect to synchronize on ssl.
                 synchronized (ssl) {
                     closeAndFreeResources();
                 }


### PR DESCRIPTION
The happy path for shutting down a ConscryptEngine is one of the close* methods which then calls closeAndFreeResources() synchronised on ssl, so all the logic can assume ssl is non-null.

However it also seems to be possible for ssl to be null when finalizing, presumably if newSsl() threw, e.g. due to low memory. If this is the case then we don't need to do anything as e.g. there cannot be any session snapshot which needs saving.

And if ssl is non-null then the finalizer should also synchronise on ssl for thread safety... *shouldn't* be necessary but does no harm.