### PR TITLE
Add uid logging to tls_handshakes

### DIFF
--- a/android-stub/src/main/java/android/util/StatsEvent.java
+++ b/android-stub/src/main/java/android/util/StatsEvent.java
@@ -69,6 +69,10 @@ public final class StatsEvent {
             throw new RuntimeException("Stub!");
         }
 
+        public StatsEvent.Builder writeIntArray(int[] values) {
+            throw new RuntimeException("Stub!");
+        }
+
         public StatsEvent.Builder writeLong(long value) {
             throw new RuntimeException("Stub!");
         }

--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -20,8 +20,10 @@ import static org.conscrypt.metrics.Source.SOURCE_GMS;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.os.Binder;
 import android.os.Build;
 import android.os.SystemClock;
+import android.system.Os;
 import android.util.Log;
 import dalvik.system.BlockGuard;
 import dalvik.system.CloseGuard;
@@ -945,7 +947,7 @@ final class Platform {
     private static void writeStats(
             boolean success, int protocol, int cipherSuite, int duration) {
         ConscryptStatsLog.write(ConscryptStatsLog.TLS_HANDSHAKE_REPORTED, success, protocol,
-                cipherSuite, duration, SOURCE_GMS);
+                cipherSuite, duration, SOURCE_GMS, new int[] {Os.getuid(), Binder.getCallingUid()});
     }
 
     public static boolean isJavaxCertificateSupported() {

--- a/common/src/main/java/org/conscrypt/metrics/ConscryptStatsLog.java
+++ b/common/src/main/java/org/conscrypt/metrics/ConscryptStatsLog.java
@@ -37,10 +37,10 @@ public final class ConscryptStatsLog {
 
     private ConscryptStatsLog() {}
 
-    public static void write(
-            int atomId, boolean success, int protocol, int cipherSuite, int duration, Source source) {
+    public static void write(int atomId, boolean success, int protocol, int cipherSuite,
+            int duration, Source source, int[] uids) {
         ReflexiveStatsEvent event = ReflexiveStatsEvent.buildEvent(
-                atomId, success, protocol, cipherSuite, duration, source.ordinal());
+                atomId, success, protocol, cipherSuite, duration, source.ordinal(), uids);
 
         ReflexiveStatsLog.write(event);
     }

--- a/common/src/main/java/org/conscrypt/metrics/ReflexiveStatsEvent.java
+++ b/common/src/main/java/org/conscrypt/metrics/ReflexiveStatsEvent.java
@@ -24,10 +24,14 @@ import org.conscrypt.Internal;
 public class ReflexiveStatsEvent {
     private static final OptionalMethod newBuilder;
     private static final Class<?> c_statsEvent;
+    private static final Object sdkVersion;
+    private static final boolean sdkVersionBiggerThan32;
 
     static {
+        sdkVersion = getSdkVersion();
         c_statsEvent = initStatsEventClass();
         newBuilder = new OptionalMethod(c_statsEvent, "newBuilder");
+        sdkVersionBiggerThan32 = (sdkVersion != null) && ((int) sdkVersion > 32);
     }
 
     private static Class<?> initStatsEventClass() {
@@ -52,8 +56,24 @@ public class ReflexiveStatsEvent {
         return new ReflexiveStatsEvent.Builder();
     }
 
-    public static ReflexiveStatsEvent buildEvent(
-            int atomId, boolean success, int protocol, int cipherSuite, int duration, int source) {
+    public static ReflexiveStatsEvent buildEvent(int atomId, boolean success, int protocol,
+            int cipherSuite, int duration, int source, int[] uids) {
+        ReflexiveStatsEvent.Builder builder = ReflexiveStatsEvent.newBuilder();
+        builder.setAtomId(atomId);
+        builder.writeBoolean(success);
+        builder.writeInt(protocol);
+        builder.writeInt(cipherSuite);
+        builder.writeInt(duration);
+        builder.writeInt(source);
+        if (sdkVersionBiggerThan32) {
+          builder.writeIntArray(uids);
+        }
+        builder.usePooledBuffer();
+        return builder.build();
+    }
+
+    public static ReflexiveStatsEvent buildEvent(int atomId, boolean success, int protocol,
+            int cipherSuite, int duration, int source) {
         ReflexiveStatsEvent.Builder builder = ReflexiveStatsEvent.newBuilder();
         builder.setAtomId(atomId);
         builder.writeBoolean(success);
@@ -65,6 +85,18 @@ public class ReflexiveStatsEvent {
         return builder.build();
     }
 
+
+    static Object getSdkVersion() {
+        try {
+            OptionalMethod getSdkVersion =
+                    new OptionalMethod(Class.forName("dalvik.system.VMRuntime"),
+                                        "getSdkVersion");
+            return getSdkVersion.invokeStatic();
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
     public static final class Builder {
         private static final Class<?> c_statsEvent_Builder;
         private static final OptionalMethod setAtomId;
@@ -72,6 +104,7 @@ public class ReflexiveStatsEvent {
         private static final OptionalMethod writeInt;
         private static final OptionalMethod build;
         private static final OptionalMethod usePooledBuffer;
+        private static final OptionalMethod writeIntArray;
 
         static {
             c_statsEvent_Builder = initStatsEventBuilderClass();
@@ -80,6 +113,7 @@ public class ReflexiveStatsEvent {
             writeInt = new OptionalMethod(c_statsEvent_Builder, "writeInt", int.class);
             build = new OptionalMethod(c_statsEvent_Builder, "build");
             usePooledBuffer = new OptionalMethod(c_statsEvent_Builder, "usePooledBuffer");
+            writeIntArray = new OptionalMethod(c_statsEvent_Builder, "writeIntArray", int[].class);
         }
 
         private static Class<?> initStatsEventBuilderClass() {
@@ -113,6 +147,11 @@ public class ReflexiveStatsEvent {
 
         public void usePooledBuffer() {
             usePooledBuffer.invoke(this.builder);
+        }
+
+        public Builder writeIntArray(final int[] values) {
+            writeIntArray.invoke(this.builder, values);
+            return this;
         }
 
         public ReflexiveStatsEvent build() {

--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -536,7 +536,8 @@ final class Platform {
         int duration = (int) durationLong;
 
         ConscryptStatsLog.write(ConscryptStatsLog.TLS_HANDSHAKE_REPORTED, success, proto.getId(),
-                suite.getId(), duration, SOURCE_MAINLINE);
+                suite.getId(), duration, SOURCE_MAINLINE,
+                new int[] {Os.getuid()});
     }
 
     public static boolean isJavaxCertificateSupported() {


### PR DESCRIPTION
Upstreams https://r.android.com/2759365

This reverts commit 3a1331299cbcf99e9af7e069b95793fa6f536b3f.

Reason for revert: try 3 of making this work (now with api level checking to avoid calling code that is not in R or S)

Non-Android note: (1) TLS handshakes are not logged on other platforms and (2) On Android, an app's uid is a unique identifier for that app (each app gets its own) and not any kind of user data.