### PR TITLE
Don't create Date or Calendar objects for ASN.1 dates unless needed.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -4867,7 +4867,7 @@ static jobjectArray NativeCrypto_get_X509_GENERAL_NAME_stack(JNIEnv* env, jclass
 static jlong ASN1_TIME_convert_to_posix(JNIEnv* env, const ASN1_TIME* time) {
     int64_t retval;
     if (!ASN1_TIME_to_posix(time, &retval)) {
-        JNI_TRACE("ASN1_time_check_and_convert(%p) => Invalid date value", time);
+        JNI_TRACE("ASN1_TIME_convert_to_posix(%p) => Invalid date value", time);
         conscrypt::jniutil::throwParsingException(env, "Invalid date value");
         return 0;
     }

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -611,10 +611,6 @@ public final class NativeCrypto {
 
     static native int X509_supported_extension(long x509ExtensionRef);
 
-    // --- ASN1_TIME -----------------------------------------------------------
-
-    static native void ASN1_TIME_to_Calendar(long asn1TimeCtx, Calendar cal) throws ParsingException;
-
     // --- ASN1 Encoding -------------------------------------------------------
 
     /**

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
@@ -50,23 +50,15 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
  */
 final class OpenSSLX509CRL extends X509CRL {
     private volatile long mContext;
-    private final Date thisUpdate;
-    private final Date nextUpdate;
+    private final long thisUpdate;
+    private final long nextUpdate;
 
     private OpenSSLX509CRL(long ctx) throws ParsingException {
         mContext = ctx;
         // The legacy X509 OpenSSL APIs don't validate ASN1_TIME structures until access, so
         // parse them here because this is the only time we're allowed to throw ParsingException
-        thisUpdate = toDate(NativeCrypto.X509_CRL_get_lastUpdate(mContext, this));
-        nextUpdate = toDate(NativeCrypto.X509_CRL_get_nextUpdate(mContext, this));
-    }
-
-    // Package-visible because it's also used by OpenSSLX509CRLEntry
-    static Date toDate(long asn1time) throws ParsingException {
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        calendar.set(Calendar.MILLISECOND, 0);
-        NativeCrypto.ASN1_TIME_to_Calendar(asn1time, calendar);
-        return calendar.getTime();
+        thisUpdate = NativeCrypto.X509_CRL_get_lastUpdate(mContext, this);
+        nextUpdate = NativeCrypto.X509_CRL_get_nextUpdate(mContext, this);
     }
 
     static OpenSSLX509CRL fromX509DerInputStream(InputStream is) throws ParsingException {
@@ -278,12 +270,12 @@ final class OpenSSLX509CRL extends X509CRL {
 
     @Override
     public Date getThisUpdate() {
-        return (Date) thisUpdate.clone();
+        return new Date(thisUpdate);
     }
 
     @Override
     public Date getNextUpdate() {
-        return (Date) nextUpdate.clone();
+        return new Date(nextUpdate);
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRLEntry.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRLEntry.java
@@ -31,13 +31,13 @@ import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
  */
 final class OpenSSLX509CRLEntry extends X509CRLEntry {
     private final long mContext;
-    private final Date revocationDate;
+    private final long revocationDate;
 
     OpenSSLX509CRLEntry(long ctx) throws ParsingException {
         mContext = ctx;
         // The legacy X509 OpenSSL APIs don't validate ASN1_TIME structures until access, so
         // parse them here because this is the only time we're allowed to throw ParsingException
-        revocationDate = OpenSSLX509CRL.toDate(NativeCrypto.get_X509_REVOKED_revocationDate(mContext));
+        revocationDate = NativeCrypto.get_X509_REVOKED_revocationDate(mContext);
     }
 
     @Override
@@ -112,7 +112,7 @@ final class OpenSSLX509CRLEntry extends X509CRLEntry {
 
     @Override
     public Date getRevocationDate() {
-        return (Date) revocationDate.clone();
+        return new Date(revocationDate);
     }
 
     @Override

--- a/common/src/test/java/org/conscrypt/HostnameVerifierTest.java
+++ b/common/src/test/java/org/conscrypt/HostnameVerifierTest.java
@@ -598,7 +598,7 @@ public final class HostnameVerifierTest {
         //
         // Certificate generated using:-
         //     openssl req -x509 -nodes -days 36500 -subj "/CN=Google Inc" \
-        //         -addext "subjectAltName=DNS:*.com" -newkey rsa:512
+        //         -addext "subjectAltName=DNS:*.com" -
         SSLSession session = session(""
                 + "-----BEGIN CERTIFICATE-----\n"
                 + "MIIBlTCCAT+gAwIBAgIUe1RB6C61ZW/SEQpKiywSEJOEOUMwDQYJKoZIhvcNAQEL\n"

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -407,6 +407,7 @@ model {
 
                     if (toolChain in Clang || toolChain in Gcc) {
                         cppCompiler.args "-Wall",
+                                "-Werror",
                                 "-fPIC",
                                 "-O3",
                                 "-std=c++17",


### PR DESCRIPTION
Continutes to parse Cert/CRL dates on creation in order to detect errors, but stores them as longs since the epoch rather than Dates and lazily creates Dates directly from them rather than requiring a Calendar.