### PR TITLE
Support "raw" format for XEC KeySpecs.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/jniutil.cc
+++ b/common/src/jni/main/cpp/conscrypt/jniutil.cc
@@ -352,12 +352,14 @@ int throwForEvpError(JNIEnv* env, int reason, const char* message,
         case EVP_R_MISSING_PARAMETERS:
         case EVP_R_INVALID_PEER_KEY:
         case EVP_R_DECODE_ERROR:
+        case EVP_R_NOT_A_PRIVATE_KEY:
             return throwInvalidKeyException(env, message);
             break;
         case EVP_R_UNSUPPORTED_ALGORITHM:
             return throwNoSuchAlgorithmException(env, message);
             break;
         case EVP_R_INVALID_BUFFER_SIZE:
+        case EVP_R_BUFFER_TOO_SMALL:
             return throwIllegalArgumentException(env, message);
             break;
         default:

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -1228,6 +1228,47 @@ static jlong NativeCrypto_EVP_parse_private_key(JNIEnv* env, jclass, jbyteArray 
     return reinterpret_cast<uintptr_t>(pkey.release());
 }
 
+
+static jbyteArray NativeCrypto_EVP_raw_X25519_private_key(
+        JNIEnv* env, jclass cls, jbyteArray keyJavaBytes) {
+    CHECK_ERROR_QUEUE_ON_RETURN;
+    JNI_TRACE("NativeCrypto_EVP_raw_X25519_private_key(%p)", keyJavaBytes);
+
+    jlong key_ptr = NativeCrypto_EVP_parse_private_key(env, cls, keyJavaBytes);
+    if (key_ptr == 0) {
+        return nullptr;
+    }
+    bssl::UniquePtr<EVP_PKEY> pkey(reinterpret_cast<EVP_PKEY*>(key_ptr));
+    if (EVP_PKEY_id(pkey.get()) != EVP_PKEY_X25519) {
+        conscrypt::jniutil::throwInvalidKeyException(env, "Invalid key type");
+        return nullptr;
+    }
+
+    size_t key_length = X25519_PRIVATE_KEY_LEN;
+    ScopedLocalRef<jbyteArray> byteArray(env, env->NewByteArray(static_cast<jsize>(key_length)));
+    if (byteArray.get() == nullptr) {
+        conscrypt::jniutil::throwOutOfMemory(env, "Allocating byte[]");
+        JNI_TRACE("NativeCrypto_EVP_raw_X25519_private_key: byte array creation failed");
+        return nullptr;
+    }
+
+    ScopedByteArrayRW bytes(env, byteArray.get());
+    if (bytes.get() == nullptr) {
+        conscrypt::jniutil::throwOutOfMemory(env, "Allocating scoped byte array");
+        JNI_TRACE("NativeCrypto_EVP_raw_X25519_private_key: scoped byte array failed");
+        return nullptr;
+    }
+
+    if (EVP_PKEY_get_raw_private_key(
+            pkey.get(), reinterpret_cast<uint8_t *>(bytes.get()),&key_length) == 0) {
+        conscrypt::jniutil::throwExceptionFromBoringSSLError(env, "EVP_PKEY_get_raw_private_key");
+        return nullptr;
+    }
+    jbyteArray result = byteArray.release();
+    JNI_TRACE("bytes=%p NativeCrypto_EVP_raw_X25519_private_key => %p", keyJavaBytes, result);
+    return result;
+}
+
 /*
  * static native byte[] EVP_marshal_public_key(long)
  */
@@ -10994,6 +11035,7 @@ static JNINativeMethod sNativeCryptoMethods[] = {
         CONSCRYPT_NATIVE_METHOD(EVP_PKEY_cmp, "(" REF_EVP_PKEY REF_EVP_PKEY ")I"),
         CONSCRYPT_NATIVE_METHOD(EVP_marshal_private_key, "(" REF_EVP_PKEY ")[B"),
         CONSCRYPT_NATIVE_METHOD(EVP_parse_private_key, "([B)J"),
+        CONSCRYPT_NATIVE_METHOD(EVP_raw_X25519_private_key, "([B)[B"),
         CONSCRYPT_NATIVE_METHOD(EVP_marshal_public_key, "(" REF_EVP_PKEY ")[B"),
         CONSCRYPT_NATIVE_METHOD(EVP_parse_public_key, "([B)J"),
         CONSCRYPT_NATIVE_METHOD(PEM_read_bio_PUBKEY, "(J)J"),

--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -1260,7 +1260,7 @@ static jbyteArray NativeCrypto_EVP_raw_X25519_private_key(
     }
 
     if (EVP_PKEY_get_raw_private_key(
-            pkey.get(), reinterpret_cast<uint8_t *>(bytes.get()),&key_length) == 0) {
+            pkey.get(), reinterpret_cast<uint8_t *>(bytes.get()), &key_length) == 0) {
         conscrypt::jniutil::throwExceptionFromBoringSSLError(env, "EVP_PKEY_get_raw_private_key");
         return nullptr;
     }

--- a/common/src/main/java/org/conscrypt/ArrayUtils.java
+++ b/common/src/main/java/org/conscrypt/ArrayUtils.java
@@ -16,10 +16,12 @@
 
 package org.conscrypt;
 
+import java.util.Arrays;
+
 /**
  * Compatibility utility for Arrays.
  */
-final class ArrayUtils {
+public final class ArrayUtils {
     private ArrayUtils() {}
 
     /**
@@ -33,19 +35,32 @@ final class ArrayUtils {
         }
     }
 
-    static String[] concatValues(String[] a1, String... values) {
+    @SafeVarargs
+    static <T> T[] concatValues(T[] a1, T... values) {
         return concat (a1, values);
     }
 
-    static String[] concat(String[] a1, String[] a2) {
-        String[] result = new String[a1.length + a2.length];
-        int offset = 0;
-        for (int i = 0; i < a1.length; i++, offset++) {
-            result[offset] = a1[i];
-        }
-        for (int i = 0; i < a2.length; i++, offset++) {
-            result[offset] = a2[i];
-        }
+    static <T> T[] concat(T[] a1, T[] a2) {
+        T[] result = Arrays.copyOf(a1, a1.length + a2.length);
+        System.arraycopy(a2, 0, result, a1.length, a2.length);
         return result;
+    }
+
+    public static byte[] concat(byte[] a1, byte[] a2) {
+        byte[] result = Arrays.copyOf(a1, a1.length + a2.length);
+        System.arraycopy(a2, 0, result, a1.length, a2.length);
+        return result;
+    }
+
+    static boolean startsWith(byte[] array, byte[] startsWith) {
+        if (array.length < startsWith.length) {
+            return false;
+        }
+        for (int i = 0; i < startsWith.length; i++) {
+            if (array[i] != startsWith[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -103,6 +103,9 @@ public final class NativeCrypto {
 
     static native byte[] EVP_marshal_public_key(NativeRef.EVP_PKEY pkey);
 
+    static native byte[] EVP_raw_X25519_private_key(byte[] data)
+            throws ParsingException, InvalidKeyException;
+
     static native long EVP_parse_public_key(byte[] data) throws ParsingException;
 
     static native long PEM_read_bio_PUBKEY(long bioCtx);

--- a/common/src/main/java/org/conscrypt/OpenSSLX25519PrivateKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX25519PrivateKey.java
@@ -1,51 +1,60 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.conscrypt;
 
 import java.security.PrivateKey;
+import java.security.spec.EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Arrays;
 
 public class OpenSSLX25519PrivateKey implements OpenSSLX25519Key, PrivateKey {
     private static final long serialVersionUID = -3136201500221850916L;
     private static final byte[] PKCS8_PREAMBLE = new byte[]{
-            0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6e, 0x04, 0x22, 0x04, 0x20,
-    };
-
-    private static final byte[] PKCS8_PREAMBLE_WITH_NULL = new byte[] {
-            0x30, 0x30, 0x02, 0x01, 0x00, 0x30, 0x07, 0x06, 0x03, 0x2B, 0x65, 0x6E, 0x05, 0x00, 0x04, 0x22, 0x04, 0x20,
+            0x30, 0x2e,                            // Sequence: 46 bytes
+                0x02, 0x01, 0x00,                  // Integer: 0 (version)
+                0x30, 0x05,                        // Sequence: 5 bytes
+                    0x06, 0x03, 0x2b, 0x65, 0x6e,  // OID: 1.3.101.110 (X25519)
+                0x04, 0x22, 0x04, 0x20,            // Octet string: 32 bytes
+            // Key bytes follow directly
     };
 
     private byte[] uCoordinate;
 
-    public OpenSSLX25519PrivateKey(PKCS8EncodedKeySpec keySpec) throws InvalidKeySpecException {
+    public OpenSSLX25519PrivateKey(EncodedKeySpec keySpec) throws InvalidKeySpecException {
         byte[] encoded = keySpec.getEncoded();
-        if (encoded == null || !"PKCS#8".equals(keySpec.getFormat())) {
-            throw new InvalidKeySpecException("Key must be encoded in PKCS#8 format");
+        if ("PKCS#8".equals(keySpec.getFormat())) {
+            if (!ArrayUtils.startsWith(encoded, PKCS8_PREAMBLE)) {
+                throw new InvalidKeySpecException("Invalid PKCS#8 data");
+            }
+            uCoordinate = Arrays.copyOfRange(encoded, PKCS8_PREAMBLE.length, encoded.length);
+        } else if ("raw".equalsIgnoreCase(keySpec.getFormat())) {
+            uCoordinate = encoded;
+        } else {
+            throw new InvalidKeySpecException("Encoding must be in PKCS#8 or raw format");
         }
-
-        int preambleLength = matchesPreamble(PKCS8_PREAMBLE, encoded) | matchesPreamble(PKCS8_PREAMBLE_WITH_NULL, encoded);
-        if (preambleLength == 0) {
-            throw new InvalidKeySpecException("Key size is not correct size");
+        if (uCoordinate.length != X25519_KEY_SIZE_BYTES) {
+            throw new InvalidKeySpecException("Invalid key size");
         }
-
-        uCoordinate = Arrays.copyOfRange(encoded, PKCS8_PREAMBLE.length, encoded.length);
-    }
-
-    private static int matchesPreamble(byte[] preamble, byte[] encoded) {
-        if (encoded.length != (preamble.length + X25519_KEY_SIZE_BYTES)) {
-            return 0;
-        }
-        int cmp = 0;
-        for (int i = 0; i < preamble.length; i++) {
-            cmp |= encoded[i] ^ preamble[i];
-        }
-        if (cmp != 0) {
-            return 0;
-        }
-        return preamble.length;
     }
 
     public OpenSSLX25519PrivateKey(byte[] coordinateBytes) {
+        if (coordinateBytes.length != X25519_KEY_SIZE_BYTES) {
+            throw new IllegalArgumentException("Invalid key size");
+        }
         uCoordinate = coordinateBytes.clone();
     }
 
@@ -64,10 +73,7 @@ public class OpenSSLX25519PrivateKey implements OpenSSLX25519Key, PrivateKey {
         if (uCoordinate == null) {
             throw new IllegalStateException("key is destroyed");
         }
-
-        byte[] encoded = Arrays.copyOf(PKCS8_PREAMBLE, PKCS8_PREAMBLE.length + uCoordinate.length);
-        System.arraycopy(uCoordinate, 0, encoded, PKCS8_PREAMBLE.length, uCoordinate.length);
-        return encoded;
+        return ArrayUtils.concat(PKCS8_PREAMBLE, uCoordinate);
     }
 
     @Override
@@ -75,7 +81,6 @@ public class OpenSSLX25519PrivateKey implements OpenSSLX25519Key, PrivateKey {
         if (uCoordinate == null) {
             throw new IllegalStateException("key is destroyed");
         }
-
         return uCoordinate.clone();
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLX25519PublicKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX25519PublicKey.java
@@ -1,52 +1,60 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.conscrypt;
 
 import java.security.PublicKey;
+import java.security.spec.EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
-import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 
 public class OpenSSLX25519PublicKey implements OpenSSLX25519Key, PublicKey {
     private static final long serialVersionUID = 453861992373478445L;
 
     private static final byte[] X509_PREAMBLE = new byte[] {
-            0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6e, 0x03, 0x21, 0x00,
-    };
-
-    private static final byte[] X509_PREAMBLE_WITH_NULL = new byte[] {
-            0x30, 0x2C, 0x30, 0x07, 0x06, 0x03, 0x2B, 0x65, 0x6E, 0x05, 0x00, 0x03, 0x21, 0x00,
+            0x30, 0x2a,                       // Sequence: 42 bytes
+                0x30, 0x05,                   // Sequence: 5 bytes
+                0x06, 0x03, 0x2b, 0x65, 0x6e, // OID: 1.3.101.110 (X25519)
+            0x03, 0x21, 0x00,                 // Bit string: 256 bits
+            // Key bytes follow directly
     };
 
     private final byte[] uCoordinate;
 
-    public OpenSSLX25519PublicKey(X509EncodedKeySpec keySpec) throws InvalidKeySpecException {
+    public OpenSSLX25519PublicKey(EncodedKeySpec keySpec) throws InvalidKeySpecException {
         byte[] encoded = keySpec.getEncoded();
-        if (encoded == null || !"X.509".equals(keySpec.getFormat())) {
-            throw new InvalidKeySpecException("Encoding must be in X.509 format");
+        if ("X.509".equals(keySpec.getFormat())) {
+            if (!ArrayUtils.startsWith(encoded, X509_PREAMBLE)) {
+                throw new InvalidKeySpecException("Invalid format");
+            }
+            uCoordinate = Arrays.copyOfRange(encoded, X509_PREAMBLE.length, encoded.length);
+        } else if ("raw".equalsIgnoreCase(keySpec.getFormat())) {
+            uCoordinate = encoded;
+        } else {
+            throw new InvalidKeySpecException("Encoding must be in X.509 or raw format");
         }
-
-        int preambleLength = matchesPreamble(X509_PREAMBLE, encoded) | matchesPreamble(X509_PREAMBLE_WITH_NULL, encoded);
-        if (preambleLength == 0) {
-            throw new InvalidKeySpecException("Key size is not correct size");
+        if (uCoordinate.length != X25519_KEY_SIZE_BYTES) {
+            throw new InvalidKeySpecException("Invalid key size");
         }
-
-        uCoordinate = Arrays.copyOfRange(encoded, preambleLength, encoded.length);
-    }
-
-    private static int matchesPreamble(byte[] preamble, byte[] encoded) {
-        if (encoded.length != (preamble.length + X25519_KEY_SIZE_BYTES)) {
-            return 0;
-        }
-        int cmp = 0;
-        for (int i = 0; i < preamble.length; i++) {
-            cmp |= encoded[i] ^ preamble[i];
-        }
-        if (cmp != 0) {
-            return 0;
-        }
-        return preamble.length;
     }
 
     public OpenSSLX25519PublicKey(byte[] coordinateBytes) {
+        if (coordinateBytes.length != X25519_KEY_SIZE_BYTES) {
+            throw new IllegalArgumentException("Invalid key size");
+        }
         uCoordinate = coordinateBytes.clone();
     }
 
@@ -66,9 +74,7 @@ public class OpenSSLX25519PublicKey implements OpenSSLX25519Key, PublicKey {
             throw new IllegalStateException("key is destroyed");
         }
 
-        byte[] encoded = Arrays.copyOf(X509_PREAMBLE, X509_PREAMBLE.length + X25519_KEY_SIZE_BYTES);
-        System.arraycopy(uCoordinate, 0, encoded, X509_PREAMBLE.length, uCoordinate.length);
-        return encoded;
+        return (ArrayUtils.concat(X509_PREAMBLE, uCoordinate));
     }
 
     @Override
@@ -76,7 +82,6 @@ public class OpenSSLX25519PublicKey implements OpenSSLX25519Key, PublicKey {
         if (uCoordinate == null) {
             throw new IllegalStateException("key is destroyed");
         }
-
         return uCoordinate.clone();
     }
 
@@ -97,7 +102,6 @@ public class OpenSSLX25519PublicKey implements OpenSSLX25519Key, PublicKey {
         if (uCoordinate == null) {
             throw new IllegalStateException("key is destroyed");
         }
-
         return Arrays.hashCode(uCoordinate);
     }
 }

--- a/common/src/main/java/org/conscrypt/OpenSSLX25519PublicKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX25519PublicKey.java
@@ -40,14 +40,18 @@ public class OpenSSLX25519PublicKey implements OpenSSLX25519Key, PublicKey {
             if (!ArrayUtils.startsWith(encoded, X509_PREAMBLE)) {
                 throw new InvalidKeySpecException("Invalid format");
             }
-            uCoordinate = Arrays.copyOfRange(encoded, X509_PREAMBLE.length, encoded.length);
+            int totalLength = X509_PREAMBLE.length + X25519_KEY_SIZE_BYTES;
+            if (encoded.length < totalLength) {
+                throw new InvalidKeySpecException("Invalid key size");
+            }
+            uCoordinate = Arrays.copyOfRange(encoded, X509_PREAMBLE.length, totalLength);
         } else if ("raw".equalsIgnoreCase(keySpec.getFormat())) {
+            if (encoded.length != X25519_KEY_SIZE_BYTES) {
+                throw new InvalidKeySpecException("Invalid key size");
+            }
             uCoordinate = encoded;
         } else {
             throw new InvalidKeySpecException("Encoding must be in X.509 or raw format");
-        }
-        if (uCoordinate.length != X25519_KEY_SIZE_BYTES) {
-            throw new InvalidKeySpecException("Invalid key size");
         }
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLXDHKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLXDHKeyFactory.java
@@ -25,16 +25,20 @@ import java.security.KeyFactorySpi;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
 /**
- * An implementation of a {@link KeyFactorySpi} for EC keys based on BoringSSL.
+ * An implementation of a {@link KeyFactorySpi} for XEC keys based on BoringSSL.
  */
 @Internal
 public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
+    private final Class<?> javaXECPublicKeySpec = getJavaXECPublicKeySpec();
+    private final Class<?> javaXECPrivateKeySpec = getJavaXECPrivateKeySpec();
+
 
     public OpenSSLXDHKeyFactory() {}
 
@@ -43,14 +47,11 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
         if (keySpec == null) {
             throw new InvalidKeySpecException("keySpec == null");
         }
-
-        if (keySpec instanceof X509EncodedKeySpec) {
-            return new OpenSSLX25519PublicKey((X509EncodedKeySpec) keySpec);
+        if (keySpec instanceof EncodedKeySpec) {
+            return new OpenSSLX25519PublicKey((EncodedKeySpec) keySpec);
         }
-        if (keySpec instanceof XdhKeySpec) {
-            return new OpenSSLX25519PublicKey(((XdhKeySpec) keySpec).getKey());
-        }
-        throw new InvalidKeySpecException("Must use ECPublicKeySpec or X509EncodedKeySpec; was "
+        throw new InvalidKeySpecException(
+                "Must use XECPublicKeySpec, X509EncodedKeySpec or Raw EncodedKeySpec; was "
                 + keySpec.getClass().getName());
     }
 
@@ -59,14 +60,11 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
         if (keySpec == null) {
             throw new InvalidKeySpecException("keySpec == null");
         }
-
-        if (keySpec instanceof PKCS8EncodedKeySpec) {
-            return new OpenSSLX25519PrivateKey((PKCS8EncodedKeySpec) keySpec);
+        if (keySpec instanceof EncodedKeySpec) {
+            return new OpenSSLX25519PrivateKey((EncodedKeySpec) keySpec);
         }
-        if (keySpec instanceof XdhKeySpec) {
-            return new OpenSSLX25519PrivateKey(((XdhKeySpec) keySpec).getKey());
-        }
-        throw new InvalidKeySpecException("Must use ECPrivateKeySpec or PKCS8EncodedKeySpec; was "
+        throw new InvalidKeySpecException(
+                "Must use XECPrivateKeySpec, PKCS8EncodedKeySpec or Raw EncodedKeySpec; was "
                 + keySpec.getClass().getName());
     }
 
@@ -76,61 +74,85 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
         if (key == null) {
             throw new InvalidKeySpecException("key == null");
         }
-
         if (keySpec == null) {
             throw new InvalidKeySpecException("keySpec == null");
         }
-
         // Support XDH or X25519 algorithm names per JEP 324
         if (!"XDH".equals(key.getAlgorithm()) && !"X25519".equals(key.getAlgorithm()) ) {
             throw new InvalidKeySpecException("Key must be an XDH or X25519 key");
         }
-
-        Class<?> publicKeySpec = getJavaPublicKeySpec();
-        Class<?> privateKeySpec = getJavaPrivateKeySpec();
-
-        if (publicKeySpec != null && key instanceof PublicKey && publicKeySpec.isAssignableFrom(keySpec)) {
-            final byte[] encoded = key.getEncoded();
-            if (!"X.509".equals(key.getFormat()) || encoded == null) {
-                throw new InvalidKeySpecException("Not a valid X.509 encoding");
-            }
-            OpenSSLX25519PublicKey publicKey = (OpenSSLX25519PublicKey) engineGeneratePublic(new X509EncodedKeySpec(encoded));
-            @SuppressWarnings("unchecked")
-            T result = (T) constructJavaPublicKeySpec(publicKeySpec, publicKey);
-            return result;
-        } else if (privateKeySpec != null && key instanceof PrivateKey && privateKeySpec.isAssignableFrom(keySpec)) {
-            final byte[] encoded = key.getEncoded();
-            if (!"PKCS#8".equals(key.getFormat()) || encoded == null) {
-                throw new InvalidKeySpecException("Not a valid PKCS#8 encoding");
-            }
-            OpenSSLX25519PrivateKey privateKey = (OpenSSLX25519PrivateKey) engineGeneratePrivate(new PKCS8EncodedKeySpec(encoded));
-            @SuppressWarnings("unchecked")
-            T result = (T) constructJavaPrivateKeySpec(privateKeySpec, privateKey);
-            return result;
-        } else if (key instanceof PrivateKey && PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
-            final byte[] encoded = key.getEncoded();
-            if (!"PKCS#8".equals(key.getFormat())) {
-                throw new InvalidKeySpecException("Encoding type must be PKCS#8; was "
-                        + key.getFormat());
-            } else if (encoded == null) {
-                throw new InvalidKeySpecException("Key is not encodable");
-            }
-            @SuppressWarnings("unchecked") T result = (T) new PKCS8EncodedKeySpec(encoded);
-            return result;
-        } else if (key instanceof PublicKey && X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
-            final byte[] encoded = key.getEncoded();
-            if (!"X.509".equals(key.getFormat())) {
-                throw new InvalidKeySpecException("Encoding type must be X.509; was "
-                        + key.getFormat());
-            } else if (encoded == null) {
-                throw new InvalidKeySpecException("Key is not encodable");
-            }
-            @SuppressWarnings("unchecked") T result = (T) new X509EncodedKeySpec(encoded);
-            return result;
+        if (key.getEncoded() == null) {
+            throw new InvalidKeySpecException("Key is destroyed");
+        }
+        // Convert any "foreign" keys to our own type, this has the same requirements as
+        // converting to a KeySpec below, and is a no-op for our own keys.
+        try {
+            key = engineTranslateKey(key);
+        } catch (InvalidKeyException e) {
+            throw new InvalidKeySpecException("Unsupported key class: " + key.getClass(), e);
         }
 
+        if (key instanceof OpenSSLX25519PublicKey) {
+            OpenSSLX25519PublicKey conscryptKey = (OpenSSLX25519PublicKey) key;
+            if (javaXECPublicKeySpec != null && javaXECPublicKeySpec.isAssignableFrom(keySpec)) {
+                @SuppressWarnings("unchecked")
+                T result = (T) constructJavaXecPublicKeySpec(javaXECPublicKeySpec, conscryptKey);
+                return result;
+            } else if (X509EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+                @SuppressWarnings("unchecked")
+                T result = (T) new X509EncodedKeySpec(key.getEncoded());
+                return result;
+            } else if (keySpec == XdhKeySpec.class) {
+                @SuppressWarnings("unchecked")
+                T result = (T) new XdhKeySpec(conscryptKey.getU());
+                return result;
+            } else if (EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+                return makeRawKeySpec(conscryptKey.getU(), keySpec);
+            }
+        } else if (key instanceof OpenSSLX25519PrivateKey) {
+            OpenSSLX25519PrivateKey conscryptKey = (OpenSSLX25519PrivateKey) key;
+            if (javaXECPrivateKeySpec != null && javaXECPrivateKeySpec.isAssignableFrom(keySpec)) {
+                @SuppressWarnings("unchecked")
+                T result = (T) constructJavaPrivateKeySpec(javaXECPrivateKeySpec, conscryptKey);
+                return result;
+            } else if (PKCS8EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+                @SuppressWarnings("unchecked")
+                T result = (T) new PKCS8EncodedKeySpec(key.getEncoded());
+                return result;
+            } else if (keySpec == XdhKeySpec.class) {
+                @SuppressWarnings("unchecked")
+                T result = (T) new XdhKeySpec(conscryptKey.getU());
+                return result;
+            } else if (EncodedKeySpec.class.isAssignableFrom(keySpec)) {
+                return makeRawKeySpec(conscryptKey.getU(), keySpec);
+            }
+        }
         throw new InvalidKeySpecException("Unsupported key type and key spec combination; key="
                 + key.getClass().getName() + ", keySpec=" + keySpec.getName());
+    }
+
+    private <T extends KeySpec> T makeRawKeySpec(byte[] bytes, Class<T> keySpecClass)
+            throws InvalidKeySpecException {
+        Exception cause;
+        try {
+            Constructor<T> constructor = keySpecClass.getConstructor(byte[].class);
+            T instance = constructor.newInstance((Object) bytes);
+            EncodedKeySpec spec = (EncodedKeySpec) instance;
+            if (!spec.getFormat().equalsIgnoreCase("raw")) {
+                throw new InvalidKeySpecException("EncodedKeySpec class must be raw format");
+            }
+            return instance;
+        } catch (NoSuchMethodException e) {
+            cause = e;
+        } catch (InvocationTargetException e) {
+            cause = e;
+        } catch (InstantiationException e) {
+            cause = e;
+        } catch (IllegalAccessException e) {
+            cause = e;
+        }
+        throw new InvalidKeySpecException("Can't process KeySpec class " + keySpecClass.getName(),
+                cause);
     }
 
     @Override
@@ -161,12 +183,12 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
                 throw new InvalidKeyException(e);
             }
         } else {
-            throw new InvalidKeyException("Key must be EC public or private key; was "
+            throw new InvalidKeyException("Key must be XEC public or private key; was "
                     + key.getClass().getName());
         }
     }
 
-    private static Class<?> getJavaPrivateKeySpec() {
+    private static Class<?> getJavaXECPrivateKeySpec() {
         try {
             return Class.forName("java.security.spec.XECPrivateKeySpec");
         } catch (ClassNotFoundException ignored) {
@@ -174,7 +196,7 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
         }
     }
 
-    private static Class<?> getJavaPublicKeySpec() {
+    private static Class<?> getJavaXECPublicKeySpec() {
         try {
             return Class.forName("java.security.spec.XECPublicKeySpec");
         } catch (ClassNotFoundException ignored) {
@@ -182,41 +204,58 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
         }
     }
 
-    private KeySpec constructJavaPrivateKeySpec(Class<?> privateKeySpec, OpenSSLX25519PrivateKey privateKey) throws InvalidKeySpecException {
+    private KeySpec constructJavaPrivateKeySpec(
+            Class<?> privateKeySpec, OpenSSLX25519PrivateKey privateKey)
+            throws InvalidKeySpecException {
         if (privateKeySpec == null) {
             throw new InvalidKeySpecException("Could not find java.security.spec.XECPrivateKeySpec");
         }
 
+        Exception cause;
         try {
-            Constructor<?> c = privateKeySpec.getConstructor(AlgorithmParameterSpec.class, byte[].class);
+            Constructor<?> c =
+                    privateKeySpec.getConstructor(AlgorithmParameterSpec.class, byte[].class);
             @SuppressWarnings("unchecked")
-            KeySpec result = (KeySpec) c.newInstance(new OpenSSLXECParameterSpec(OpenSSLXECParameterSpec.X25519), privateKey.getU());
+            KeySpec result = (KeySpec) c.newInstance(
+                    new OpenSSLXECParameterSpec(OpenSSLXECParameterSpec.X25519), privateKey.getU());
             return result;
         } catch (NoSuchMethodException e) {
-            throw new InvalidKeySpecException("Could not find java.security.spec.XECPrivateKeySpec", e);
+            cause = e;
         } catch (InstantiationException e) {
-            throw new InvalidKeySpecException("Could not find java.security.spec.XECPrivateKeySpec", e);
+            cause = e;
         } catch (IllegalAccessException e) {
-            throw new InvalidKeySpecException("Could not find java.security.spec.XECPrivateKeySpec", e);
+            cause = e;
         } catch (InvocationTargetException e) {
-            throw new InvalidKeySpecException("Could not find java.security.spec.XECPrivateKeySpec", e);
+            cause = e;
         }
+        throw new InvalidKeySpecException(
+                "Could not find java.security.spec.XECPrivateKeySpec", cause);
     }
 
-    private KeySpec constructJavaPublicKeySpec(Class<?> publicKeySpec, OpenSSLX25519PublicKey publicKey) throws InvalidKeySpecException {
+    private KeySpec constructJavaXecPublicKeySpec(
+            Class<?> publicKeySpec, OpenSSLX25519PublicKey publicKey)
+            throws InvalidKeySpecException {
+        if (publicKeySpec == null) {
+            throw new InvalidKeySpecException("Could not find java.security.spec.XECPublicKeySpec");
+        }
+        Exception cause;
         try {
-            Constructor<?> c = publicKeySpec.getConstructor(AlgorithmParameterSpec.class, BigInteger.class);
+            Constructor<?> c =
+                    publicKeySpec.getConstructor(AlgorithmParameterSpec.class, BigInteger.class);
             @SuppressWarnings("unchecked")
-            KeySpec result = (KeySpec) c.newInstance(new OpenSSLXECParameterSpec(OpenSSLXECParameterSpec.X25519), new BigInteger(1, publicKey.getU()));
+            KeySpec result = (KeySpec) c.newInstance(new OpenSSLXECParameterSpec(
+                    OpenSSLXECParameterSpec.X25519), new BigInteger(1, publicKey.getU()));
             return result;
         } catch (NoSuchMethodException e) {
-            throw new InvalidKeySpecException("Could not find java.security.spec.XECPublicKeySpec", e);
+            cause = e;
         } catch (InstantiationException e) {
-            throw new InvalidKeySpecException("Could not find java.security.spec.XECPublicKeySpec", e);
+            cause = e;
         } catch (IllegalAccessException e) {
-            throw new InvalidKeySpecException("Could not find java.security.spec.XECPublicKeySpec", e);
+            cause = e;
         } catch (InvocationTargetException e) {
-            throw new InvalidKeySpecException("Could not find java.security.spec.XECPublicKeySpec", e);
+            cause = e;
         }
+        throw new InvalidKeySpecException(
+                "Could not find java.security.spec.XECPrivateKeySpec", cause);
     }
 }

--- a/common/src/main/java/org/conscrypt/OpenSSLXDHKeyPairGenerator.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLXDHKeyPairGenerator.java
@@ -47,7 +47,7 @@ public final class OpenSSLXDHKeyPairGenerator extends KeyPairGenerator {
 
     @Override
     public void initialize(int keysize, SecureRandom random) {
-        if (keysize != OpenSSLX25519Key.X25519_KEY_SIZE_BYTES) {
+        if (keysize != OpenSSLX25519Key.X25519_KEY_SIZE_BYTES * 8) {
             throw new IllegalArgumentException("Only X25519 supported");
         }
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLXDHKeyPairGenerator.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLXDHKeyPairGenerator.java
@@ -23,8 +23,8 @@ import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 
 /**
- * An implementation of {@link KeyPairGenerator} for XDH keys which uses BoringSSL to perform all the
- * operations. This only supports X25519 keys.
+ * An implementation of {@link KeyPairGenerator} for XDH keys which uses BoringSSL to perform all
+ * the operations. This only supports X25519 keys.
  */
 @Internal
 public final class OpenSSLXDHKeyPairGenerator extends KeyPairGenerator {
@@ -41,11 +41,15 @@ public final class OpenSSLXDHKeyPairGenerator extends KeyPairGenerator {
 
         NativeCrypto.X25519_keypair(publicKeyBytes, privateKeyBytes);
 
-        return new KeyPair(new OpenSSLX25519PublicKey(publicKeyBytes), new OpenSSLX25519PrivateKey(privateKeyBytes));
+        return new KeyPair(new OpenSSLX25519PublicKey(publicKeyBytes),
+                new OpenSSLX25519PrivateKey(privateKeyBytes));
     }
 
     @Override
     public void initialize(int keysize, SecureRandom random) {
+        if (keysize != OpenSSLX25519Key.X25519_KEY_SIZE_BYTES) {
+            throw new IllegalArgumentException("Only X25519 supported");
+        }
     }
 
     @Override

--- a/common/src/main/java/org/conscrypt/XdhKeySpec.java
+++ b/common/src/main/java/org/conscrypt/XdhKeySpec.java
@@ -1,19 +1,27 @@
 package org.conscrypt;
 
-import java.security.spec.KeySpec;
+import java.security.spec.EncodedKeySpec;
 
 /**
  * External Diffie–Hellman key spec holding a key which could be either a public or private key.
+ *
+ * Subclasses {@code EncodedKeySpec} using the non-Standard "raw" format.  The XdhKeyFactory
+ * class utilises this in order to create XDH keys from raw bytes and to return them
+ * as an XdhKeySpec allowing the raw key material to be extracted from an XDH key.
+ *
  */
-public final class XdhKeySpec implements KeySpec {
-    private final byte[] key;
-
+public final class XdhKeySpec extends EncodedKeySpec {
     /**
      * Creates an instance of {@link XdhKeySpec} by passing a public or private key in its raw
      * format.
      */
-    public XdhKeySpec(byte[] key) {
-        this.key = key;
+    public XdhKeySpec(byte[] encoded) {
+        super(encoded);
+    }
+
+    @Override
+    public String getFormat() {
+        return "raw";
     }
 
     /**
@@ -22,6 +30,6 @@ public final class XdhKeySpec implements KeySpec {
      * @return key in its raw format.
      */
     public byte[] getKey() {
-        return key;
+        return getEncoded();
     }
 }

--- a/common/src/test/java/org/conscrypt/ArrayUtilsTest.java
+++ b/common/src/test/java/org/conscrypt/ArrayUtilsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ArrayUtilsTest {
+    @Test
+    public void offsetCount() {
+        byte[] data = bytes("Some data");
+        for (int offset = 0; offset <= data.length; offset++) {
+            for (int length = 0; length <= data.length - offset; length++) {
+                ArrayUtils.checkOffsetAndCount(data.length, offset, length);
+            }
+        }
+        assertThrows(ArrayIndexOutOfBoundsException.class,
+                () -> ArrayUtils.checkOffsetAndCount(data.length, 0, data.length + 1));
+        assertThrows(ArrayIndexOutOfBoundsException.class,
+                () -> ArrayUtils.checkOffsetAndCount(data.length, data.length, 1));
+
+    }
+
+    @Test
+    public void offsetCount_Empty() {
+        ArrayUtils.checkOffsetAndCount(0, 0, 0);
+        assertThrows(ArrayIndexOutOfBoundsException.class,
+                () -> ArrayUtils.checkOffsetAndCount(0, 0, 1));
+        assertThrows(ArrayIndexOutOfBoundsException.class,
+                () -> ArrayUtils.checkOffsetAndCount(0, 1, 0));
+    }
+
+    @Test
+    public void concatStringArrays() {
+        String[] data = new String[] {"a", "b", "c", "d", "e", "f"};
+        for (int i = 0; i <= data.length; i++) {
+            String[] a1 = Arrays.copyOfRange(data, 0, i);
+            String[] a2 = Arrays.copyOfRange(data, i, data.length);
+            assertArrayEquals(data, ArrayUtils.concat(a1, a2));
+        }
+    }
+
+    @Test
+    public void concatStringValues() {
+        String[] expected = new String[] { "a", "b", "c",};
+
+        assertArrayEquals(expected,
+                ArrayUtils.concatValues(new String[] {}, "a", "b", "c"));
+        assertArrayEquals(expected,
+                ArrayUtils.concatValues(new String[] { "a" }, "b", "c"));
+        assertArrayEquals(expected,
+                ArrayUtils.concatValues(new String[] { "a", "b" }, "c"));
+        assertArrayEquals(expected,
+                ArrayUtils.concatValues(new String[] { "a", "b", "c" }));
+    }
+
+    @Test
+    public void concatByteArrays() {
+        byte[] data = bytes("Some bytes");
+        for (int i = 0; i <= data.length; i++) {
+            byte[] a1 = Arrays.copyOfRange(data, 0, i);
+            byte[] a2 = Arrays.copyOfRange(data, i, data.length);
+            assertArrayEquals(data, ArrayUtils.concat(a1, a2));
+        }
+    }
+
+    @Test
+    public void startsWith() {
+        byte[] data = bytes("OneTwoThree");
+        assertTrue(ArrayUtils.startsWith(data, bytes("One")));
+        assertTrue(ArrayUtils.startsWith(data, bytes("")));
+        assertFalse(ArrayUtils.startsWith(data, bytes("Two")));
+    }
+
+    @Test
+    public void startsWith_Empty() {
+        byte[] data = new byte[0];
+        assertFalse(ArrayUtils.startsWith(data, bytes("One")));
+        assertTrue(ArrayUtils.startsWith(data, bytes("")));
+    }
+
+ static byte[] bytes(String string) {
+        return string.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyFactoryTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.javax.crypto;
+
+import static org.conscrypt.TestUtils.decodeBase64;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.EncodedKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+import org.conscrypt.OpenSSLX25519PrivateKey;
+import org.conscrypt.OpenSSLX25519PublicKey;
+import org.conscrypt.TestUtils;
+import org.conscrypt.XdhKeySpec;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class XdhKeyFactoryTest {
+    private final byte[] publicKeyX509Bytes =
+            decodeBase64("MCowBQYDK2VuAyEAeNH3ZKS7SCZT495bvIvoyYB9PNIFefUSTfi6eNhFYXA=");
+    private final byte[] privateKeyPkcs8Bytes =
+            decodeBase64("MC4CAQAwBQYDK2VuBCIEIADBSHEZer+X0ZdqReHuMDx61nQwWwNHOnx9HHRNJBJK");
+    private final KeyFactory factory = KeyFactory.getInstance("XDH");
+    private final PublicKey publicKey =
+            factory.generatePublic(new X509EncodedKeySpec(publicKeyX509Bytes));
+    private final PrivateKey privateKey =
+            factory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyPkcs8Bytes));
+
+    private final byte[] publicKeyRawBytes = ((OpenSSLX25519PublicKey) publicKey).getU();
+    private final byte[] privateKeyRawBytes = ((OpenSSLX25519PrivateKey) privateKey).getU();
+
+    public XdhKeyFactoryTest() throws NoSuchAlgorithmException, InvalidKeySpecException {
+    }
+
+    @Test
+    public void constructor() {
+        // Class init already implicitly tests generating public and private keys from their
+        // encoded format, but we still need to check the opposite translation.
+        assertEquals("X.509", publicKey.getFormat());
+        assertArrayEquals(publicKeyX509Bytes, publicKey.getEncoded());
+
+        assertEquals("PKCS#8", privateKey.getFormat());
+        assertArrayEquals(privateKeyPkcs8Bytes, privateKey.getEncoded());
+
+    }
+    @Test
+    public void generatePublic() throws Exception {
+        PublicKey key = factory.generatePublic(new XdhKeySpec(publicKeyRawBytes));
+        assertTrue(key instanceof OpenSSLX25519PublicKey);
+        assertEquals("X.509", key.getFormat());
+        assertArrayEquals(publicKeyX509Bytes, key.getEncoded());
+        assertEquals(publicKey, key);
+        assertNotSame(publicKey, key);
+
+        key = factory.generatePublic(new TestKeySpec(publicKeyRawBytes));
+        assertTrue(key instanceof OpenSSLX25519PublicKey);
+        assertEquals("X.509", key.getFormat());
+        assertArrayEquals(publicKeyX509Bytes, key.getEncoded());
+        assertEquals(publicKey, key);
+        assertNotSame(publicKey, key);
+    }
+
+    @Test
+    public void generatePrivate() throws Exception{
+        PrivateKey key = factory.generatePrivate(new XdhKeySpec(privateKeyRawBytes));
+        assertTrue(key instanceof OpenSSLX25519PrivateKey);
+        assertEquals("PKCS#8", key.getFormat());
+        assertArrayEquals(privateKeyPkcs8Bytes, key.getEncoded());
+        assertEquals(privateKey, key);
+        assertNotSame(privateKey, key);
+
+        key = factory.generatePrivate(new TestKeySpec(privateKeyRawBytes));
+        assertTrue(key instanceof OpenSSLX25519PrivateKey);
+        assertEquals("PKCS#8", key.getFormat());
+        assertArrayEquals(privateKeyPkcs8Bytes, key.getEncoded());
+        assertEquals(privateKey, key);
+        assertNotSame(privateKey, key);
+    }
+
+    @Test
+    public void publicKeySpec_Success() throws Exception {
+        X509EncodedKeySpec x509Spec = factory.getKeySpec(publicKey, X509EncodedKeySpec.class);
+        assertArrayEquals(publicKeyX509Bytes, x509Spec.getEncoded());
+
+        XdhKeySpec xdhSpec = factory.getKeySpec(publicKey, XdhKeySpec.class);
+        assertArrayEquals(publicKeyRawBytes, xdhSpec.getEncoded());
+
+        TestKeySpec testSpec = factory.getKeySpec(publicKey, TestKeySpec.class);
+        assertArrayEquals(publicKeyRawBytes, testSpec.getEncoded());
+
+        x509Spec = factory.getKeySpec(new TestPublicKey(), X509EncodedKeySpec.class);
+        assertArrayEquals(publicKeyX509Bytes, x509Spec.getEncoded());
+    }
+
+    @Test
+    public void privateKeySpec_Success() throws Exception {
+        PKCS8EncodedKeySpec pkcs8Spec = factory.getKeySpec(privateKey, PKCS8EncodedKeySpec.class);
+        assertArrayEquals(privateKeyPkcs8Bytes, pkcs8Spec.getEncoded());
+
+        XdhKeySpec xdhSpec = factory.getKeySpec(privateKey, XdhKeySpec.class);
+        assertArrayEquals(privateKeyRawBytes, xdhSpec.getEncoded());
+
+        TestKeySpec testSpec = factory.getKeySpec(privateKey, TestKeySpec.class);
+        assertArrayEquals(privateKeyRawBytes, testSpec.getEncoded());
+
+        pkcs8Spec = factory.getKeySpec(new TestPrivateKey(), PKCS8EncodedKeySpec.class);
+        assertArrayEquals(privateKeyPkcs8Bytes, pkcs8Spec.getEncoded());
+    }
+
+    @Test
+    public void keySpec_Fail() throws Exception {
+        assertThrows(InvalidKeySpecException.class,
+                () -> factory.getKeySpec(publicKey, PKCS8EncodedKeySpec.class));
+        PrivateKey privateKey = factory.generatePrivate(
+                new PKCS8EncodedKeySpec(privateKeyPkcs8Bytes));
+        assertThrows(InvalidKeySpecException.class,
+                () -> factory.getKeySpec(privateKey, X509EncodedKeySpec.class));
+
+        assertThrows(InvalidKeySpecException.class, () -> factory.getKeySpec(
+                new TestPublicKeyWrongEncoding(), X509EncodedKeySpec.class));
+        assertThrows(InvalidKeySpecException.class, () -> factory.getKeySpec(
+                new TestPrivateKeyWrongEncoding(), PKCS8EncodedKeySpec.class));
+
+        assertThrows(InvalidKeySpecException.class,
+                () -> factory.getKeySpec(publicKey, TestKeySpecWrongEncoding.class));
+        assertThrows(InvalidKeySpecException.class,
+                () -> factory.getKeySpec(privateKey, TestKeySpecWrongEncoding.class));
+
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        KeyPair kp = kpg.generateKeyPair();
+
+        assertThrows(InvalidKeySpecException.class,
+                () -> factory.getKeySpec(kp.getPublic(), X509EncodedKeySpec.class));
+        assertThrows(InvalidKeySpecException.class,
+                () -> factory.getKeySpec(kp.getPrivate(), PKCS8EncodedKeySpec.class));
+    }
+
+    @Test
+    public void xecPublicKeySpec() throws Exception {
+        // TODO(prb): Finish this
+        TestUtils.assumeXecClassesAvailable();
+        @SuppressWarnings("unchecked")
+        Class<? extends KeySpec> javaClass = (Class<? extends KeySpec>)
+                TestUtils.findClass("java.security.spec.XECPublicKeySpec");
+        PublicKey key = factory.generatePublic(new X509EncodedKeySpec(publicKeyX509Bytes));
+        KeySpec spec = factory.getKeySpec(key, javaClass);
+        assertNotNull(spec);
+    }
+
+    @Test
+    public void xecPrivateKeySpec() throws Exception {
+        // TODO(prb): Finish this
+        TestUtils.assumeXecClassesAvailable();
+        @SuppressWarnings("unchecked")
+        Class<? extends KeySpec> javaClass = (Class<? extends KeySpec>)
+                TestUtils.findClass("java.security.spec.XECPrivateKeySpec");
+        PrivateKey key = factory.generatePrivate(new X509EncodedKeySpec(privateKeyPkcs8Bytes));
+        KeySpec spec = factory.getKeySpec(key, javaClass);
+        assertNotNull(spec);
+    }
+
+    @Test
+    public void translate() throws Exception {
+        TestPublicKey testPublicKey = new TestPublicKey();
+        Key translatedPublicKey = factory.translateKey(testPublicKey);
+        assertTrue(translatedPublicKey instanceof OpenSSLX25519PublicKey);
+        assertEquals(publicKey, translatedPublicKey);
+        assertNotSame(publicKey, translatedPublicKey);
+
+        TestPrivateKey testPrivateKey = new TestPrivateKey();
+        Key translatedPrivateKey = factory.translateKey(testPrivateKey);
+        assertTrue(translatedPrivateKey instanceof OpenSSLX25519PrivateKey);
+        assertEquals(privateKey, translatedPrivateKey);
+        assertNotSame(privateKey, translatedPrivateKey);
+
+        translatedPublicKey = factory.translateKey(publicKey);
+        assertSame(publicKey, translatedPublicKey);
+
+        translatedPrivateKey = factory.translateKey(privateKey);
+        assertSame(privateKey, translatedPrivateKey);
+    }
+
+    @Test
+    public void translate_Fail() throws Exception {
+        assertThrows(InvalidKeyException.class,
+                () -> factory.translateKey(new TestPublicKeyWrongEncoding()));
+        assertThrows(InvalidKeyException.class,
+                () -> factory.translateKey(new TestPrivateKeyWrongEncoding()));
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        KeyPair kp = kpg.generateKeyPair();
+        assertThrows(InvalidKeyException.class,
+                () -> factory.translateKey(kp.getPublic()));
+        assertThrows(InvalidKeyException.class,
+                () -> factory.translateKey(kp.getPrivate()));
+    }
+
+    /**
+     * "foreign" KeySpec class which implements raw encoding.
+     */
+    public static final class TestKeySpec extends EncodedKeySpec {
+        public TestKeySpec(byte[] encodedKey) {
+            super(encodedKey);
+        }
+
+        @Override
+        public String getFormat() {
+            return "raw";
+        }
+    }
+    /**
+     * "foreign" KeySpec class which *doesn't* implement raw encoding.
+     */
+    public static final class TestKeySpecWrongEncoding extends EncodedKeySpec {
+        public TestKeySpecWrongEncoding(byte[] encodedKey) {
+            super(encodedKey);
+        }
+
+        @Override
+        public String getFormat() {
+            return "wrong";
+        }
+    }
+
+    /**
+     * "foreign" public key class which implements XDH and X.509
+     */
+    private final class TestPublicKey implements PublicKey {
+        @Override
+        public String getAlgorithm() {
+            return "XDH";
+        }
+
+        @Override
+        public String getFormat() {
+            return "X.509";
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return publicKeyX509Bytes;
+        }
+    }
+    /**
+     * "foreign" public key class which implements XDH and but not X.509
+     */
+    private final class TestPublicKeyWrongEncoding implements PublicKey {
+        @Override
+        public String getAlgorithm() {
+            return "XDH";
+        }
+
+        @Override
+        public String getFormat() {
+            return "Some Format";
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return publicKeyX509Bytes;
+        }
+    }
+    /**
+     * "foreign" private key class which implements XDH and PKCS#8
+     */
+    private final class TestPrivateKey implements PrivateKey {
+        @Override
+        public String getAlgorithm() {
+            return "XDH";
+        }
+
+        @Override
+        public String getFormat() {
+            return "PKCS#8";
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return privateKeyPkcs8Bytes;
+        }
+    }
+    /**
+     * "foreign" private key class which implements XDH but not PKCS#8
+     */
+    private final class TestPrivateKeyWrongEncoding implements PrivateKey {
+        @Override
+        public String getAlgorithm() {
+            return "XDH";
+        }
+
+        @Override
+        public String getFormat() {
+            return "Some Format";
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return privateKeyPkcs8Bytes;
+        }
+    }
+}

--- a/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyTest.java
+++ b/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt.javax.crypto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+import javax.crypto.KeyAgreement;
+import org.conscrypt.ArrayUtils;
+import org.conscrypt.OpenSSLX25519PrivateKey;
+import org.conscrypt.OpenSSLX25519PublicKey;
+import org.conscrypt.OpenSSLXDHKeyPairGenerator;
+import org.conscrypt.XdhKeySpec;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class XdhKeyTest {
+    private final OpenSSLXDHKeyPairGenerator generator = new OpenSSLXDHKeyPairGenerator();
+    private final KeyPair keyPair = generator.generateKeyPair();
+    private final OpenSSLX25519PublicKey publicKey = (OpenSSLX25519PublicKey) keyPair.getPublic();
+    private final byte[] publicKeyBytes = publicKey.getU();
+    private final OpenSSLX25519PrivateKey privateKey = (OpenSSLX25519PrivateKey) keyPair.getPrivate();
+    private final byte[] privateKeyBytes = privateKey.getU();
+
+    @Test
+    public void constructor() throws Exception {
+        assertKeysWork(publicKey, privateKey);
+    }
+
+    @Test
+    public void publicKey_Raw() throws Exception {
+        OpenSSLX25519PublicKey copy = new OpenSSLX25519PublicKey(publicKeyBytes);
+        assertEquals(publicKey, copy);
+        assertNotSame(publicKey, copy);
+        assertKeysWork(copy, privateKey);
+        assertThrows(IllegalArgumentException.class,
+                () -> new OpenSSLX25519PublicKey(loseOneByte(publicKeyBytes)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new OpenSSLX25519PublicKey(gainOneByte(publicKeyBytes)));
+    }
+
+    @Test
+    public void publicKey_RawSpec() throws Exception {
+        OpenSSLX25519PublicKey copy = new OpenSSLX25519PublicKey(new XdhKeySpec(publicKeyBytes));
+        assertEquals(publicKey, copy);
+        assertNotSame(publicKey, copy);
+        assertKeysWork(copy, privateKey);
+
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PublicKey(new XdhKeySpec(loseOneByte(publicKeyBytes))));
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PublicKey(new XdhKeySpec(gainOneByte(publicKeyBytes))));
+    }
+
+    @Test
+    public void publicKey_X509() throws Exception {
+        assertEquals("X.509", publicKey.getFormat());
+        byte[] x509bytes = publicKey.getEncoded();
+
+        OpenSSLX25519PublicKey copy = new OpenSSLX25519PublicKey(new X509EncodedKeySpec(x509bytes));
+        assertEquals(publicKey, copy);
+        assertNotSame(publicKey, copy);
+        assertKeysWork(copy, privateKey);
+
+        // Flip a bit in the X.509 preamble
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PublicKey(new X509EncodedKeySpec(flipBit(x509bytes))));
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PublicKey(new X509EncodedKeySpec(loseOneByte(x509bytes))));
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PublicKey(new X509EncodedKeySpec(gainOneByte(x509bytes))));
+    }
+
+    @Test
+    public void privateKey_Raw() throws Exception {
+        OpenSSLX25519PrivateKey copy = new OpenSSLX25519PrivateKey(privateKeyBytes);
+        assertEquals(privateKey, copy);
+        assertNotSame(privateKey, copy);
+        assertKeysWork(publicKey, copy);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new OpenSSLX25519PrivateKey(loseOneByte(privateKeyBytes)));
+        assertThrows(IllegalArgumentException.class,
+                () -> new OpenSSLX25519PrivateKey(gainOneByte(privateKeyBytes)));
+    }
+
+    @Test
+    public void privateKey_RawSpec() throws Exception {
+        // Create copy of key via raw EncodedKeySpec
+        OpenSSLX25519PrivateKey copy = new OpenSSLX25519PrivateKey(new XdhKeySpec(privateKeyBytes));
+        assertEquals(privateKey, copy);
+        assertNotSame(privateKey, copy);
+        assertKeysWork(publicKey, copy);
+
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PrivateKey(new XdhKeySpec(loseOneByte(publicKeyBytes))));
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PrivateKey(new XdhKeySpec(gainOneByte(publicKeyBytes))));
+    }
+
+    @Test
+    public void privateKey_X509() throws Exception {
+        assertEquals("PKCS#8", privateKey.getFormat());
+        byte[] pkcs8Bytes = privateKey.getEncoded();
+
+        OpenSSLX25519PrivateKey copy =
+                new OpenSSLX25519PrivateKey(new PKCS8EncodedKeySpec(pkcs8Bytes));
+        assertEquals(privateKey, copy);
+        assertNotSame(privateKey, copy);
+        assertKeysWork(publicKey, copy);
+
+        assertThrows(InvalidKeySpecException.class, () ->
+                new OpenSSLX25519PrivateKey(new PKCS8EncodedKeySpec(flipBit(pkcs8Bytes))));
+        assertThrows(InvalidKeySpecException.class, () ->
+                new OpenSSLX25519PrivateKey(new PKCS8EncodedKeySpec(loseOneByte(pkcs8Bytes))));
+        assertThrows(InvalidKeySpecException.class, () ->
+                new OpenSSLX25519PrivateKey(new PKCS8EncodedKeySpec(gainOneByte(pkcs8Bytes))));
+    }
+
+    @Test
+    public void destruction() {
+        OpenSSLX25519PrivateKey privateCopy = new OpenSSLX25519PrivateKey(privateKeyBytes);
+        privateCopy.destroy();
+        assertTrue(privateCopy.isDestroyed());
+    }
+
+    private void assertKeysWork(PublicKey publicKey, PrivateKey privateKey) throws Exception {
+        // Ideally we should check public is derived from private here too, but math is hard.
+        KeyAgreement ka = KeyAgreement.getInstance("XDH");
+        ka.init(privateKey);
+        ka.doPhase(publicKey, true);
+        assertNotNull(ka.generateSecret());
+    }
+
+    private byte[] loseOneByte(byte[] input) {
+        return Arrays.copyOfRange(input, 0, input.length - 1);
+    }
+
+    private byte[] gainOneByte(byte[] input) {
+        return ArrayUtils.concat(input, new byte[1]);
+    }
+
+    private byte[] flipBit(byte[] input) {
+        byte[] corrupted = input.clone();
+        // Offset 3 chosen by fair dice roll.
+        corrupted[3] = (byte) (corrupted[3] ^ 0x01);
+        return corrupted;
+    }
+}

--- a/openjdk/src/test/java/org/conscrypt/ConscryptOpenJdkSuite.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptOpenJdkSuite.java
@@ -53,6 +53,8 @@ import org.conscrypt.javax.crypto.ECDHKeyAgreementTest;
 import org.conscrypt.javax.crypto.KeyGeneratorTest;
 import org.conscrypt.javax.crypto.ScryptTest;
 import org.conscrypt.javax.crypto.XDHKeyAgreementTest;
+import org.conscrypt.javax.crypto.XdhKeyFactoryTest;
+import org.conscrypt.javax.crypto.XdhKeyTest;
 import org.conscrypt.javax.net.ssl.HttpsURLConnectionTest;
 import org.conscrypt.javax.net.ssl.KeyManagerFactoryTest;
 import org.conscrypt.javax.net.ssl.KeyStoreBuilderParametersTest;
@@ -82,6 +84,7 @@ import org.junit.runners.Suite;
         // org.conscrypt tests
         AddressUtilsTest.class,
         ApplicationProtocolSelectorAdapterTest.class,
+        ArrayUtilsTest.class,
         CertPinManagerTest.class,
         ChainStrengthAnalyzerTest.class,
         ClientSessionContextTest.class,
@@ -147,6 +150,8 @@ import org.junit.runners.Suite;
         ECDHKeyAgreementTest.class,
         KeyGeneratorTest.class,
         XDHKeyAgreementTest.class,
+        XdhKeyFactoryTest.class,
+        XdhKeyTest.class,
         // javax.net.ssl tests
         HttpsURLConnectionTest.class,
         KeyManagerFactoryTest.class,

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -348,7 +348,6 @@ public final class TestUtils {
 
     // Return a Class by name or null
     public static Class<?> findClass(String name) {
-        ClassNotFoundException ex = null;
         try {
             return Class.forName(name);
         } catch (ClassNotFoundException ignored) {

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -346,6 +346,16 @@ public final class TestUtils {
         throw ex;
     }
 
+    // Return a Class by name or null
+    public static Class<?> findClass(String name) {
+        ClassNotFoundException ex = null;
+        try {
+            return Class.forName(name);
+        } catch (ClassNotFoundException ignored) {
+            return null;
+        }
+    }
+
     static SSLSocketFactory setUseEngineSocket(
             SSLSocketFactory conscryptFactory, boolean useEngineSocket) {
         try {
@@ -846,6 +856,10 @@ public final class TestUtils {
     public static boolean isOsx() {
         String name = osName();
         return name.startsWith("macosx") || name.startsWith("osx");
+    }
+
+    public static void assumeXecClassesAvailable() {
+        Assume.assumeTrue(findClass("java.security.spec.XECPrivateKeySpec") != null);
     }
 
     // Find base method via reflection due to visibility issues when building with Gradle.


### PR DESCRIPTION
XdhKeySpec now implements "raw" EncodedKeySpec, allowing better interoperability between a Conscrypt client API and a difference Conscrypt implementation.

As a precursor to this, added missing tests for XDH keys and key factories and tidied the implementation.