### PR TITLE
Reset HMAC and CMAC contexts more efficiently

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -366,6 +366,8 @@ public final class NativeCrypto {
 
     static native byte[] CMAC_Final(NativeRef.CMAC_CTX ctx);
 
+    static native void CMAC_Reset(NativeRef.CMAC_CTX ctx);
+
     // --- HMAC functions ------------------------------------------------------
 
     static native long HMAC_CTX_new();
@@ -379,6 +381,8 @@ public final class NativeCrypto {
     static native void HMAC_UpdateDirect(NativeRef.HMAC_CTX ctx, long inPtr, int inLength);
 
     static native byte[] HMAC_Final(NativeRef.HMAC_CTX ctx);
+
+    static native void HMAC_Reset(NativeRef.HMAC_CTX ctx);
 
     // --- HPKE functions ------------------------------------------------------
     static native byte[] EVP_HPKE_CTX_export(

--- a/common/src/main/java/org/conscrypt/OpenSSLMac.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLMac.java
@@ -20,7 +20,6 @@ import java.nio.ByteBuffer;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
-import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
 import javax.crypto.MacSpi;
 import javax.crypto.SecretKey;
@@ -30,11 +29,6 @@ import javax.crypto.SecretKey;
  */
 @Internal
 public abstract class OpenSSLMac extends MacSpi {
-    /**
-     * The secret key used in this keyed MAC.
-     */
-    protected byte[] keyBytes;
-
     /**
      * Holds the output size of the message digest.
      */
@@ -51,6 +45,11 @@ public abstract class OpenSSLMac extends MacSpi {
 
     /**
      * Creates and initializes the relevant BoringSSL *MAC context.
+     */
+    protected abstract void initContext(byte[] keyBytes);
+
+    /**
+     * Resets the context for a new operation with the same key.
      */
     protected abstract void resetContext();
 
@@ -75,13 +74,13 @@ public abstract class OpenSSLMac extends MacSpi {
             throw new InvalidAlgorithmParameterException("unknown parameter type");
         }
 
-        keyBytes = key.getEncoded();
+        byte[] keyBytes = key.getEncoded();
         if (keyBytes == null) {
             throw new InvalidKeyException("key cannot be encoded");
         }
 
         try {
-            resetContext();
+            initContext(keyBytes);
         } catch (RuntimeException e) {
             throw new InvalidKeyException("invalid key", e);
         }
@@ -159,12 +158,16 @@ public abstract class OpenSSLMac extends MacSpi {
         }
 
         @Override
-        protected void resetContext() {
+        protected void initContext(byte[] keyBytes) {
             NativeRef.HMAC_CTX ctxLocal = new NativeRef.HMAC_CTX(NativeCrypto.HMAC_CTX_new());
-            if (keyBytes != null) {
-                NativeCrypto.HMAC_Init_ex(ctxLocal, keyBytes, evpMd);
-            }
+            NativeCrypto.HMAC_Init_ex(ctxLocal, keyBytes, evpMd);
             this.ctx = ctxLocal;
+        }
+
+        @Override
+        protected void resetContext() {
+            final NativeRef.HMAC_CTX ctxLocal = ctx;
+            NativeCrypto.HMAC_Reset(ctxLocal);
         }
 
         @Override
@@ -231,12 +234,16 @@ public abstract class OpenSSLMac extends MacSpi {
         }
 
         @Override
-        protected void resetContext() {
+        protected void initContext(byte[] keyBytes) {
             NativeRef.CMAC_CTX ctxLocal = new NativeRef.CMAC_CTX(NativeCrypto.CMAC_CTX_new());
-            if (keyBytes != null) {
-                NativeCrypto.CMAC_Init(ctxLocal, keyBytes);
-            }
+            NativeCrypto.CMAC_Init(ctxLocal, keyBytes);
             this.ctx = ctxLocal;
+        }
+
+        @Override
+        protected void resetContext() {
+            final NativeRef.CMAC_CTX ctxLocal = ctx;
+            NativeCrypto.CMAC_Reset(ctxLocal);
         }
 
         @Override

--- a/common/src/test/java/org/conscrypt/MacTest.java
+++ b/common/src/test/java/org/conscrypt/MacTest.java
@@ -126,6 +126,11 @@ public class MacTest {
             macBytes = generateReusingMac(algorithm, keyBytes, msgBytes);
             assertArrayEquals(failMessage("Re-use Mac", baseFailMsg, macBytes),
                     expectedBytes, macBytes);
+
+            // Calculated using a pre-loved Mac with the same key
+            macBytes = generateReusingMacSameKey(algorithm, secretKey, msgBytes);
+            assertArrayEquals(failMessage("Re-use Mac same key", baseFailMsg, macBytes),
+                    expectedBytes, macBytes);
         }
     }
 
@@ -377,6 +382,19 @@ public class MacTest {
         mac.init(key);
         mac.update(message);
         return mac.doFinal();
+    }
+
+    private byte[] generateReusingMacSameKey(String algorithm, SecretKeySpec key, byte[] message)
+            throws Exception {
+        Mac mac = getConscryptMac(algorithm, key);
+
+        // Calculate a MAC over some other message.
+        byte[] otherMessage = new byte[message.length];
+        mac.doFinal(otherMessage);
+
+        // The MAC should now have been reset to compute a new MAC with the same
+        // key.
+        return mac.doFinal(message);
     }
 
     private Mac getConscryptMac(String algorithm) throws Exception {


### PR DESCRIPTION
If computing a new MAC with the same key, we would ideally save a little bit of work. (A couple blocks of the underlying hash for HMAC and key schedule calculation with CMAC.) Use the APIs for doing this, and also cover this case with tests.

I noticed that MacSpi also has an optional clone() method, which we could support here too, but I've left that for another PR.