### PR TITLE
Replace test RSA-512 keys with RSA-2048

### DIFF
--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -114,83 +114,46 @@ public class NativeCryptoTest {
     private static RSAPrivateCrtKey TEST_RSA_KEY;
 
     @BeforeClass
-    public static void getPlatformMethods() throws Exception {
+    @SuppressWarnings("JdkObsolete") // Public API KeyStore.aliases() uses Enumeration
+    public static void initStatics() throws Exception {
         Class<?> c_Platform = TestUtils.conscryptClass("Platform");
         m_Platform_getFileDescriptor =
                 c_Platform.getDeclaredMethod("getFileDescriptor", Socket.class);
         m_Platform_getFileDescriptor.setAccessible(true);
-    }
 
-    private static OpenSSLKey getServerPrivateKey() {
-        initCerts();
-        return SERVER_PRIVATE_KEY;
-    }
+        PrivateKeyEntry serverPrivateKeyEntry = TestKeyStore.getServer().getPrivateKey("RSA", "RSA");
+        SERVER_PRIVATE_KEY = OpenSSLKey.fromPrivateKey(serverPrivateKeyEntry.getPrivateKey());
+        SERVER_CERTIFICATES_HOLDER = encodeCertificateList(serverPrivateKeyEntry.getCertificateChain());
+        SERVER_CERTIFICATE_REFS = getCertificateReferences(SERVER_CERTIFICATES_HOLDER);
+        ENCODED_SERVER_CERTIFICATES = getEncodedCertificates(SERVER_CERTIFICATES_HOLDER);
 
-    private static long[] getServerCertificateRefs() {
-        initCerts();
-        return SERVER_CERTIFICATE_REFS;
-    }
+        PrivateKeyEntry clientPrivateKeyEntry = TestKeyStore.getClientCertificate().getPrivateKey("RSA", "RSA");
+        CLIENT_PRIVATE_KEY = OpenSSLKey.fromPrivateKey(clientPrivateKeyEntry.getPrivateKey());
+        CLIENT_CERTIFICATES_HOLDER = encodeCertificateList(clientPrivateKeyEntry.getCertificateChain());
+        CLIENT_CERTIFICATE_REFS = getCertificateReferences(CLIENT_CERTIFICATES_HOLDER);
+        ENCODED_CLIENT_CERTIFICATES = getEncodedCertificates(CLIENT_CERTIFICATES_HOLDER);
 
-    private static byte[][] getEncodedServerCertificates() {
-        initCerts();
-        return ENCODED_SERVER_CERTIFICATES;
-    }
+        KeyStore ks = TestKeyStore.getClient().keyStore;
+        String caCertAlias = ks.aliases().nextElement();
+        X509Certificate certificate = (X509Certificate) ks.getCertificate(caCertAlias);
+        X500Principal principal = certificate.getIssuerX500Principal();
+        CA_PRINCIPALS = new byte[][] { principal.getEncoded() };
 
-    private static OpenSSLKey getClientPrivateKey() {
-        initCerts();
-        return CLIENT_PRIVATE_KEY;
-    }
+        // NIST P-256 aka SECG secp256r1 aka X9.62 prime256v1
+        OpenSSLECGroupContext openSslSpec = OpenSSLECGroupContext.getCurveByName("prime256v1");
+        BigInteger s = new BigInteger(
+                "229cdbbf489aea584828a261a23f9ff8b0f66f7ccac98bf2096ab3aee41497c5", 16);
+        CHANNEL_ID_PRIVATE_KEY = new OpenSSLECPrivateKey(new ECPrivateKeySpec(s, openSslSpec.getECParameterSpec()))
+                .getOpenSSLKey();
 
-    private static long[] getClientCertificateRefs() {
-        initCerts();
-        return CLIENT_CERTIFICATE_REFS;
-    }
+        // Channel ID is the concatenation of the X and Y coordinates of the public key.
+        CHANNEL_ID = new BigInteger(
+                "702b07871fd7955c320b26f15e244e47eed60272124c92b9ebecf0b42f90069b"
+                        + "ab53592ebfeb4f167dbf3ce61513afb0e354c479b1c1b69874fa471293494f77",
+                16).toByteArray();
 
-    private static byte[][] getEncodedClientCertificates() {
-        initCerts();
-        return ENCODED_CLIENT_CERTIFICATES;
-    }
-
-    private static byte[][] getCaPrincipals() {
-        initCerts();
-        return CA_PRINCIPALS;
-    }
-
-    /**
-     * Lazily create shared test certificates.
-     */
-    @SuppressWarnings("JdkObsolete") // Public API KeyStore.aliases() uses Enumeration
-    private static synchronized void initCerts() {
-        if (SERVER_PRIVATE_KEY != null) {
-            return;
-        }
-
-        try {
-            PrivateKeyEntry serverPrivateKeyEntry =
-                    TestKeyStore.getServer().getPrivateKey("RSA", "RSA");
-            SERVER_PRIVATE_KEY = OpenSSLKey.fromPrivateKey(serverPrivateKeyEntry.getPrivateKey());
-            SERVER_CERTIFICATES_HOLDER =
-                    encodeCertificateList(serverPrivateKeyEntry.getCertificateChain());
-            SERVER_CERTIFICATE_REFS = getCertificateReferences(SERVER_CERTIFICATES_HOLDER);
-            ENCODED_SERVER_CERTIFICATES = getEncodedCertificates(SERVER_CERTIFICATES_HOLDER);
-
-            PrivateKeyEntry clientPrivateKeyEntry =
-                    TestKeyStore.getClientCertificate().getPrivateKey("RSA", "RSA");
-            CLIENT_PRIVATE_KEY = OpenSSLKey.fromPrivateKey(clientPrivateKeyEntry.getPrivateKey());
-            CLIENT_CERTIFICATES_HOLDER =
-                    encodeCertificateList(clientPrivateKeyEntry.getCertificateChain());
-            CLIENT_CERTIFICATE_REFS = getCertificateReferences(CLIENT_CERTIFICATES_HOLDER);
-            ENCODED_CLIENT_CERTIFICATES = getEncodedCertificates(CLIENT_CERTIFICATES_HOLDER);
-
-            KeyStore ks = TestKeyStore.getClient().keyStore;
-            String caCertAlias = ks.aliases().nextElement();
-            X509Certificate certificate = (X509Certificate) ks.getCertificate(caCertAlias);
-            X500Principal principal = certificate.getIssuerX500Principal();
-            CA_PRINCIPALS = new byte[][] {principal.getEncoded()};
-            initChannelIdKey();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        // RSA keys are slow to generate, so prefer to reuse the key when possible.
+        TEST_RSA_KEY = generateRsaKey();
     }
 
     private static long[] getCertificateReferences(OpenSSLX509Certificate[] certs) {
@@ -222,40 +185,12 @@ public class NativeCryptoTest {
         return openSslCerts;
     }
 
-    private static synchronized void initChannelIdKey() throws Exception {
-        if (CHANNEL_ID_PRIVATE_KEY != null) {
-            return;
-        }
-
-        // NIST P-256 aka SECG secp256r1 aka X9.62 prime256v1
-        OpenSSLECGroupContext openSslSpec = OpenSSLECGroupContext.getCurveByName("prime256v1");
-        BigInteger s = new BigInteger(
-                "229cdbbf489aea584828a261a23f9ff8b0f66f7ccac98bf2096ab3aee41497c5", 16);
-        CHANNEL_ID_PRIVATE_KEY =
-                new OpenSSLECPrivateKey(new ECPrivateKeySpec(s, openSslSpec.getECParameterSpec()))
-                        .getOpenSSLKey();
-
-        // Channel ID is the concatenation of the X and Y coordinates of the public key.
-        CHANNEL_ID = new BigInteger(
-                "702b07871fd7955c320b26f15e244e47eed60272124c92b9ebecf0b42f90069b"
-                        + "ab53592ebfeb4f167dbf3ce61513afb0e354c479b1c1b69874fa471293494f77",
-                16).toByteArray();
-    }
-
     private static RSAPrivateCrtKey generateRsaKey() throws Exception {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         kpg.initialize(2048);
 
         KeyPair keyPair = kpg.generateKeyPair();
         return (RSAPrivateCrtKey) keyPair.getPrivate();
-    }
-
-    private static synchronized RSAPrivateCrtKey getTestRsaKey() throws Exception {
-        // RSA keys are slow to generate, so prefer to reuse the key when possible.
-        if (TEST_RSA_KEY == null) {
-            TEST_RSA_KEY = generateRsaKey();
-        }
-        return TEST_RSA_KEY;
     }
 
     private static NativeRef.EVP_PKEY getRsaPkey(RSAPrivateCrtKey privKey) throws Exception {
@@ -297,7 +232,7 @@ public class NativeCryptoTest {
 
     @Test(expected = NullPointerException.class)
     public void EVP_PKEY_cmp_withNullShouldThrow() throws Exception {
-        RSAPrivateCrtKey privKey1 = getTestRsaKey();
+        RSAPrivateCrtKey privKey1 = TEST_RSA_KEY;
         NativeRef.EVP_PKEY pkey1 = getRsaPkey(privKey1);
         assertNotSame(NULL, pkey1);
         NativeCrypto.EVP_PKEY_cmp(pkey1, null);
@@ -305,7 +240,7 @@ public class NativeCryptoTest {
 
     @Test
     public void test_EVP_PKEY_cmp() throws Exception {
-        RSAPrivateCrtKey privKey1 = getTestRsaKey();
+        RSAPrivateCrtKey privKey1 = TEST_RSA_KEY;
 
         NativeRef.EVP_PKEY pkey1 = getRsaPkey(privKey1);
         assertNotSame(NULL, pkey1);
@@ -403,7 +338,7 @@ public class NativeCryptoTest {
     @Test(expected = NullPointerException.class)
     public void setLocalCertsAndPrivateKey_withNullSSLShouldThrow() throws Exception {
         NativeCrypto.setLocalCertsAndPrivateKey(
-                NULL, null, getEncodedServerCertificates(), getServerPrivateKey().getNativeRef());
+                NULL, null, ENCODED_SERVER_CERTIFICATES, SERVER_PRIVATE_KEY.getNativeRef());
     }
 
     @Test(expected = NullPointerException.class)
@@ -411,7 +346,7 @@ public class NativeCryptoTest {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c, null);
         try {
-            NativeCrypto.setLocalCertsAndPrivateKey(s, null, null, getServerPrivateKey().getNativeRef());
+            NativeCrypto.setLocalCertsAndPrivateKey(s, null, null, SERVER_PRIVATE_KEY.getNativeRef());
         } finally {
             NativeCrypto.SSL_free(s, null);
             NativeCrypto.SSL_CTX_free(c, null);
@@ -423,7 +358,7 @@ public class NativeCryptoTest {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c, null);
         try {
-            NativeCrypto.setLocalCertsAndPrivateKey(s, null, getEncodedServerCertificates(), null);
+            NativeCrypto.setLocalCertsAndPrivateKey(s, null, ENCODED_SERVER_CERTIFICATES, null);
         } finally {
             NativeCrypto.SSL_free(s, null);
             NativeCrypto.SSL_CTX_free(c, null);
@@ -436,7 +371,7 @@ public class NativeCryptoTest {
         long s = NativeCrypto.SSL_new(c, null);
 
         NativeCrypto.setLocalCertsAndPrivateKey(
-                s, null, getEncodedServerCertificates(), getServerPrivateKey().getNativeRef());
+                s, null, ENCODED_SERVER_CERTIFICATES, SERVER_PRIVATE_KEY.getNativeRef());
 
         NativeCrypto.SSL_free(s, null);
         NativeCrypto.SSL_CTX_free(c, null);
@@ -449,8 +384,6 @@ public class NativeCryptoTest {
 
     @Test(expected = NullPointerException.class)
     public void SSL_set1_tls_channel_id_withNullKeyShouldThrow() throws Exception {
-        initChannelIdKey();
-
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c, null);
         try {
@@ -463,8 +396,6 @@ public class NativeCryptoTest {
 
     @Test
     public void test_SSL_use_PrivateKey_for_tls_channel_id() throws Exception {
-        initChannelIdKey();
-
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c, null);
 
@@ -1101,7 +1032,7 @@ public class NativeCryptoTest {
         // normal client and server case
         final ServerSocket listener = newServerSocket();
         Hooks cHooks = new Hooks();
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
         Future<TestSSLHandshakeCallbacks> server =
                 handshake(listener, 0, false, sHooks, null, null);
@@ -1109,7 +1040,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
         assertEqualCertificateChains(
-                getServerCertificateRefs(), clientCallback.certificateChainRefs);
+                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertFalse(serverCallback.verifyCertificateChainCalled);
         assertFalse(clientCallback.clientCertificateRequestedCalled);
@@ -1138,7 +1069,7 @@ public class NativeCryptoTest {
             }
         }, null, null);
         Future<TestSSLHandshakeCallbacks> server1 = handshake(listener, 0,
-                false, new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+                false, new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                     @Override
                     public void configureCallbacks(TestSSLHandshakeCallbacks callbacks) {
                         callbacks.onNewSessionEstablishedSaveSession = true;
@@ -1148,7 +1079,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks serverCallback1 = server1.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback1.verifyCertificateChainCalled);
         assertEqualCertificateChains(
-                getServerCertificateRefs(), clientCallback1.certificateChainRefs);
+                SERVER_CERTIFICATE_REFS, clientCallback1.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback1.authMethod);
         assertFalse(serverCallback1.verifyCertificateChainCalled);
         assertFalse(clientCallback1.clientCertificateRequestedCalled);
@@ -1178,7 +1109,7 @@ public class NativeCryptoTest {
             }
         }, null, null);
         Future<TestSSLHandshakeCallbacks> server2 = handshake(listener, 0,
-                false, new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+                false, new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                     @Override
                     public long beforeHandshake(long c) throws SSLException {
                         long sslNativePtr = super.beforeHandshake(c);
@@ -1190,7 +1121,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks serverCallback2 = server2.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback2.verifyCertificateChainCalled);
         assertEqualCertificateChains(
-                getServerCertificateRefs(), clientCallback2.certificateChainRefs);
+                SERVER_CERTIFICATE_REFS, clientCallback2.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback2.authMethod);
         assertFalse(serverCallback2.verifyCertificateChainCalled);
         assertFalse(clientCallback2.clientCertificateRequestedCalled);
@@ -1221,14 +1152,14 @@ public class NativeCryptoTest {
                     throws CertificateEncodingException, SSLException {
                 super.clientCertificateRequested(s);
                 NativeCrypto.setLocalCertsAndPrivateKey(
-                        s, null, getEncodedClientCertificates(), getClientPrivateKey().getNativeRef());
+                        s, null, ENCODED_CLIENT_CERTIFICATES, CLIENT_PRIVATE_KEY.getNativeRef());
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public long beforeHandshake(long c) throws SSLException {
                 long s = super.beforeHandshake(c);
-                NativeCrypto.SSL_set_client_CA_list(s, null, getCaPrincipals());
+                NativeCrypto.SSL_set_client_CA_list(s, null, CA_PRINCIPALS);
                 NativeCrypto.SSL_set_verify(s, null, SSL_VERIFY_PEER);
                 return s;
             }
@@ -1240,11 +1171,11 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
         assertEqualCertificateChains(
-                getServerCertificateRefs(), clientCallback.certificateChainRefs);
+                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertTrue(serverCallback.verifyCertificateChainCalled);
         assertEqualCertificateChains(
-                getClientCertificateRefs(), serverCallback.certificateChainRefs);
+                CLIENT_CERTIFICATE_REFS, serverCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", serverCallback.authMethod);
 
         assertTrue(clientCallback.clientCertificateRequestedCalled);
@@ -1253,7 +1184,7 @@ public class NativeCryptoTest {
         assertEquals(new HashSet<String>(Arrays.asList("EC", "RSA")),
                 SSLUtils.getSupportedClientKeyTypes(
                         clientCallback.keyTypes, clientCallback.signatureAlgs));
-        assertEqualPrincipals(getCaPrincipals(), clientCallback.asn1DerEncodedX500Principals);
+        assertEqualPrincipals(CA_PRINCIPALS, clientCallback.asn1DerEncodedX500Principals);
         assertFalse(serverCallback.clientCertificateRequestedCalled);
 
         assertFalse(clientCallback.clientPSKKeyRequestedInvoked);
@@ -1274,11 +1205,11 @@ public class NativeCryptoTest {
         final ServerSocket listener = newServerSocket();
         try {
             Hooks cHooks = new Hooks();
-            Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+            Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                 @Override
                 public long beforeHandshake(long c) throws SSLException {
                     long s = super.beforeHandshake(c);
-                    NativeCrypto.SSL_set_client_CA_list(s, null, getCaPrincipals());
+                    NativeCrypto.SSL_set_client_CA_list(s, null, CA_PRINCIPALS);
                     NativeCrypto.SSL_set_verify(
                             s, null, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
                     return s;
@@ -1303,7 +1234,7 @@ public class NativeCryptoTest {
         Socket serverSocket = null;
         try {
             Hooks cHooks = new Hooks();
-            Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+            Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
             Future<TestSSLHandshakeCallbacks> client =
                     handshake(listener, 1, true, cHooks, null, null);
             Future<TestSSLHandshakeCallbacks> server =
@@ -1326,7 +1257,7 @@ public class NativeCryptoTest {
         Socket clientSocket = null;
         try {
             Hooks cHooks = new Hooks();
-            Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+            Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
             Future<TestSSLHandshakeCallbacks> client =
                     handshake(listener, -1, true, cHooks, null, null);
             Future<TestSSLHandshakeCallbacks> server =
@@ -1344,15 +1275,13 @@ public class NativeCryptoTest {
 
     @Test
     public void test_SSL_do_handshake_with_channel_id_normal() throws Exception {
-        initChannelIdKey();
-
         // Normal handshake with TLS Channel ID.
         final ServerSocket listener = newServerSocket();
         Hooks cHooks = new Hooks();
         cHooks.channelIdPrivateKey = CHANNEL_ID_PRIVATE_KEY;
         // TLS Channel ID currently requires ECDHE-based key exchanges.
         cHooks.enabledCipherSuites = Collections.singletonList("ECDHE-RSA-AES128-SHA");
-        ServerHooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        ServerHooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         sHooks.channelIdEnabled = true;
         sHooks.enabledCipherSuites = cHooks.enabledCipherSuites;
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
@@ -1362,7 +1291,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
         assertEqualCertificateChains(
-                getServerCertificateRefs(), clientCallback.certificateChainRefs);
+                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertFalse(serverCallback.verifyCertificateChainCalled);
         assertFalse(clientCallback.clientCertificateRequestedCalled);
@@ -1383,15 +1312,13 @@ public class NativeCryptoTest {
 
     @Test
     public void test_SSL_do_handshake_with_channel_id_not_supported_by_server() throws Exception {
-        initChannelIdKey();
-
         // Client tries to use TLS Channel ID but the server does not enable/offer the extension.
         final ServerSocket listener = newServerSocket();
         Hooks cHooks = new Hooks();
         cHooks.channelIdPrivateKey = CHANNEL_ID_PRIVATE_KEY;
         // TLS Channel ID currently requires ECDHE-based key exchanges.
         cHooks.enabledCipherSuites = Collections.singletonList("ECDHE-RSA-AES128-SHA");
-        ServerHooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        ServerHooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         sHooks.channelIdEnabled = false;
         sHooks.enabledCipherSuites = cHooks.enabledCipherSuites;
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
@@ -1401,7 +1328,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
         assertEqualCertificateChains(
-                getServerCertificateRefs(), clientCallback.certificateChainRefs);
+                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertFalse(serverCallback.verifyCertificateChainCalled);
         assertFalse(clientCallback.clientCertificateRequestedCalled);
@@ -1422,15 +1349,13 @@ public class NativeCryptoTest {
 
     @Test
     public void test_SSL_do_handshake_with_channel_id_not_enabled_by_client() throws Exception {
-        initChannelIdKey();
-
         // Client does not use TLS Channel ID when the server has the extension enabled/offered.
         final ServerSocket listener = newServerSocket();
         Hooks cHooks = new Hooks();
         cHooks.channelIdPrivateKey = null;
         // TLS Channel ID currently requires ECDHE-based key exchanges.
         cHooks.enabledCipherSuites = Collections.singletonList("ECDHE-RSA-AES128-SHA");
-        ServerHooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        ServerHooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         sHooks.channelIdEnabled = true;
         sHooks.enabledCipherSuites = cHooks.enabledCipherSuites;
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
@@ -1440,7 +1365,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
         assertEqualCertificateChains(
-                getServerCertificateRefs(), clientCallback.certificateChainRefs);
+                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertFalse(serverCallback.verifyCertificateChainCalled);
         assertFalse(clientCallback.clientCertificateRequestedCalled);
@@ -1687,7 +1612,7 @@ public class NativeCryptoTest {
             }
         };
 
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public long beforeHandshake(long c) throws SSLException {
                 long s = super.beforeHandshake(c);
@@ -1730,7 +1655,7 @@ public class NativeCryptoTest {
             }
         };
 
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public long beforeHandshake(long c) throws SSLException {
                 long s = super.beforeHandshake(c);
@@ -1813,7 +1738,7 @@ public class NativeCryptoTest {
                     }
                 };
                 Hooks sHooks = new ServerHooks(
-                        getServerPrivateKey(), getEncodedServerCertificates()) {
+                        SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                     @Override
                     public long getContext() throws SSLException {
                         return serverContext;
@@ -1853,7 +1778,7 @@ public class NativeCryptoTest {
                     }
                 };
                 Hooks sHooks = new ServerHooks(
-                        getServerPrivateKey(), getEncodedServerCertificates()) {
+                        SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                     @Override
                     public long getContext() throws SSLException {
                         return serverContext;
@@ -1905,7 +1830,7 @@ public class NativeCryptoTest {
                     return s;
                 }
             };
-            Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+            Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
             Future<TestSSLHandshakeCallbacks> client =
                     handshake(listener, 0, true, cHooks, null, null);
             @SuppressWarnings("unused")
@@ -1928,7 +1853,7 @@ public class NativeCryptoTest {
         // negative test case for SSL_set_session_creation_enabled(false) on server
         {
             Hooks cHooks = new Hooks();
-            Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+            Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                 @Override
                 public long beforeHandshake(long c) throws SSLException {
                     long s = super.beforeHandshake(c);
@@ -2013,7 +1938,7 @@ public class NativeCryptoTest {
                 return s;
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public void afterHandshake(long session, long s, long c, Socket sock, FileDescriptor fd,
                     SSLHandshakeCallbacks callback) throws Exception {
@@ -2044,7 +1969,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, ssl, context, socket, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public void afterHandshake(long session, long ssl, long c, Socket sock,
                     FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
@@ -2079,7 +2004,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, ssl, context, socket, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public void afterHandshake(long session, long ssl, long c, Socket sock,
                     FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
@@ -2112,7 +2037,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, ssl, context, socket, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public void afterHandshake(long session, long ssl, long c, Socket sock,
                     FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
@@ -2151,7 +2076,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, ssl, context, socket, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public void afterHandshake(long session, long ssl, long c, Socket sock,
                     FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
@@ -2206,11 +2131,11 @@ public class NativeCryptoTest {
             public void afterHandshake(long session, long s, long c, Socket sock, FileDescriptor fd,
                     SSLHandshakeCallbacks callback) throws Exception {
                 byte[][] cc = NativeCrypto.SSL_get0_peer_certificates(s, null);
-                assertEqualByteArrays(getEncodedServerCertificates(), cc);
+                assertEqualByteArrays(ENCODED_SERVER_CERTIFICATES, cc);
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
         Future<TestSSLHandshakeCallbacks> server =
                 handshake(listener, 0, false, sHooks, null, null);
@@ -2222,7 +2147,7 @@ public class NativeCryptoTest {
     public void test_SSL_cipher_names() throws Exception {
         final ServerSocket listener = newServerSocket();
         Hooks cHooks = new Hooks();
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         // Both legacy and standard names are accepted.
         cHooks.enabledCipherSuites = Collections.singletonList("ECDHE-RSA-AES128-GCM-SHA256");
         sHooks.enabledCipherSuites =
@@ -2311,7 +2236,7 @@ public class NativeCryptoTest {
                     super.afterHandshake(session, s, c, sock, fd, callback);
                 }
             };
-            Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+            Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                 @Override
                 public void afterHandshake(long session, long s, long c, Socket sock,
                         FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
@@ -2337,7 +2262,7 @@ public class NativeCryptoTest {
                     fail();
                 }
             };
-            Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+            Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                 @Override
                 public void afterHandshake(long session, long s, long c, Socket sock,
                         FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
@@ -2438,7 +2363,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates()) {
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override
             public void afterHandshake(long session, final long s, long c, Socket sock,
                     FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
@@ -2554,7 +2479,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
         Future<TestSSLHandshakeCallbacks> server =
                 handshake(listener, 0, false, sHooks, null, null);
@@ -2582,7 +2507,7 @@ public class NativeCryptoTest {
                     super.afterHandshake(session, s, c, sock, fd, callback);
                 }
             };
-            Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+            Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
             Future<TestSSLHandshakeCallbacks> client =
                     handshake(listener, 0, true, cHooks, null, null);
             Future<TestSSLHandshakeCallbacks> server =
@@ -2610,7 +2535,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
         Future<TestSSLHandshakeCallbacks> server =
                 handshake(listener, 0, false, sHooks, null, null);
@@ -2639,7 +2564,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
         Future<TestSSLHandshakeCallbacks> server =
                 handshake(listener, 0, false, sHooks, null, null);
@@ -2683,7 +2608,7 @@ public class NativeCryptoTest {
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
         };
-        Hooks sHooks = new ServerHooks(getServerPrivateKey(), getEncodedServerCertificates());
+        Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES);
         Future<TestSSLHandshakeCallbacks> client = handshake(listener, 0, true, cHooks, null, null);
         Future<TestSSLHandshakeCallbacks> server =
                 handshake(listener, 0, false, sHooks, null, null);
@@ -2758,7 +2683,7 @@ public class NativeCryptoTest {
 
     @Test
     public void test_EVP_DigestSignInit() throws Exception {
-        RSAPrivateCrtKey privKey = getTestRsaKey();
+        RSAPrivateCrtKey privKey = TEST_RSA_KEY;
 
         NativeRef.EVP_PKEY pkey;
         pkey = new NativeRef.EVP_PKEY(NativeCrypto.EVP_PKEY_new_RSA(
@@ -3074,7 +2999,7 @@ public class NativeCryptoTest {
     }
 
     private static long getRawPkeyCtxForEncrypt() throws Exception {
-        return NativeCrypto.EVP_PKEY_encrypt_init(getRsaPkey(getTestRsaKey()));
+        return NativeCrypto.EVP_PKEY_encrypt_init(getRsaPkey(TEST_RSA_KEY));
     }
 
     private static NativeRef.EVP_PKEY_CTX getPkeyCtxForEncrypt() throws Exception {

--- a/openjdk/src/test/java/org/conscrypt/OpenSSLKeyTest.java
+++ b/openjdk/src/test/java/org/conscrypt/OpenSSLKeyTest.java
@@ -23,29 +23,64 @@ import junit.framework.TestCase;
 public class OpenSSLKeyTest extends TestCase {
     static final String RSA_PUBLIC_KEY =
         "-----BEGIN PUBLIC KEY-----\n" +
-        "MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAOHsK2E2FLYfEMWEVH/rJMTqDZLLLysh\n" +
-        "AH5odcfhYdF9xvFFU9rqJT7zXUDH4SjdhZGUUAO5IOC1e8ZIyRsbiY0CAwEAAQ==\n" +
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3G7PGpfZx68wTY9eLb4b\n" +
+        "th3Y7MXgh1A2oqB202KTiClKy9Y+Z+HCx5KIXXcycVjAfhK7qG+F/XVeE0TpzR8c\n" +
+        "0wj2e3kxwS/wiMjoYXIcbFW0iN6g1F6n71Zykf0uOE8DZKCffzjmld+Ia5M4qKsC\n" +
+        "gW4TTUODGVChBUTKui4b7Q8qsBOUTXm7SeyuZcZRChZ2w9aICZ3OR1qHnG0EXvgs\n" +
+        "0ZhCIgvtVQPaEwqMWaGYQKa8hW9X3KUvY6D8fQkQdhY2j5m/y2757tNsQWhH7l/C\n" +
+        "gdH/2F7qa3+V1yTqj9ihceLq1/FxAZkd6q7G9YE8ZyvtoKU86o6+4arMELQi86QF\n" +
+        "cQIDAQAB\n" +
         "-----END PUBLIC KEY-----";
 
     static final String RSA_PRIVATE_KEY =
         "-----BEGIN RSA PRIVATE KEY-----\n" +
-        "MIIBOgIBAAJBAOHsK2E2FLYfEMWEVH/rJMTqDZLLLyshAH5odcfhYdF9xvFFU9rq\n" +
-        "JT7zXUDH4SjdhZGUUAO5IOC1e8ZIyRsbiY0CAwEAAQJBALcu+oGJC0QcbknpIWbT\n" +
-        "L+4mZTkYXLeYu8DDTHT0j47+6eEyYBOoRGcZDdlMWquvFIrV48RSot0GPh1MBE1p\n" +
-        "lKECIQD4krM4UshCwUHH9ZVkoxcPsxzPTTW7ukky4RZVN6mgWQIhAOisOAXVVjon\n" +
-        "fbGNQ6CezH7oOttEeZmiWCu48AVCyixVAiAaDZ41OA//Vywi3i2jV6iyH47Ud347\n" +
-        "R+ImMAtcMTJZOQIgF0+Z1UvIdc8bErzad68xQc22h91WaYQQXWEL+xrz8nkCIDcA\n" +
-        "MpCP/H5qTCj/l5rxQg+/NUGCg2pHHNLL+cy5N5RM\n" +
+        "MIIEpAIBAAKCAQEA3G7PGpfZx68wTY9eLb4bth3Y7MXgh1A2oqB202KTiClKy9Y+\n" +
+        "Z+HCx5KIXXcycVjAfhK7qG+F/XVeE0TpzR8c0wj2e3kxwS/wiMjoYXIcbFW0iN6g\n" +
+        "1F6n71Zykf0uOE8DZKCffzjmld+Ia5M4qKsCgW4TTUODGVChBUTKui4b7Q8qsBOU\n" +
+        "TXm7SeyuZcZRChZ2w9aICZ3OR1qHnG0EXvgs0ZhCIgvtVQPaEwqMWaGYQKa8hW9X\n" +
+        "3KUvY6D8fQkQdhY2j5m/y2757tNsQWhH7l/CgdH/2F7qa3+V1yTqj9ihceLq1/Fx\n" +
+        "AZkd6q7G9YE8ZyvtoKU86o6+4arMELQi86QFcQIDAQABAoIBABkX4iqoU6nYJxsF\n" +
+        "MZbqd9QdBLc7dWph9r4/nxdENwA+lx2qN3Ny703xv+VH7u2ZSVxwvH0ZqPqn9Dwk\n" +
+        "UatAmfLqJ8j5jHDuCKdBm7aQG203unQER/G1Ds//ms5EsJDHad74K//7FcDE8A4y\n" +
+        "9bW5tfDO+5KFl3R3ycTERoG4QwSSyb8qGbA5Xo+C+9EK9ldE5f7tnryXpG/iCHem\n" +
+        "NanAF+Jxof1GanaCD6xQDug4ReEqZrWWwtco89qfNNSXEpH05hPmgl35UKO9RQn5\n" +
+        "07EtowT+WwDEQ/8zMmuL+z/hEf1LiHKCLH8oMtr6D+ENmroiMQhJ6XjlHIqp2nvB\n" +
+        "wHUR2IMCgYEA++hWbdHxZ3I+QvBIjUKF6OfWkN0ZHVWU9ZNTZoG4ggdxlm5XN+C7\n" +
+        "tohumtChIU0oNkdG38akyN5HlTg+tbd7E0ZgBnYMwAsEEXt5aEoFtFAxEorI26zr\n" +
+        "uvWqRwXNFVKTuC9+JFZvFiteYMSWzryn8dS2cNVG1hswGa1kf0Xg218CgYEA4AOS\n" +
+        "F1snvadqxocM7U8LpY8mSeXV5PayZN87GLFaK41G/zD0l+mVZAWZld9ux+rR/2OP\n" +
+        "uPWZWtn/+4v2DERukA0jerGdFocCv1s893Stoz/oVapCW0h6pa+Fa6EX2nuqNST0\n" +
+        "bE/dbHhfYditfoGQhQlOLmqrJc+B6jaOt+m7oS8CgYBVvwxMbX4inDydRHUtwEsc\n" +
+        "sG3U+a2m0o7V2MQ2zEkl2arMbdq6ZoD+7QnZINL4Ju9dKn3xhghpZ2AuZurRqBb4\n" +
+        "xKfDC0Pjytwjp0f4O9odOn65tQwR2paTGTRQ4KSicW1e8KubauB9R13kyoYa8RSp\n" +
+        "uKIxXieykaaZ1u+ycvLLOQKBgQC1PU5SRTbm82+pBZTI3t4eaa3htekTISD+CbnH\n" +
+        "ZZ39hIT/bH1H9v0d+oXjQu1fI7YZOVULoPEdFylLPFaqYCdPtsGQv+jHVB498bRm\n" +
+        "xOjDHq57uI+NSRupt1Nr297vroPsEWULyKXt34nUITllE7B4Yin11el4YuXKN6/K\n" +
+        "Tnm2kwKBgQC6Qy/DiFeF5uf0xnAkh0HFjzL+F3isIUV5l31jzna2sJSKridm+Hst\n" +
+        "mnaNDu/BKViEvSof3IpW8f7PSzskc4+Fos1KMdCkxG3bNrym8OLdWi+J4NjTbbCa\n" +
+        "sudhqm8rNr8zWFAEZ48jpcv7whYfkjCIh4z0uVNOq9dspolJaW14yg==\n" +
         "-----END RSA PRIVATE KEY-----";
 
     static final BigInteger RSA_MODULUS = new BigInteger(
-        "e1ec2b613614b61f10c584547feb24c4ea0d92cb2f2b21007e6875c7e161d17d" +
-        "c6f14553daea253ef35d40c7e128dd8591945003b920e0b57bc648c91b1b898d", 16);
+        "dc6ecf1a97d9c7af304d8f5e2dbe1bb61dd8ecc5e0875036a2a076d362938829" +
+        "4acbd63e67e1c2c792885d77327158c07e12bba86f85fd755e1344e9cd1f1cd3" +
+        "08f67b7931c12ff088c8e861721c6c55b488dea0d45ea7ef567291fd2e384f03" +
+        "64a09f7f38e695df886b9338a8ab02816e134d43831950a10544caba2e1bed0f" +
+        "2ab013944d79bb49ecae65c6510a1676c3d688099dce475a879c6d045ef82cd1" +
+        "9842220bed5503da130a8c59a19840a6bc856f57dca52f63a0fc7d0910761636" +
+        "8f99bfcb6ef9eed36c416847ee5fc281d1ffd85eea6b7f95d724ea8fd8a171e2" +
+        "ead7f17101991deaaec6f5813c672beda0a53cea8ebee1aacc10b422f3a40571", 16);
 
     static final BigInteger RSA_PUBLIC_EXPONENT = new BigInteger("10001", 16);
     static final BigInteger RSA_PRIVATE_EXPONENT = new BigInteger(
-        "b72efa81890b441c6e49e92166d32fee266539185cb798bbc0c34c74f48f8efe" +
-        "e9e1326013a84467190dd94c5aabaf148ad5e3c452a2dd063e1d4c044d6994a1", 16);
+        "1917e22aa853a9d8271b053196ea77d41d04b73b756a61f6be3f9f174437003e" +
+        "971daa377372ef4df1bfe547eeed99495c70bc7d19a8faa7f43c2451ab4099f2" +
+        "ea27c8f98c70ee08a7419bb6901b6d37ba740447f1b50ecfff9ace44b090c769" +
+        "def82bfffb15c0c4f00e32f5b5b9b5f0cefb9285977477c9c4c44681b8430492" +
+        "c9bf2a19b0395e8f82fbd10af65744e5feed9ebc97a46fe20877a635a9c017e2" +
+        "71a1fd466a76820fac500ee83845e12a66b596c2d728f3da9f34d4971291f4e6" +
+        "13e6825df950a3bd4509f9d3b12da304fe5b00c443ff33326b8bfb3fe111fd4b" +
+        "8872822c7f2832dafa0fe10d9aba22310849e978e51c8aa9da7bc1c07511d883", 16);
 
     public void test_fromPublicKeyPemInputStream() throws Exception {
         ByteArrayInputStream is = new ByteArrayInputStream(RSA_PUBLIC_KEY.getBytes("UTF-8"));


### PR DESCRIPTION
RSA-512 was factored in 1999, before Android even existed. Test with a more plausible key size. Since generating RSA keys is a little slow (0.1s), I've made NativeCryptoTest reuse a single generated test key.