### PR TITLE
Gradle tidy-up.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,12 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath libraries.android_tools
+        classpath libs.android.tools
     }
-}
-
-plugins {
-    id 'digital.wup.android-maven-publish' version '3.6.2'
 }
 
 description = 'Conscrypt: Android'

--- a/benchmark-android/build.gradle
+++ b/benchmark-android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath libraries.android_tools
+        classpath libs.android.tools
     }
 }
 
@@ -61,14 +61,14 @@ if (androidSdkInstalled) {
 
     dependencies {
         depsJarApi project(path: ':conscrypt-android'),
-                   libraries.bouncycastle_provider,
-                   libraries.bouncycastle_apis
+                   libs.bouncycastle.provider,
+                   libs.bouncycastle.apis
 
         depsJarImplementation project(':conscrypt-benchmark-base'),
                               project(path: ":conscrypt-testing", configuration: "shadow"),
                               project(':conscrypt-libcore-stub')
 
-        implementation 'com.google.caliper:caliper:1.0-beta-2'
+        implementation libs.caliper
     }
 
     // This task bundles up everything we're going to send to the device into a single jar.

--- a/benchmark-base/build.gradle
+++ b/benchmark-base/build.gradle
@@ -2,5 +2,5 @@ description = 'Conscrypt: Base library for benchmarks'
 
 dependencies {
     implementation project(path: ":conscrypt-testing", configuration: "shadow"),
-            libraries.junit
+            libs.junit
 }

--- a/benchmark-jmh/build.gradle
+++ b/benchmark-jmh/build.gradle
@@ -1,8 +1,6 @@
 plugins {
-    id 'me.champeau.gradle.jmh' version '0.5.3'
+    alias libs.plugins.jmh
 }
-
-apply plugin: 'idea'
 
 description = 'Conscrypt: JMH on OpenJDK Benchmarks'
 
@@ -31,13 +29,13 @@ jmh {
         setBenchmarkParameters(parseParams(jmhParams))
     }
     warmupIterations = "$jmhWarmupIterations".toInteger()
-    iterations = "$jmhIterations".toInteger();
+    iterations = "$jmhIterations".toInteger()
     fork = "$jmhFork".toInteger()
-    jvmArgs = jmhJvmArgs.toString()
+    // jvmArgs = jmhJvmArgs
     if (jmhJvm != null) {
         jvm = jmhJvm
     }
-    duplicateClassesStrategy = 'warn'
+    duplicateClassesStrategy = DuplicatesStrategy.WARN
 }
 
 configurations {
@@ -65,20 +63,21 @@ sourceSets {
 }
 
 dependencies {
-    implementation project(path: ":conscrypt-openjdk", configuration: "runtimeElements"),
+    implementation project(":conscrypt-openjdk"),
+            project(path: ":conscrypt-testing", configuration: "runtimeElements"),
             project(':conscrypt-benchmark-base'),
             // Add the preferred native openjdk configuration for this platform.
-            project(':conscrypt-openjdk').sourceSets["$preferredSourceSet"].output,
-            libraries.junit,
-            libraries.netty_handler,
-            libraries.netty_tcnative
+            //project(':conscrypt-openjdk').sourceSets["$preferredSourceSet"].output,
+            libs.junit,
+            libs.netty.handler,
+            libs.netty.tcnative
 
-    jmhGeneratorAnnprocess libraries.jmh_generator_annprocess
+    jmhGeneratorAnnprocess libs.jmh.generator.annprocess
 
     // Override the default JMH dependencies with the new versions.
-    jmh libraries.jmh_core,
-            libraries.jmh_generator_reflection,
-            libraries.jmh_generator_bytecode
+    jmh libs.jmh.core,
+            libs.jmh.generator.reflection,
+            libs.jmh.generator.bytecode
 }
 
 // Running benchmarks in IntelliJ seems broken without this.

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@ import org.ajoberstar.grgit.Grgit
 import org.gradle.util.VersionNumber
 
 buildscript {
-    ext.android_tools = 'com.android.tools.build:gradle:7.4.0'
-    ext.errorproneVersion = '2.31.0'
     repositories {
         google()
         mavenCentral()
@@ -11,17 +9,16 @@ buildscript {
     dependencies {
         // This must be applied in the root project otherwise each subproject will
         // have it in a different ClassLoader.
-        classpath android_tools
+        classpath libs.android.tools
     }
 }
 
 plugins {
-    // Add dependency for build script so we can access Git from our
-    // build script.
-    id 'org.ajoberstar.grgit' version '5.2.2'
-    id 'net.ltgt.errorprone' version '4.0.0'
-    id "com.google.osdetector" version "1.7.3"
-    id "biz.aQute.bnd.builder" version "6.4.0" apply false
+    alias libs.plugins.bnd apply false
+    alias libs.plugins.errorprone
+    alias libs.plugins.grgit
+    alias libs.plugins.osdetector
+    alias libs.plugins.task.tree
 }
 
 subprojects {
@@ -65,9 +62,8 @@ subprojects {
             }
         }
     }
-    apply plugin: "idea"
     apply plugin: "jacoco"
-    apply plugin: "net.ltgt.errorprone"
+    apply plugin: libs.plugins.errorprone.get().pluginId
 
     group = "org.conscrypt"
     description = 'Conscrypt is an alternate Java Security Provider that uses BoringSSL'
@@ -91,28 +87,6 @@ subprojects {
         boringSslGit = Grgit.open(dir: boringsslHome)
         boringSslVersion = boringSslGit.head().id
 
-        jmhVersion = '1.21'
-        libraries = [
-                android_tools: android_tools,
-                roboelectric: 'org.robolectric:android-all:7.1.0_r7-robolectric-0',
-
-                // Test dependencies.
-                bouncycastle_apis: 'org.bouncycastle:bcpkix-jdk15on:1.63',
-                bouncycastle_provider: 'org.bouncycastle:bcprov-jdk15on:1.63',
-                junit  : 'junit:junit:4.13.2',
-                mockito: 'org.mockito:mockito-core:2.28.2',
-                truth  : 'com.google.truth:truth:1.0',
-
-                // Benchmark dependencies
-                jmh_core: "org.openjdk.jmh:jmh-core:${jmhVersion}",
-                jmh_generator_annprocess: "org.openjdk.jmh:jmh-generator-annprocess:${jmhVersion}",
-                jmh_generator_asm: "org.openjdk.jmh:jmh-generator-asm:${jmhVersion}",
-                jmh_generator_bytecode: "org.openjdk.jmh:jmh-generator-bytecode:${jmhVersion}",
-                jmh_generator_reflection: "org.openjdk.jmh:jmh-generator-reflection:${jmhVersion}",
-                netty_handler: 'io.netty:netty-handler:4.1.24.Final',
-                netty_tcnative: 'io.netty:netty-tcnative-boringssl-static:2.0.26.Final',
-        ]
-
         signJar = { jarPath ->
             if (rootProject.hasProperty('signingKeystore') && rootProject.hasProperty('signingPassword')) {
                 def command = 'jarsigner -keystore ' + rootProject.signingKeystore +
@@ -133,11 +107,21 @@ subprojects {
     }
 
     jacoco {
-        toolVersion = "0.8.4"
+        toolVersion = libs.versions.jacoco
+    }
+
+    configurations {
+        jacocoAnt
+        jacocoAgent
     }
 
     dependencies {
-        errorprone("com.google.errorprone:error_prone_core:$errorproneVersion")
+        jacocoAnt libs.jacoco.ant
+        jacocoAgent libs.jacoco.agent
+    }
+
+    dependencies {
+        errorprone libs.errorprone
     }
 
     tasks.register("generateProperties", WriteProperties) {
@@ -192,12 +176,12 @@ subprojects {
         }
 
         tasks.register("javadocJar", Jar) {
-            classifier = 'javadoc'
+            archiveClassifier = 'javadoc'
             from javadoc
         }
 
         tasks.register("sourcesJar", Jar) {
-            classifier = 'sources'
+            archiveClassifier = 'sources'
             from sourceSets.main.allSource
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,54 @@
+[versions]
+android-tools = "7.4.2"
+bnd = "6.4.0"
+bouncycastle = "1.67"
+caliper = "1.0-beta-2"
+errorprone = "2.31.0"
+errorprone-plugin = "4.0.0"
+grgit = "5.2.2"
+jacoco = "0.8.12"
+jmh = "1.37"
+jmh-plugin = "0.7.2"
+junit = "4.13.2"
+mockito = "2.28.2"
+netty-handler = "4.1.24.Final"
+netty-tcnative = "2.0.26.Final"
+osdetector = "1.7.3"
+shadow = "7.1.2"
+task-tree = "3.0.0"
+
+[plugins]
+bnd = { id = "biz.aQute.bnd.builder", version.ref = "bnd" }
+errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone-plugin" }
+grgit = { id = "org.ajoberstar.grgit", version.ref = "grgit" }
+jmh = { id = "me.champeau.jmh", version.ref = "jmh-plugin" }
+osdetector = { id = "com.google.osdetector", version.ref = "osdetector" }
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
+task-tree = { id = "com.dorongold.task-tree", version.ref = "task-tree" }
+
+[libraries]
+# Android tooling
+android-tools = { module = "com.android.tools.build:gradle", version.ref = "android-tools" }
+caliper = { module = "com.google.caliper:caliper", version.ref = "caliper" }
+
+# Bouncycastle
+bouncycastle-apis = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "bouncycastle" }
+bouncycastle-provider = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncycastle" }
+
+# Testing
+errorprone = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }
+jacoco-agent = { module = "org.jacoco:org.jacoco.agent", version.ref = "jacoco" }
+jacoco-ant = { module = "org.jacoco:org.jacoco.ant", version.ref = "jacoco" }
+junit = { module = "junit:junit", version.ref = "junit" }
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+
+# JMH Benchmarking
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }
+jmh-generator-bytecode = { module = "org.openjdk.jmh:jmh-generator-bytecode", version.ref = "jmh" }
+jmh-generator-reflection = { module = "org.openjdk.jmh:jmh-generator-reflection", version.ref = "jmh" }
+
+# Netty
+netty-handler = { module = "io.netty:netty-handler", version.ref = "netty-handler" }
+netty-tcnative = { module = "io.netty:netty-tcnative-boringssl-static", version.ref = "netty-tcnative" }
+

--- a/libcore-stub/build.gradle
+++ b/libcore-stub/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     // Only compile against this. Other modules will embed the generated code directly.
     compileOnly project(':conscrypt-constants')
 
-    testImplementation libraries.junit
+    testImplementation libs.junit
 }
 
 // Disable the javadoc task.

--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -10,7 +10,7 @@ ext {
 }
 
 if (buildUberJar) {
-    apply plugin: 'biz.aQute.bnd.builder'
+    apply plugin: libs.plugins.bnd.get().pluginId
 
     configurations {
         uberJar

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -1,12 +1,11 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    alias libs.plugins.bnd
+    alias libs.plugins.shadow
 }
 
 import aQute.bnd.gradle.BundleTaskConvention
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.codehaus.groovy.runtime.InvokerHelper
-
-apply plugin: 'biz.aQute.bnd.builder'
 
 description = 'Conscrypt: OpenJdk'
 
@@ -199,7 +198,7 @@ if (isExecutableOnPath('cpplint')) {
         args = sourceFiles
 
         // Capture stderr from the process
-        errorOutput = new ByteArrayOutputStream();
+        errorOutput = new ByteArrayOutputStream()
 
         // Need to ignore exit value so that doLast will execute.
         ignoreExitValue = true
@@ -207,7 +206,7 @@ if (isExecutableOnPath('cpplint')) {
         doLast {
             // Create the report file.
             def reportDir = file("${buildDir}/cpplint")
-            reportDir.mkdirs();
+            reportDir.mkdirs()
             def reportFile = new File(reportDir, "report.txt")
             def reportStream = new FileOutputStream(reportFile)
 
@@ -218,13 +217,13 @@ if (isExecutableOnPath('cpplint')) {
                 }
             } catch (Exception e) {
                 // The process failed - get the error report from the stderr.
-                String report = errorOutput.toString();
+                String report = errorOutput.toString()
 
                 // Write the report to the console.
                 System.err.println(report)
 
                 // Also write the report file.
-                reportStream.write(report.bytes);
+                reportStream.write(report.bytes)
 
                 // Extension method cpplint.output() can be used to obtain the report
                 ext.output = {
@@ -232,9 +231,9 @@ if (isExecutableOnPath('cpplint')) {
                 }
 
                 // Rethrow the exception to terminate the build.
-                throw e;
+                throw e
             } finally {
-                reportStream.close();
+                reportStream.close()
             }
         }
     }
@@ -272,8 +271,8 @@ dependencies {
 
     testImplementation project(':conscrypt-constants'),
             project(path: ':conscrypt-testing', configuration: 'shadow'),
-            libraries.junit,
-            libraries.mockito
+            libs.junit,
+            libs.mockito
 
     testRuntimeOnly sourceSets["$preferredSourceSet"].output
 
@@ -296,7 +295,7 @@ def addNativeJar(NativeBuildInfo nativeBuild) {
         // Depend on the regular classes task
         dependsOn classes
         manifest = jar.manifest
-        classifier = nativeBuild.mavenClassifier()
+        archiveClassifier = nativeBuild.mavenClassifier()
 
         from sourceSet.output + sourceSets.main.output
 
@@ -341,6 +340,7 @@ check.dependsOn testInterop
 jacocoTestReport {
     additionalSourceDirs.from files("$rootDir/openjdk/src/test/java", "$rootDir/common/src/main/java")
     executionData tasks.withType(Test)
+    dependsOn test
 }
 
 javadoc {
@@ -531,15 +531,14 @@ boolean isExecutableOnPath(executable) {
     FilenameFilter filter = new FilenameFilter() {
         @Override
         boolean accept(File dir, String name) {
-            return executable.equals(name);
+            return executable == name
         }
     }
     for(String folder : System.getenv('PATH').split("" + File.pathSeparatorChar)) {
         File[] files = file(folder).listFiles(filter)
         if (files != null && files.size() > 0) {
-            return true;
+            return true
         }
     }
-    return false;
+    return false
 }
-

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath libraries.android_tools
+        classpath(libs.android.tools)
     }
 }
 
@@ -99,7 +99,7 @@ if (androidSdkInstalled) {
         testCompileOnly project(':conscrypt-android-stub'),
                         project(':conscrypt-libcore-stub')
         testImplementation project(path: ":conscrypt-testing", configuration: "shadow"),
-                           libraries.junit
+                           libs.junit
         compileOnly project(':conscrypt-android-stub'),
                     project(':conscrypt-libcore-stub')
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    alias libs.plugins.shadow
 }
 
 description = 'Conscrypt: Testing'
@@ -20,9 +20,9 @@ dependencies {
                 project(':conscrypt-libcore-stub'),
                 project(':conscrypt-android-stub')
 
-    implementation libraries.bouncycastle_apis,
-            libraries.bouncycastle_provider,
-            libraries.junit
+    implementation libs.bouncycastle.apis,
+            libs.bouncycastle.provider,
+            libs.junit
 }
 
 // No public methods here.


### PR DESCRIPTION
Use central version repository for dependencies (current best practice)

Fix Jacoco coverage reports.
Start fixing JMH benchmarks.

General warning fixes.

Remove some unused plugins, e.g. Truth, Roboelectric.