### PR TITLE
Zero out native resource reference while finalizing.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
@@ -49,7 +49,7 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
  * An implementation of {@link X509CRL} based on BoringSSL.
  */
 final class OpenSSLX509CRL extends X509CRL {
-    private final long mContext;
+    private volatile long mContext;
     private final Date thisUpdate;
     private final Date nextUpdate;
 
@@ -415,7 +415,9 @@ final class OpenSSLX509CRL extends X509CRL {
     protected void finalize() throws Throwable {
         try {
             if (mContext != 0) {
-                NativeCrypto.X509_CRL_free(mContext, this);
+                long toFree = mContext;
+                mContext = 0;
+                NativeCrypto.X509_CRL_free(toFree, this);
             }
         } finally {
             super.finalize();

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
@@ -414,8 +414,8 @@ final class OpenSSLX509CRL extends X509CRL {
     @SuppressWarnings("deprecation")
     protected void finalize() throws Throwable {
         try {
-            if (mContext != 0) {
-                long toFree = mContext;
+            long toFree = mContext;
+            if (toFree != 0) {
                 mContext = 0;
                 NativeCrypto.X509_CRL_free(toFree, this);
             }

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -58,7 +58,7 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 public final class OpenSSLX509Certificate extends X509Certificate {
     private static final long serialVersionUID = 1992239142393372128L;
 
-    private transient final long mContext;
+    private transient volatile long mContext;
     private transient Integer mHashCode;
 
     private final Date notBefore;
@@ -578,7 +578,9 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     protected void finalize() throws Throwable {
         try {
             if (mContext != 0) {
-                NativeCrypto.X509_free(mContext, this);
+                long toFree = mContext;
+                mContext = 0;
+                NativeCrypto.X509_free(toFree, this);
             }
         } finally {
             super.finalize();

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -577,8 +577,8 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     @SuppressWarnings("deprecation")
     protected void finalize() throws Throwable {
         try {
-            if (mContext != 0) {
-                long toFree = mContext;
+            long toFree = mContext;
+            if (toFree != 0) {
                 mContext = 0;
                 NativeCrypto.X509_free(toFree, this);
             }


### PR DESCRIPTION
Good hygiene, and possible cause of some native crashes we're seeing.