### PR TITLE
Fix NativeCrypto.X509_verify() exceptions.

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -535,7 +535,7 @@ public final class NativeCrypto {
     static native byte[] X509_get_serialNumber(long x509ctx, OpenSSLX509Certificate holder);
 
     static native void X509_verify(long x509ctx, OpenSSLX509Certificate holder, NativeRef.EVP_PKEY pkeyCtx)
-            throws BadPaddingException;
+            throws BadPaddingException, IllegalBlockSizeException;
 
     static native byte[] get_X509_tbs_cert(long x509ctx, OpenSSLX509Certificate holder);
 

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.TimeZone;
 
 import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
 import javax.security.auth.x500.X500Principal;
 import org.conscrypt.OpenSSLX509CertificateFactory.ParsingException;
 
@@ -384,8 +385,8 @@ public final class OpenSSLX509Certificate extends X509Certificate {
             NativeCrypto.X509_verify(mContext, this, pkey.getNativeRef());
         } catch (RuntimeException e) {
             throw new CertificateException(e);
-        } catch (BadPaddingException e) {
-            throw new SignatureException();
+        } catch (BadPaddingException | IllegalBlockSizeException e) {
+            throw new SignatureException(e);
         }
     }
 


### PR DESCRIPTION
Re-throw IllegalBlockSizeException as SignatureException from OpenSSLX509Certificate.verify(), as per the API contract and fix the signature in NativeCrypto.

The only other user of the native method, OpenSSLX509CRL, already had this fix.