### PR TITLE
Add support for Linux aarch64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,11 @@ subprojects {
                         }
                     }
                 }
-                gcc(Gcc)
+                gcc(Gcc) {
+                    target("linux_aarch64") {
+                        cppCompiler.executable = "/usr/bin/gcc"
+                    }
+                }
             }
         }
     }

--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -3,7 +3,7 @@ description = 'Conscrypt: OpenJdk UberJAR'
 ext {
     buildUberJar = Boolean.parseBoolean(System.getProperty('org.conscrypt.openjdk.buildUberJar', 'false'))
     uberJarClassifiers = (System.getProperty('org.conscrypt.openjdk.uberJarClassifiers',
-            'osx-x86_64,osx-aarch_64,linux-x86_64,windows-x86_64')).split(',')
+            'osx-x86_64,osx-aarch_64,linux-x86_64,linux-aarch_64,windows-x86_64')).split(',')
     classesDir = "${buildDir}/classes"
     resourcesDir = "${buildDir}/resources"
     sourcesDir = "${buildDir}/sources"

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -22,6 +22,7 @@ description = 'Conscrypt: OpenJdk'
 enum NativeBuildInfo {
     WINDOWS_X86_64("windows", "x86_64"),
     LINUX_X86_64("linux", "x86_64"),
+    LINUX_AARCH64("linux", "aarch_64"),
     MAC_X86_64("osx", "x86_64") {
         String libDir() {
             "build.x86"
@@ -116,8 +117,14 @@ ext {
     jniSourceDir = "$rootDir/common/src/jni"
     assert file("$jniSourceDir").exists()
 
-    // Decide which targets we should build and test
-    nativeBuilds = NativeBuildInfo.findAll("${osdetector.os}")
+    // Decide which targets we should build and test:
+    // - if osx, build both x86 and aarch64
+    // - if linux, build current architecture because it doesn't support cross-compilation
+    if ("${osdetector.os}" == "osx") {
+        nativeBuilds = NativeBuildInfo.findAll("${osdetector.os}")
+    } else {
+        nativeBuilds = [NativeBuildInfo.find("${osdetector.os}", "${osdetector.arch}")]
+    }
     buildToTest = NativeBuildInfo.find("${osdetector.os}", "${osdetector.arch}")
 
     assert !nativeBuilds.isEmpty() : "No native builds selected."


### PR DESCRIPTION
- add gcc target for linux-aarch64

- for linux, build only current architecture

- boring SSL build command is the same as linux x86 platform