### PR TITLE
Ensure TLSv1 is still enabled by default unless it's deprecated.

### DIFF
--- a/common/src/main/java/org/conscrypt/ArrayUtils.java
+++ b/common/src/main/java/org/conscrypt/ArrayUtils.java
@@ -32,4 +32,20 @@ final class ArrayUtils {
                     + offset + "; regionLength=" + count);
         }
     }
+
+    static String[] concatValues(String[] a1, String... values) {
+        return concat (a1, values);
+    }
+
+    static String[] concat(String[] a1, String[] a2) {
+        String[] result = new String[a1.length + a2.length];
+        int offset = 0;
+        for (int i = 0; i < a1.length; i++, offset++) {
+            result[offset] = a1[i];
+        }
+        for (int i = 0; i < a2.length; i++, offset++) {
+            result[offset] = a2[i];
+        }
+        return result;
+    }
 }

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -42,7 +42,6 @@ import javax.crypto.ShortBufferException;
 import javax.net.ssl.SSLException;
 import javax.security.auth.x500.X500Principal;
 import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
-import org.conscrypt.Platform;
 
 /**
  * Provides the Java side of our JNI glue for OpenSSL.
@@ -1016,16 +1015,24 @@ public final class NativeCrypto {
 
     static native void set_SSL_psk_server_callback_enabled(long ssl, NativeSsl ssl_holder, boolean enabled);
 
+    private static final String[] ENABLED_PROTOCOLS_TLSV1 = Platform.isTlsV1Deprecated()
+            ? new String[0]
+            : new String[] {
+                DEPRECATED_PROTOCOL_TLSV1,
+                DEPRECATED_PROTOCOL_TLSV1_1,
+            };
+
+
     /** Protocols to enable by default when "TLSv1.3" is requested. */
-    static final String[] TLSV13_PROTOCOLS = new String[] {
+    static final String[] TLSV13_PROTOCOLS = ArrayUtils.concatValues(
+            ENABLED_PROTOCOLS_TLSV1,
             SUPPORTED_PROTOCOL_TLSV1_2,
-            SUPPORTED_PROTOCOL_TLSV1_3,
-    };
+            SUPPORTED_PROTOCOL_TLSV1_3);
 
     /** Protocols to enable by default when "TLSv1.2" is requested. */
-    static final String[] TLSV12_PROTOCOLS = new String[] {
-            SUPPORTED_PROTOCOL_TLSV1_2,
-    };
+    static final String[] TLSV12_PROTOCOLS = ArrayUtils.concatValues(
+            ENABLED_PROTOCOLS_TLSV1,
+            SUPPORTED_PROTOCOL_TLSV1_2);
 
     /** Protocols to enable by default when "TLSv1.1" is requested. */
     static final String[] TLSV11_PROTOCOLS = new String[] {

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -811,4 +811,15 @@ public final class TestUtils {
         String name = osName();
         return name.startsWith("macosx") || name.startsWith("osx");
     }
+
+    // Find base method via reflection due to visibility issues when building with Gradle.
+    public static boolean isTlsV1Deprecated() {
+        try {
+            return (Boolean) conscryptClass("Platform")
+                    .getDeclaredMethod("isTlsV1Deprecated")
+                    .invoke(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
+++ b/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.conscrypt.TestUtils;
+
 /**
  * This class defines expected string names for protocols, key types,
  * client and server auth types, cipher suites.
@@ -164,8 +166,13 @@ public final class StandardNames {
     public static final Set<String> SSL_CONTEXT_PROTOCOLS_WITH_DEFAULT_CONFIG = new HashSet<String>(
             Arrays.asList(SSL_CONTEXT_PROTOCOLS_DEFAULT, "TLS", "TLSv1.3"));
     // Deprecated TLS protocols... May or may not be present or enabled.
-    public static final Set<String> SSL_CONTEXT_PROTOCOLS_DEPRECATED = new HashSet<>(
-        Arrays.asList("TLSv1", "TLSv1.1"));
+    public static final Set<String> SSL_CONTEXT_PROTOCOLS_DEPRECATED = new HashSet<>();
+    static {
+        if (TestUtils.isTlsV1Deprecated()) {
+            SSL_CONTEXT_PROTOCOLS_DEPRECATED.add("TLSv1");
+            SSL_CONTEXT_PROTOCOLS_DEPRECATED.add("TLSv1.1");
+        }
+    }
 
     public static final Set<String> KEY_TYPES = new HashSet<String>(
             Arrays.asList("RSA", "DSA", "DH_RSA", "DH_DSA", "EC", "EC_EC", "EC_RSA"));
@@ -463,10 +470,8 @@ public final class StandardNames {
             Arrays.asList(SSL_CONTEXT_PROTOCOLS_ENABLED.get(version)));
         Set<String> actual = new HashSet<>(Arrays.asList(protocols));
 
-        // TODO(prb): Temporary measure - just ignore deprecated protocols.  Allows
-        // testing on source trees where these have been disabled in unknown ways.
-        // Future work will provide a supported API for disabling protocols, but for
-        // now we need to work with what's in the field.
+        // Ignore deprecated protocols, which are set earlier based
+        // on Platform.isTlsV1Deprecated().
         expected.removeAll(SSL_CONTEXT_PROTOCOLS_DEPRECATED);
         actual.removeAll(SSL_CONTEXT_PROTOCOLS_DEPRECATED);
 


### PR DESCRIPTION
The various SSLContexts get their list of default protocols from the arrays in NativeCrypto, and we need to keep it that way for now as some partner code relies on it.

This change ensures those lists contain the TLSv1 protocols unless they're explicitly deprecated and fixes the assertions in StandardNames to only ignore those protocols if they're really deprecated.