### PR TITLE
Don't throw when resetting an uninitialised Mac.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLMac.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLMac.java
@@ -38,6 +38,7 @@ public abstract class OpenSSLMac extends MacSpi {
      * Holds a dummy buffer for writing single bytes to the digest.
      */
     private final byte[] singleByte = new byte[1];
+    protected boolean initialized = false;
 
     private OpenSSLMac(int size) {
         this.size = size;
@@ -84,6 +85,7 @@ public abstract class OpenSSLMac extends MacSpi {
         } catch (RuntimeException e) {
             throw new InvalidKeyException("invalid key", e);
         }
+        initialized = true;
     }
 
     @Override
@@ -140,6 +142,9 @@ public abstract class OpenSSLMac extends MacSpi {
 
     @Override
     protected void engineReset() {
+        if (!initialized) {
+            return;
+        }
         resetContext();
     }
 

--- a/common/src/test/java/org/conscrypt/MacTest.java
+++ b/common/src/test/java/org/conscrypt/MacTest.java
@@ -151,6 +151,8 @@ public class MacTest {
                     mac = Mac.getInstance(algorithm, provider);
                     assertEquals(algorithm, mac.getAlgorithm());
                     assertEquals(provider, mac.getProvider());
+                    // It's not an error to reset an uninitialised Mac.
+                    mac.reset();
                     if (key != null) {
                         // TODO(prb) Ensure we have at least one test vector for every
                         // MAC in Conscrypt and Android.


### PR DESCRIPTION
Turns out Android, SunJCE and BC all allow this and the javadoc has nothing to say on the subject.  Caught this as a side effect of an unrelated Android test, so added an explicit check in our own ServiceTester test which runs against all installed Providers.

Added a new field to track initialized state because if the native context ever becomes null after that (e.g. concurrency bug) that's still an error.