### PR TITLE
Enable C++17 for Android standalone builds.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,8 @@ if (androidSdkInstalled) {
                 cmake {
                     arguments '-DANDROID=True',
                             '-DANDROID_STL=c++_static',
-                            "-DBORINGSSL_HOME=$boringsslHome"
+                            "-DBORINGSSL_HOME=$boringsslHome",
+                            "-DCMAKE_CXX_STANDARD=17"
                     cFlags '-fvisibility=hidden',
                             '-DBORINGSSL_SHARED_LIBRARY',
                             '-DBORINGSSL_IMPLEMENTATION',


### PR DESCRIPTION
Was previously only enabled for OpenJDK and Platform builds.