### PR TITLE
Use CMAKE_MSVC_RUNTIME_LIBRARY to select BoringSSL C runtime.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           & $Env:GITHUB_WORKSPACE\.github\workflows\vsenv.ps1 -arch x64 -hostArch x64
           mkdir build64
           pushd build64
-          cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE=/MT -DCMAKE_CXX_FLAGS_RELEASE=/MT -GNinja ..
+          cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -GNinja ..
           ninja
           popd
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -110,8 +110,7 @@ mkdir build64
 cd build64
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ^
       -DCMAKE_BUILD_TYPE=Release ^
-      -DCMAKE_C_FLAGS_RELEASE=/MT ^
-      -DCMAKE_CXX_FLAGS_RELEASE=/MT ^
+      -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded ^
       -GNinja ..
 ninja
 ```


### PR DESCRIPTION
Use CMAKE_MSVC_RUNTIME_LIBRARY to select BoringSSL C runtime.

Fixes CI on Windows.

Unsure exactly what triggered it upstream but without this, cmake
starting adding /MD to the cflags and overriding ours, causing
link errors.  Switching Conscrypt to /MT causes runtime crashes.

This fix seems better than setting the flags directly anyway.

Maybe worth upstreaming as the default unless there are use cases
for CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL