### PR TITLE
Remove "extends TestCase" from TrustedCertificateStoreTest.

### DIFF
--- a/platform/src/test/java/org/conscrypt/TrustedCertificateStoreTest.java
+++ b/platform/src/test/java/org/conscrypt/TrustedCertificateStoreTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.security.auth.x500.X500Principal;
-import junit.framework.TestCase;
 import org.conscrypt.java.security.TestKeyStore;
 import org.junit.After;
 import org.junit.Before;
@@ -56,9 +55,17 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 @SuppressWarnings("unused")
 @RunWith(Parameterized.class)
-public class TrustedCertificateStoreTest extends TestCase {
+public class TrustedCertificateStoreTest {
     private static final Random tempFileRandom = new Random();
 
     private static File dirTest;
@@ -409,7 +416,6 @@ public class TrustedCertificateStoreTest extends TestCase {
     private TrustedCertificateStore store;
 
     @Before
-    @Override
     public void setUp() throws Exception {
         dirTest = Files.createTempDirectory("cert-store-test").toFile();
         dirSystem = new File(dirTest, "system");
@@ -430,7 +436,6 @@ public class TrustedCertificateStoreTest extends TestCase {
     }
 
     @After
-    @Override
     public void tearDown() {
         cleanStore();
     }


### PR DESCRIPTION
Upstreams https://r.android.com/2730693

This may be causing an issue wherein the test framework looks for unparameterized versions of tests which are nonexistent.