### PR TITLE
Use correct delete[] operator for saved ALPN data.

### DIFF
--- a/common/src/jni/main/include/conscrypt/app_data.h
+++ b/common/src/jni/main/include/conscrypt/app_data.h
@@ -238,7 +238,7 @@ class AppData {
 
     void clearApplicationProtocols() {
         if (applicationProtocolsData != nullptr) {
-            delete applicationProtocolsData;
+            delete[] applicationProtocolsData;
             applicationProtocolsData = nullptr;
             applicationProtocolsLength = static_cast<size_t>(-1);
         }


### PR DESCRIPTION
Causes runtime aborts when using tcmalloc and is UB everywhere else.

Could probably tidy this further (e.g. use ScopedBytesRO when saving the ALPN data), but not today.