### PR TITLE
Avoid calling synchronized TimeZone#getTimeZone method at runtime

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
@@ -49,6 +49,9 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
  * An implementation of {@link X509CRL} based on BoringSSL.
  */
 final class OpenSSLX509CRL extends X509CRL {
+
+    private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+
     private volatile long mContext;
     private final Date thisUpdate;
     private final Date nextUpdate;
@@ -63,7 +66,7 @@ final class OpenSSLX509CRL extends X509CRL {
 
     // Package-visible because it's also used by OpenSSLX509CRLEntry
     static Date toDate(long asn1time) throws ParsingException {
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar calendar = Calendar.getInstance(UTC_TIME_ZONE);
         calendar.set(Calendar.MILLISECOND, 0);
         NativeCrypto.ASN1_TIME_to_Calendar(asn1time, calendar);
         return calendar.getTime();

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -58,6 +58,8 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 public final class OpenSSLX509Certificate extends X509Certificate {
     private static final long serialVersionUID = 1992239142393372128L;
 
+    private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
+
     private transient volatile long mContext;
     private transient Integer mHashCode;
 
@@ -80,7 +82,7 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     }
 
     private static Date toDate(long asn1time) throws ParsingException {
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar calendar = Calendar.getInstance(UTC_TIME_ZONE);
         calendar.set(Calendar.MILLISECOND, 0);
         NativeCrypto.ASN1_TIME_to_Calendar(asn1time, calendar);
         return calendar.getTime();


### PR DESCRIPTION
It is identified in profiling tool that `TimeZone.getTimeZone("UTC")` can cause threads to block and degrade performance because it is a synchronized method. 
The proposed solution is to make UTC timezone a reusable constant as performance enhancement. 