### PR TITLE
Correct inverted logic in OpenSSLXDHKeyFactory.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLXDHKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLXDHKeyFactory.java
@@ -82,7 +82,7 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
         }
 
         // Support XDH or X25519 algorithm names per JEP 324
-        if (!"XDH".equals(key.getAlgorithm()) || !"X25519".equals(key.getAlgorithm()) ) {
+        if (!"XDH".equals(key.getAlgorithm()) && !"X25519".equals(key.getAlgorithm()) ) {
             throw new InvalidKeySpecException("Key must be an XDH or X25519 key");
         }
 

--- a/common/src/test/java/org/conscrypt/ConscryptSuite.java
+++ b/common/src/test/java/org/conscrypt/ConscryptSuite.java
@@ -36,6 +36,8 @@ import org.conscrypt.java.security.KeyFactoryTestDSA;
 import org.conscrypt.java.security.KeyFactoryTestEC;
 import org.conscrypt.java.security.KeyFactoryTestRSA;
 import org.conscrypt.java.security.KeyFactoryTestRSACrt;
+import org.conscrypt.java.security.KeyFactoryTestRSACustom;
+import org.conscrypt.java.security.KeyFactoryTestXDH;
 import org.conscrypt.java.security.KeyPairGeneratorTest;
 import org.conscrypt.java.security.KeyPairGeneratorTestDH;
 import org.conscrypt.java.security.KeyPairGeneratorTestDSA;
@@ -115,6 +117,8 @@ import org.junit.runners.Suite;
         KeyFactoryTestEC.class,
         KeyFactoryTestRSA.class,
         KeyFactoryTestRSACrt.class,
+        KeyFactoryTestRSACustom.class,
+        KeyFactoryTestXDH.class,
         KeyPairGeneratorTest.class,
         KeyPairGeneratorTestDH.class,
         KeyPairGeneratorTestDSA.class,


### PR DESCRIPTION
And add missing tests to the OpenJDK suite which
is how this got missed in #1156.