### PR TITLE
Lint fixes.

### DIFF
--- a/android-stub/src/main/java/android/util/StatsEvent.java
+++ b/android-stub/src/main/java/android/util/StatsEvent.java
@@ -16,12 +16,8 @@
 
 package android.util;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused",  "DoNotCallSuggester"})
 public final class StatsEvent {
-    private StatsEvent(int atomId, StatsEvent.Buffer buffer, byte[] payload, int numBytes) {
-        throw new RuntimeException("Stub!");
-    }
-
     public static StatsEvent.Builder newBuilder() {
         throw new RuntimeException("Stub!");
     }
@@ -43,20 +39,10 @@ public final class StatsEvent {
     }
 
     private static final class Buffer {
-        private static StatsEvent.Buffer obtain() {
-            throw new RuntimeException("Stub!");
-        }
-
-        private Buffer() {
-            throw new RuntimeException("Stub!");
-        }
     }
 
+    @SuppressWarnings({"unused",  "DoNotCallSuggester"})
     public static final class Builder {
-        private Builder(StatsEvent.Buffer buffer) {
-            throw new RuntimeException("Stub!");
-        }
-
         public StatsEvent.Builder setAtomId(int atomId) {
             throw new RuntimeException("Stub!");
         }
@@ -89,10 +75,6 @@ public final class StatsEvent {
             throw new RuntimeException("Stub!");
         }
 
-        private void writeByteArray(byte[] value, byte typeId) {
-            throw new RuntimeException("Stub!");
-        }
-
         public StatsEvent.Builder writeAttributionChain(int[] uids, String[] tags) {
             throw new RuntimeException("Stub!");
         }
@@ -110,18 +92,6 @@ public final class StatsEvent {
         }
 
         public StatsEvent build() {
-            throw new RuntimeException("Stub!");
-        }
-
-        private void writeTypeId(byte typeId) {
-            throw new RuntimeException("Stub!");
-        }
-
-        private void writeAnnotationCount() {
-            throw new RuntimeException("Stub!");
-        }
-
-        private static byte[] stringToBytes(String value) {
             throw new RuntimeException("Stub!");
         }
     }

--- a/android-stub/src/main/java/dalvik/system/BlockGuard.java
+++ b/android-stub/src/main/java/dalvik/system/BlockGuard.java
@@ -16,6 +16,7 @@
 
 package dalvik.system;
 
+@SuppressWarnings("DoNotCallSuggester")
 public class BlockGuard {
     private BlockGuard() {}
 

--- a/android-stub/src/main/java/dalvik/system/CloseGuard.java
+++ b/android-stub/src/main/java/dalvik/system/CloseGuard.java
@@ -16,6 +16,7 @@
 
 package dalvik.system;
 
+@SuppressWarnings("DoNotCallSuggester")
 public class CloseGuard {
     private CloseGuard() {}
 

--- a/android/src/main/java/org/conscrypt/KitKatPlatformOpenSSLSocketImplAdapter.java
+++ b/android/src/main/java/org/conscrypt/KitKatPlatformOpenSSLSocketImplAdapter.java
@@ -433,20 +433,7 @@ public class KitKatPlatformOpenSSLSocketImplAdapter
         delegate.setHandshakeTimeout(handshakeTimeoutMilliseconds);
     }
 
-    @Override
-    @SuppressWarnings("deprecation")
-    public byte[] getNpnSelectedProtocol() {
-        return delegate.getNpnSelectedProtocol();
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public void setNpnProtocols(byte[] npnProtocols) {
-        delegate.setNpnProtocols(npnProtocols);
-    }
-
     // These aren't in the Platform's OpenSSLSocketImpl but we have them to support duck typing.
-
     @SuppressWarnings("deprecation")
     public byte[] getAlpnSelectedProtocol() {
         return delegate.getAlpnSelectedProtocol();

--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -836,7 +836,7 @@ final public class Platform {
         // TODO: Use the platform version on platforms that support it
 
         String property = Security.getProperty("conscrypt.ct.enable");
-        if (property == null || !Boolean.valueOf(property)) {
+        if (property == null || !Boolean.parseBoolean(property)) {
             return false;
         }
 
@@ -850,7 +850,7 @@ final public class Platform {
         for (String part : parts) {
             property = Security.getProperty(propertyName + ".*");
             if (property != null) {
-                enable = Boolean.valueOf(property);
+                enable = Boolean.parseBoolean(property);
             }
 
             propertyName = propertyName + "." + part;
@@ -858,7 +858,7 @@ final public class Platform {
 
         property = Security.getProperty(propertyName);
         if (property != null) {
-            enable = Boolean.valueOf(property);
+            enable = Boolean.parseBoolean(property);
         }
         return enable;
     }

--- a/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
@@ -661,22 +661,6 @@ abstract class AbstractConscryptSocket extends SSLSocket {
     abstract void setChannelIdPrivateKey(PrivateKey privateKey);
 
     /**
-     * Returns null always for backward compatibility.
-     * @deprecated NPN is not supported
-     */
-    @Deprecated
-    byte[] getNpnSelectedProtocol() {
-        return null;
-    }
-
-    /**
-     * This method does nothing and is kept for backward compatibility.
-     * @deprecated NPN is not supported
-     */
-    @Deprecated
-    void setNpnProtocols(byte[] npnProtocols) {}
-
-    /**
      * Returns the protocol agreed upon by client and server, or {@code null} if
      * no protocol was agreed upon.
      *

--- a/common/src/main/java/org/conscrypt/AbstractSessionContext.java
+++ b/common/src/main/java/org/conscrypt/AbstractSessionContext.java
@@ -247,7 +247,7 @@ abstract class AbstractSessionContext implements SSLSessionContext {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("Finalize")
     protected void finalize() throws Throwable {
         try {
             freeNative();

--- a/common/src/main/java/org/conscrypt/AllocatedBuffer.java
+++ b/common/src/main/java/org/conscrypt/AllocatedBuffer.java
@@ -51,6 +51,7 @@ public abstract class AllocatedBuffer {
      * @deprecated this method is not used
      */
     @Deprecated
+    @SuppressWarnings("InlineMeSuggester")
     public AllocatedBuffer retain() {
         // Do nothing.
         return this;

--- a/common/src/main/java/org/conscrypt/ArrayUtils.java
+++ b/common/src/main/java/org/conscrypt/ArrayUtils.java
@@ -37,6 +37,7 @@ public final class ArrayUtils {
     }
 
     @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <T> T[] concatValues(T[] a1, T... values) {
         return concat (a1, values);
     }

--- a/common/src/main/java/org/conscrypt/CertificatePriorityComparator.java
+++ b/common/src/main/java/org/conscrypt/CertificatePriorityComparator.java
@@ -75,7 +75,7 @@ public final class CertificatePriorityComparator implements Comparator<X509Certi
     }
 
     @Override
-    @SuppressWarnings("JdkObsolete")  // Certificate uses Date
+    @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})  // Certificate uses Date
     public int compare(X509Certificate lhs, X509Certificate rhs) {
         int result;
         boolean lhsSelfSigned = lhs.getSubjectDN().equals(lhs.getIssuerDN());

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -177,6 +177,7 @@ public final class Conscrypt {
          * @deprecated Use provideTrustManager(true)
          */
         @Deprecated
+        @SuppressWarnings("InlineMeSuggester")
         public ProviderBuilder provideTrustManager() {
             return provideTrustManager(true);
         }

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -1671,7 +1671,7 @@ final class ConscryptEngine extends AbstractConscryptEngine implements NativeCry
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("Finalize")
     protected void finalize() throws Throwable {
         try {
             // If ssl is null, object must not be fully constructed so nothing for us to do here.

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -1057,7 +1057,7 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("Finalize")
     protected final void finalize() throws Throwable {
         try {
             /*

--- a/common/src/main/java/org/conscrypt/DefaultSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/DefaultSSLContextImpl.java
@@ -72,14 +72,8 @@ public class DefaultSSLContextImpl extends OpenSSLContextImpl {
         char[] pwd = (keystorepwd == null) ? null : keystorepwd.toCharArray();
 
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-        InputStream is = null;
-        try {
-            is = new BufferedInputStream(new FileInputStream(keystore));
+        try (InputStream is = new BufferedInputStream(new FileInputStream(keystore))) {
             ks.load(is, pwd);
-        } finally {
-            if (is != null) {
-                is.close();
-            }
         }
 
         String kmfAlg = KeyManagerFactory.getDefaultAlgorithm();
@@ -105,14 +99,8 @@ public class DefaultSSLContextImpl extends OpenSSLContextImpl {
 
         // TODO Defaults: jssecacerts; cacerts
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-        InputStream is = null;
-        try {
-            is = new BufferedInputStream(new FileInputStream(keystore));
+        try (InputStream is = new BufferedInputStream(new FileInputStream(keystore))) {
             ks.load(is, pwd);
-        } finally {
-            if (is != null) {
-                is.close();
-            }
         }
         String tmfAlg = TrustManagerFactory.getDefaultAlgorithm();
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlg);

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -133,19 +133,19 @@ public final class NativeCrypto {
     static native int RSA_private_decrypt(int flen, byte[] from, byte[] to, NativeRef.EVP_PKEY pkey,
             int padding) throws BadPaddingException, SignatureException;
 
-    /**
-     * @return array of {n, e}
+    /*
+     * Returns array of {n, e}
      */
     static native byte[][] get_RSA_public_params(NativeRef.EVP_PKEY rsa);
 
-    /**
-     * @return array of {n, e, d, p, q, dmp1, dmq1, iqmp}
+    /*
+     * Returns array of {n, e, d, p, q, dmp1, dmq1, iqmp}
      */
     static native byte[][] get_RSA_private_params(NativeRef.EVP_PKEY rsa);
 
     // --- ChaCha20 -----------------------
 
-    /**
+    /*
      * Returns the encrypted or decrypted version of the data.
      */
     static native void chacha20_encrypt_decrypt(byte[] in, int inOffset, byte[] out, int outOffset,
@@ -538,6 +538,7 @@ public final class NativeCrypto {
             throws BadPaddingException, IllegalBlockSizeException;
 
     static native byte[] get_X509_tbs_cert(long x509ctx, OpenSSLX509Certificate holder);
+
 
     static native byte[] get_X509_tbs_cert_without_ext(long x509ctx, OpenSSLX509Certificate holder, String oid);
 

--- a/common/src/main/java/org/conscrypt/NativeRef.java
+++ b/common/src/main/java/org/conscrypt/NativeRef.java
@@ -27,7 +27,6 @@ abstract class NativeRef {
         if (address == 0) {
             throw new NullPointerException("address == 0");
         }
-
         this.address = address;
     }
 
@@ -42,11 +41,11 @@ abstract class NativeRef {
 
     @Override
     public int hashCode() {
-        return (int) (address ^ (address >>> 32));
+        return Long.hashCode(address);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("Finalize")
     protected void finalize() throws Throwable {
         try {
             if (address != 0) {
@@ -56,6 +55,12 @@ abstract class NativeRef {
             super.finalize();
         }
     }
+
+    // VisibleForTesting
+    public boolean isNull() {
+        return address == 0;
+    }
+
 
     abstract void doFree(long context);
 

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -27,9 +27,7 @@ import static org.conscrypt.NativeConstants.SSL_VERIFY_PEER;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.SocketException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
@@ -133,7 +131,7 @@ final class NativeSsl {
         if (label == null) {
             throw new NullPointerException("Label is null");
         }
-        byte[] labelBytes = label.getBytes(Charset.forName("US-ASCII"));
+        byte[] labelBytes = label.getBytes(StandardCharsets.US_ASCII);
         return NativeCrypto.SSL_export_keying_material(ssl, this, labelBytes, context, length);
     }
 
@@ -141,8 +139,8 @@ final class NativeSsl {
         return NativeCrypto.SSL_get_signed_cert_timestamp_list(ssl, this);
     }
 
-    /**
-     * @see NativeCrypto.SSLHandshakeCallbacks#clientPSKKeyRequested(String, byte[], byte[])
+    /*
+     * See NativeCrypto.SSLHandshakeCallbacks#clientPSKKeyRequested(String, byte[], byte[]).
      */
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     int clientPSKKeyRequested(String identityHint, byte[] identityBytesOut, byte[] key) {
@@ -160,11 +158,7 @@ final class NativeSsl {
         } else if (identity.isEmpty()) {
             identityBytes = EmptyArray.BYTE;
         } else {
-            try {
-                identityBytes = identity.getBytes("UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                throw new RuntimeException("UTF-8 encoding not supported", e);
-            }
+            identityBytes = identity.getBytes(StandardCharsets.UTF_8);
         }
         if (identityBytes.length + 1 > identityBytesOut.length) {
             // Insufficient space in the output buffer
@@ -187,8 +181,8 @@ final class NativeSsl {
         return secretKeyBytes.length;
     }
 
-    /**
-     * @see NativeCrypto.SSLHandshakeCallbacks#serverPSKKeyRequested(String, String, byte[])
+    /*
+     * See NativeCrypto.SSLHandshakeCallbacks#serverPSKKeyRequested(String, String, byte[]).
      */
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     int serverPSKKeyRequested(String identityHint, String identity, byte[] key) {
@@ -638,8 +632,8 @@ final class NativeSsl {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    protected final void finalize() throws Throwable {
+    @SuppressWarnings("Finalize")
+    protected void finalize() throws Throwable {
         try {
             close();
         } finally {

--- a/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLContextImpl.java
@@ -67,12 +67,14 @@ public abstract class OpenSSLContextImpl extends SSLContextSpi {
     }
 
     /**
-     * Constuctor for the DefaultSSLContextImpl.  The unused boolean parameter is solely to
+     * Constructor for the DefaultSSLContextImpl.  The unused boolean parameter is solely to
      * indicate that this constructor is desired.
      */
     @SuppressWarnings("StaticAssignmentInConstructor")
     OpenSSLContextImpl(String[] protocols, boolean unused)
             throws GeneralSecurityException, IOException {
+        // TODO(prb): It looks like nowadays we can push the synchronisation into
+        // DefaultSSLContextImpl itself, but put it in its own CL for safety.
         synchronized (DefaultSSLContextImpl.class) {
             this.protocols = null;
             // This is the only place defaultSslContextImpl is read or written so all

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateCrtKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateCrtKey.java
@@ -97,7 +97,7 @@ final class OpenSSLRSAPrivateCrtKey extends OpenSSLRSAPrivateKey implements RSAP
     }
 
     static OpenSSLKey getInstance(RSAPrivateCrtKey rsaPrivateKey) throws InvalidKeyException {
-        /**
+        /*
          * If the key is not encodable (PKCS11-like key), then wrap it and use
          * JNI upcalls to satisfy requests.
          */
@@ -246,7 +246,7 @@ final class OpenSSLRSAPrivateCrtKey extends OpenSSLRSAPrivateKey implements RSAP
     }
 
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         int hashCode = super.hashCode();
         if (publicExponent != null) {
             hashCode ^= publicExponent.hashCode();

--- a/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateKey.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLRSAPrivateKey.java
@@ -123,7 +123,7 @@ class OpenSSLRSAPrivateKey implements RSAPrivateKey, OpenSSLKeyHolder {
     }
 
     static OpenSSLKey getInstance(RSAPrivateKey rsaPrivateKey) throws InvalidKeyException {
-        /**
+        /*
          * If the key is not encodable (PKCS11-like key), then wrap it and use
          * JNI upcalls to satisfy requests.
          */

--- a/common/src/main/java/org/conscrypt/OpenSSLSignature.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSignature.java
@@ -166,6 +166,7 @@ public class OpenSSLSignature extends SignatureSpi {
 
     @Deprecated
     @Override
+    @SuppressWarnings("InlineMeSuggester")
     protected Object engineGetParameter(String param) throws InvalidParameterException {
         return null;
     }
@@ -453,9 +454,7 @@ public class OpenSSLSignature extends SignatureSpi {
                                 saltSizeBytes,
                                 TRAILER_FIELD_BC_ID));
                 return result;
-            } catch (NoSuchAlgorithmException e) {
-                throw new ProviderException("Failed to create PSS AlgorithmParameters", e);
-            } catch (InvalidParameterSpecException e) {
+            } catch (NoSuchAlgorithmException | InvalidParameterSpecException e) {
                 throw new ProviderException("Failed to create PSS AlgorithmParameters", e);
             }
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -111,19 +111,18 @@ public abstract class OpenSSLSocketImpl extends AbstractConscryptSocket {
     /**
      * @deprecated NPN is not supported
      */
-    @Override
     @Deprecated
+    @SuppressWarnings("InlineMeSuggester")
     public final byte[] getNpnSelectedProtocol() {
-        return super.getNpnSelectedProtocol();
+        return null;
     }
 
     /**
      * @deprecated NPN is not supported
      */
-    @Override
     @Deprecated
+    @SuppressWarnings("InlineMeSuggester")
     public final void setNpnProtocols(byte[] npnProtocols) {
-        super.setNpnProtocols(npnProtocols);
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRL.java
@@ -278,11 +278,13 @@ final class OpenSSLX509CRL extends X509CRL {
     }
 
     @Override
+    @SuppressWarnings({"JavaUtilDate"}) // Needed for API compatibility
     public Date getThisUpdate() {
         return (Date) thisUpdate.clone();
     }
 
     @Override
+    @SuppressWarnings({"JavaUtilDate"}) // Needed for API compatibility
     public Date getNextUpdate() {
         return (Date) nextUpdate.clone();
     }
@@ -412,7 +414,7 @@ final class OpenSSLX509CRL extends X509CRL {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("Finalize")
     protected void finalize() throws Throwable {
         try {
             long toFree = mContext;

--- a/common/src/main/java/org/conscrypt/OpenSSLX509CRLEntry.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509CRLEntry.java
@@ -57,7 +57,7 @@ final class OpenSSLX509CRLEntry extends X509CRLEntry {
             return null;
         }
 
-        return new HashSet<String>(Arrays.asList(critOids));
+        return new HashSet<>(Arrays.asList(critOids));
     }
 
     @Override
@@ -82,7 +82,7 @@ final class OpenSSLX509CRLEntry extends X509CRLEntry {
             return null;
         }
 
-        return new HashSet<String>(Arrays.asList(critOids));
+        return new HashSet<>(Arrays.asList(critOids));
     }
 
     @Override
@@ -111,6 +111,7 @@ final class OpenSSLX509CRLEntry extends X509CRLEntry {
     }
 
     @Override
+    @SuppressWarnings("JavaUtilDate") // Needed for API compatibility
     public Date getRevocationDate() {
         return (Date) revocationDate.clone();
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLX509Certificate.java
@@ -74,13 +74,6 @@ public final class OpenSSLX509Certificate extends X509Certificate {
         notAfter = toDate(NativeCrypto.X509_get_notAfter(mContext, this));
     }
 
-    // A non-throwing constructor used when we have already parsed the dates
-    private OpenSSLX509Certificate(long ctx, Date notBefore, Date notAfter) {
-        mContext = ctx;
-        this.notBefore = notBefore;
-        this.notAfter = notAfter;
-    }
-
     private static Date toDate(long asn1time) throws ParsingException {
         Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         calendar.set(Calendar.MILLISECOND, 0);
@@ -90,7 +83,6 @@ public final class OpenSSLX509Certificate extends X509Certificate {
 
     public static OpenSSLX509Certificate fromX509DerInputStream(InputStream is)
             throws ParsingException {
-        @SuppressWarnings("resource")
         final OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
 
         try {
@@ -117,7 +109,6 @@ public final class OpenSSLX509Certificate extends X509Certificate {
 
     public static List<OpenSSLX509Certificate> fromPkcs7DerInputStream(InputStream is)
             throws ParsingException {
-        @SuppressWarnings("resource")
         OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
 
         final long[] certRefs;
@@ -148,7 +139,6 @@ public final class OpenSSLX509Certificate extends X509Certificate {
 
     public static OpenSSLX509Certificate fromX509PemInputStream(InputStream is)
             throws ParsingException {
-        @SuppressWarnings("resource")
         final OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
 
         try {
@@ -166,7 +156,6 @@ public final class OpenSSLX509Certificate extends X509Certificate {
 
     public static List<OpenSSLX509Certificate> fromPkcs7PemInputStream(InputStream is)
             throws ParsingException {
-        @SuppressWarnings("resource")
         OpenSSLBIOInputStream bis = new OpenSSLBIOInputStream(is, true);
 
         final long[] certRefs;
@@ -250,14 +239,14 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     }
 
     @Override
-    @SuppressWarnings("JdkObsolete")  // Needed for API compatibility
+    @SuppressWarnings({"JdkObsolete", "JavaUtilDate"})  // Needed for API compatibility
     public void checkValidity() throws CertificateExpiredException,
             CertificateNotYetValidException {
         checkValidity(new Date());
     }
 
     @Override
-    @SuppressWarnings("JdkObsolete")  // Needed for API compatibility
+    @SuppressWarnings({"JdkObsolete", "JavaUtilDate"}) // Needed for API compatibility
     public void checkValidity(Date date) throws CertificateExpiredException,
             CertificateNotYetValidException {
         if (getNotBefore().compareTo(date) > 0) {
@@ -292,11 +281,13 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     }
 
     @Override
+    @SuppressWarnings({"JavaUtilDate"}) // Needed for API compatibility
     public Date getNotBefore() {
         return (Date) notBefore.clone();
     }
 
     @Override
+    @SuppressWarnings({"JavaUtilDate"}) // Needed for API compatibility
     public Date getNotAfter() {
         return (Date) notAfter.clone();
     }
@@ -576,7 +567,7 @@ public final class OpenSSLX509Certificate extends X509Certificate {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("Finalize")
     protected void finalize() throws Throwable {
         try {
             long toFree = mContext;

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -35,7 +35,6 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
@@ -220,44 +219,44 @@ final class SSLParametersImpl implements Cloneable {
         return (SSLParametersImpl) result.clone();
     }
 
-    /**
+    /*
      * Returns the appropriate session context.
      */
     AbstractSessionContext getSessionContext() {
         return client_mode ? clientSessionContext : serverSessionContext;
     }
 
-    /**
-     * @return client session context
+    /*
+     * Returns the client session context.
      */
     ClientSessionContext getClientSessionContext() {
         return clientSessionContext;
     }
 
     /**
-     * @return X.509 key manager or {@code null} for none.
+     * Returns X.509 key manager or null for none.
      */
     X509KeyManager getX509KeyManager() {
         return x509KeyManager;
     }
 
-    /**
-     * @return Pre-Shared Key (PSK) key manager or {@code null} for none.
+    /*
+     * Returns Pre-Shared Key (PSK) key manager or null for none.
      */
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     PSKKeyManager getPSKKeyManager() {
         return pskKeyManager;
     }
 
-    /**
-     * @return X.509 trust manager or {@code null} for none.
+    /*
+     * Returns X.509 trust manager or null for none.
      */
     X509TrustManager getX509TrustManager() {
         return x509TrustManager;
     }
 
-    /**
-     * @return the names of enabled cipher suites
+    /*
+     * Returns the names of enabled cipher suites.
      */
     String[] getEnabledCipherSuites() {
         if (Arrays.asList(enabledProtocols).contains(NativeCrypto.SUPPORTED_PROTOCOL_TLSV1_3)) {
@@ -267,7 +266,7 @@ final class SSLParametersImpl implements Cloneable {
         return enabledCipherSuites.clone();
     }
 
-    /**
+    /*
      * Sets the enabled cipher suites after filtering through OpenSSL.
      */
     void setEnabledCipherSuites(String[] cipherSuites) {
@@ -279,16 +278,15 @@ final class SSLParametersImpl implements Cloneable {
                         NativeCrypto.SUPPORTED_TLS_1_3_CIPHER_SUITES_SET));
     }
 
-    /**
-     * @return the set of enabled protocols
+    /*
+     * Returns the set of enabled protocols.
      */
     String[] getEnabledProtocols() {
         return enabledProtocols.clone();
     }
 
-    /**
+    /*
      * Sets the list of available protocols for use in SSL connection.
-     * @throws IllegalArgumentException if {@code protocols == null}
      */
     void setEnabledProtocols(String[] protocols) {
         if (protocols == null) {
@@ -306,10 +304,8 @@ final class SSLParametersImpl implements Cloneable {
         enabledProtocols = NativeCrypto.checkEnabledProtocols(filteredProtocols).clone();
     }
 
-    /**
+    /*
      * Sets the list of ALPN protocols.
-     *
-     * @param protocols the list of ALPN protocols
      */
     void setApplicationProtocols(String[] protocols) {
         this.applicationProtocols = SSLUtils.encodeProtocols(protocols);
@@ -319,30 +315,29 @@ final class SSLParametersImpl implements Cloneable {
         return SSLUtils.decodeProtocols(applicationProtocols);
     }
 
-    /**
+    /*
      * Used for server-mode only. Sets or clears the application-provided ALPN protocol selector.
-     * If set, will override the protocol list provided by {@link #setApplicationProtocols(String[])}.
+     * If set, will override the protocol list provided by setApplicationProtocols(String[]).
      */
     void setApplicationProtocolSelector(ApplicationProtocolSelectorAdapter applicationProtocolSelector) {
         this.applicationProtocolSelector = applicationProtocolSelector;
     }
 
-    /**
+    /*
      * Returns the application protocol (ALPN) selector for this socket.
      */
     ApplicationProtocolSelectorAdapter getApplicationProtocolSelector() {
         return applicationProtocolSelector;
     }
 
-    /**
+    /*
      * Tunes the peer holding this parameters to work in client mode.
-     * @param   mode if the peer is configured to work in client mode
      */
     void setUseClientMode(boolean mode) {
         client_mode = mode;
     }
 
-    /**
+    /*
      * Returns the value indicating if the parameters configured to work
      * in client mode.
      */
@@ -350,8 +345,8 @@ final class SSLParametersImpl implements Cloneable {
         return client_mode;
     }
 
-    /**
-     * Tunes the peer holding this parameters to require client authentication
+    /*
+     * Tunes the peer holding this parameters to require client authentication.
      */
     void setNeedClientAuth(boolean need) {
         need_client_auth = need;
@@ -359,15 +354,15 @@ final class SSLParametersImpl implements Cloneable {
         want_client_auth = false;
     }
 
-    /**
+    /*
      * Returns the value indicating if the peer with this parameters tuned
-     * to require client authentication
+     * to require client authentication.
      */
     boolean getNeedClientAuth() {
         return need_client_auth;
     }
 
-    /**
+    /*
      * Tunes the peer holding this parameters to request client authentication
      */
     void setWantClientAuth(boolean want) {
@@ -376,7 +371,7 @@ final class SSLParametersImpl implements Cloneable {
         need_client_auth = false;
     }
 
-    /**
+    /*
      * Returns the value indicating if the peer with this parameters
      * tuned to request client authentication
      */
@@ -384,17 +379,17 @@ final class SSLParametersImpl implements Cloneable {
         return want_client_auth;
     }
 
-    /**
+    /*
      * Allows/disallows the peer holding this parameters to
-     * create new SSL session
+     * create new SSL session.
      */
     void setEnableSessionCreation(boolean flag) {
         enable_session_creation = flag;
     }
 
-    /**
+    /*
      * Returns the value indicating if the peer with this parameters
-     * allowed to cteate new SSL session
+     * allowed to cteate new SSL session.
      */
     boolean getEnableSessionCreation() {
         return enable_session_creation;
@@ -404,7 +399,7 @@ final class SSLParametersImpl implements Cloneable {
         this.useSessionTickets = useSessionTickets;
     }
 
-    /**
+    /*
      * Whether connections using this SSL connection should use the TLS
      * extension Server Name Indication (SNI).
      */
@@ -412,7 +407,7 @@ final class SSLParametersImpl implements Cloneable {
         useSni = flag;
     }
 
-    /**
+    /*
      * Returns whether connections using this SSL connection should use the TLS
      * extension Server Name Indication (SNI).
      */
@@ -420,21 +415,21 @@ final class SSLParametersImpl implements Cloneable {
         return useSni != null ? useSni : isSniEnabledByDefault();
     }
 
-    /**
+    /*
      * For testing only.
      */
     void setCTVerificationEnabled(boolean enabled) {
         ctVerificationEnabled = enabled;
     }
 
-    /**
+    /*
      * For testing only.
      */
     void setSCTExtension(byte[] extension) {
         sctExtension = extension;
     }
 
-    /**
+    /*
      * For testing only.
      */
     void setOCSPResponse(byte[] response) {
@@ -445,9 +440,9 @@ final class SSLParametersImpl implements Cloneable {
         return ocspResponse;
     }
 
-    /**
-     * This filters {@code obsoleteProtocol} from the list of {@code protocols}
-     * down to help with app compatibility.
+    /*
+     * Filters obsoleteProtocols from the list of protocols
+     * to help with app compatibility.
      */
     private static String[] filterFromProtocols(String[] protocols,
         List<String> obsoleteProtocols) {
@@ -455,7 +450,7 @@ final class SSLParametersImpl implements Cloneable {
             return EMPTY_STRING_ARRAY;
         }
 
-        ArrayList<String> newProtocols = new ArrayList<String>();
+        ArrayList<String> newProtocols = new ArrayList<>();
         for (String protocol : protocols) {
             if (!obsoleteProtocols.contains(protocol)) {
                 newProtocols.add(protocol);
@@ -468,7 +463,7 @@ final class SSLParametersImpl implements Cloneable {
         if (cipherSuites == null || cipherSuites.length == 0) {
             return cipherSuites;
         }
-        ArrayList<String> newCipherSuites = new ArrayList<String>(cipherSuites.length);
+        ArrayList<String> newCipherSuites = new ArrayList<>(cipherSuites.length);
         for (String cipherSuite : cipherSuites) {
             if (!toRemove.contains(cipherSuite)) {
                 newCipherSuites.add(cipherSuite);
@@ -479,7 +474,7 @@ final class SSLParametersImpl implements Cloneable {
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-    /**
+    /*
      * Returns whether Server Name Indication (SNI) is enabled by default for
      * sockets. For more information on SNI, see RFC 6066 section 3.
      */
@@ -499,11 +494,11 @@ final class SSLParametersImpl implements Cloneable {
         }
     }
 
-    /**
+    /*
      * For abstracting the X509KeyManager calls between
-     * {@link X509KeyManager#chooseClientAlias(String[], java.security.Principal[], java.net.Socket)}
+     * X509KeyManager#chooseClientAlias(String[], java.security.Principal[], java.net.Socket)
      * and
-     * {@link X509ExtendedKeyManager#chooseEngineClientAlias(String[], java.security.Principal[], javax.net.ssl.SSLEngine)}
+     * X509ExtendedKeyManager#chooseEngineClientAlias(String[], java.security.Principal[], javax.net.ssl.SSLEngine)
      */
     interface AliasChooser {
         String chooseClientAlias(X509KeyManager keyManager, X500Principal[] issuers,
@@ -512,9 +507,9 @@ final class SSLParametersImpl implements Cloneable {
         String chooseServerAlias(X509KeyManager keyManager, String keyType);
     }
 
-    /**
-     * For abstracting the {@code PSKKeyManager} calls between those taking an {@code SSLSocket} and
-     * those taking an {@code SSLEngine}.
+    /*
+     * For abstracting the PSKKeyManager calls between those taking an SSLSocket and
+     * those taking an SSLEngine.
      */
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     interface PSKCallbacks {
@@ -523,9 +518,9 @@ final class SSLParametersImpl implements Cloneable {
         SecretKey getPSKKey(PSKKeyManager keyManager, String identityHint, String identity);
     }
 
-    /**
+    /*
      * Returns the clone of this object.
-     * @return the clone.
+     * TODO(prb): Shouldn't need to override this anymore.
      */
     @Override
     protected Object clone() {
@@ -570,10 +565,8 @@ final class SSLParametersImpl implements Cloneable {
         }
     }
 
-    /**
-     * Finds the first {@link X509KeyManager} element in the provided array.
-     *
-     * @return the first {@code X509KeyManager} or {@code null} if not found.
+    /*
+     * Returns the first X509KeyManager element in the provided array.
      */
     private static X509KeyManager findFirstX509KeyManager(KeyManager[] kms) {
         for (KeyManager km : kms) {
@@ -584,10 +577,8 @@ final class SSLParametersImpl implements Cloneable {
         return null;
     }
 
-    /**
-     * Finds the first {@link PSKKeyManager} element in the provided array.
-     *
-     * @return the first {@code PSKKeyManager} or {@code null} if not found.
+    /*
+     * Returns the first PSKKeyManager element in the provided array.
      */
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     private static PSKKeyManager findFirstPSKKeyManager(KeyManager[] kms) {
@@ -605,8 +596,8 @@ final class SSLParametersImpl implements Cloneable {
         return null;
     }
 
-    /**
-     * Gets the default X.509 trust manager.
+    /*
+     * Returns the default X.509 trust manager.
      */
     static X509TrustManager getDefaultX509TrustManager()
             throws KeyManagementException {
@@ -639,11 +630,8 @@ final class SSLParametersImpl implements Cloneable {
         }
     }
 
-    /**
-     * Finds the first {@link X509TrustManager} element in the provided array.
-     *
-     * @return the first {@code X509ExtendedTrustManager} or
-     *         {@code X509TrustManager} or {@code null} if not found.
+    /*
+     * Returns the first X509TrustManager element in the provided array.
      */
     private static X509TrustManager findFirstX509TrustManager(TrustManager[] tms) {
         for (TrustManager tm : tms) {
@@ -722,8 +710,8 @@ final class SSLParametersImpl implements Cloneable {
         }
     }
 
-    /**
-     * Check if SCT verification is enforced for a given hostname.
+    /*
+     * Checks whether SCT verification is enforced for a given hostname.
      */
     boolean isCTVerificationEnabled(String hostname) {
         if (hostname == null) {

--- a/common/src/main/java/org/conscrypt/TrustManagerImpl.java
+++ b/common/src/main/java/org/conscrypt/TrustManagerImpl.java
@@ -60,7 +60,6 @@ import java.security.cert.PKIXRevocationChecker.Option;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -109,7 +108,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
     /**
      * The CertPinManager, which validates the chain against a host-to-pin mapping
      */
-    private CertPinManager pinManager;
+    private final CertPinManager pinManager;
 
     /**
      * The backing store for the AndroidCAStore if non-null. This will
@@ -142,7 +141,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
     private final Exception err;
     private final CertificateFactory factory;
     private final CertBlocklist blocklist;
-    private LogStore ctLogStore;
+    private final LogStore ctLogStore;
     private Verifier ctVerifier;
     private Policy ctPolicy;
 
@@ -194,10 +193,8 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
                 rootKeyStoreLocal = keyStore;
                 trustedCertificateStoreLocal =
                     (certStore != null) ? certStore : Platform.newDefaultCertStore();
-                acceptedIssuersLocal = null;
                 trustedCertificateIndexLocal = new TrustedCertificateIndex();
             } else {
-                rootKeyStoreLocal = null;
                 trustedCertificateStoreLocal = certStore;
                 acceptedIssuersLocal = acceptedIssuers(keyStore);
                 trustedCertificateIndexLocal
@@ -249,7 +246,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
 
             // TODO remove duplicates if same cert is found in both a
             // PrivateKeyEntry and TrustedCertificateEntry
-            List<X509Certificate> trusted = new ArrayList<X509Certificate>();
+            List<X509Certificate> trusted = new ArrayList<>();
             for (Enumeration<String> en = ks.aliases(); en.hasMoreElements();) {
                 final String alias = en.nextElement();
                 final X509Certificate cert = (X509Certificate) ks.getCertificate(alias);
@@ -257,14 +254,14 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
                     trusted.add(cert);
                 }
             }
-            return trusted.toArray(new X509Certificate[trusted.size()]);
+            return trusted.toArray(new X509Certificate[0]);
         } catch (KeyStoreException e) {
             return new X509Certificate[0];
         }
     }
 
     private static Set<TrustAnchor> trustAnchors(X509Certificate[] certs) {
-        Set<TrustAnchor> trustAnchors = new HashSet<TrustAnchor>(certs.length);
+        Set<TrustAnchor> trustAnchors = new HashSet<>(certs.length);
         for (X509Certificate cert : certs) {
             trustAnchors.add(new TrustAnchor(cert, null));
         }
@@ -335,7 +332,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
 
     /**
      * Returns the full trusted certificate chain found from {@code certs}.
-     *
+     * <p>
      * Throws {@link CertificateException} when no trusted chain can be found from {@code certs}.
      */
     public List<X509Certificate> getTrustedChainForServer(X509Certificate[] certs,
@@ -352,7 +349,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
 
     /**
      * Returns the full trusted certificate chain found from {@code certs}.
-     *
+     * <p>
      * Throws {@link CertificateException} when no trusted chain can be found from {@code certs}.
      */
     public List<X509Certificate> getTrustedChainForServer(X509Certificate[] certs,
@@ -476,15 +473,15 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
     private List<X509Certificate> checkTrusted(X509Certificate[] certs, byte[] ocspData,
             byte[] tlsSctData, String authType, String host, boolean clientAuth)
             throws CertificateException {
-        if (certs == null || certs.length == 0 || authType == null || authType.length() == 0) {
+        if (certs == null || certs.length == 0 || authType == null || authType.isEmpty()) {
             throw new IllegalArgumentException("null or zero-length parameter");
         }
         if (err != null) {
             throw new CertificateException(err);
         }
-        Set<X509Certificate> used = new HashSet<X509Certificate>();
-        ArrayList<X509Certificate> untrustedChain = new ArrayList<X509Certificate>();
-        ArrayList<TrustAnchor> trustedChain = new ArrayList<TrustAnchor>();
+        Set<X509Certificate> used = new HashSet<>();
+        List<X509Certificate> untrustedChain = new ArrayList<>();
+        List<TrustAnchor> trustedChain = new ArrayList<>();
         // Initialize the chain to contain the leaf certificate. This potentially could be a trust
         // anchor. If the leaf is a trust anchor we still continue with path building to build the
         // complete trusted chain for additional validation such as certificate pinning.
@@ -504,7 +501,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
     /**
      * Recursively build certificate chains until a valid chain is found or all possible paths are
      * exhausted.
-     *
+     * <p>
      * The chain is built in two sections, the complete trusted path is the the combination of
      * {@code untrustedChain} and {@code trustAnchorChain}. The chain begins at the leaf
      * certificate and ends in the final trusted root certificate.
@@ -526,7 +523,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
      */
     private List<X509Certificate> checkTrustedRecursive(X509Certificate[] certs, byte[] ocspData,
             byte[] tlsSctData, String host, boolean clientAuth,
-            ArrayList<X509Certificate> untrustedChain, ArrayList<TrustAnchor> trustAnchorChain,
+            List<X509Certificate> untrustedChain, List<TrustAnchor> trustAnchorChain,
             Set<X509Certificate> used) throws CertificateException {
         CertificateException lastException = null;
         X509Certificate current;
@@ -668,8 +665,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
                         "Trust anchor for certification path not found.", null, certPath, -1));
             }
 
-            List<X509Certificate> wholeChain = new ArrayList<X509Certificate>();
-            wholeChain.addAll(untrustedChain);
+            List<X509Certificate> wholeChain = new ArrayList<>(untrustedChain);
             for (TrustAnchor anchor : trustAnchorChain) {
                 wholeChain.add(anchor.getTrustedCert());
             }
@@ -698,7 +694,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
 
             // Validate the untrusted part of the chain
             try {
-                Set<TrustAnchor> anchorSet = new HashSet<TrustAnchor>();
+                Set<TrustAnchor> anchorSet = new HashSet<>();
                 // We know that untrusted chains to the first trust anchor, only add that.
                 anchorSet.add(trustAnchorChain.get(0));
                 PKIXParameters params = new PKIXParameters(anchorSet);
@@ -762,7 +758,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
 
         PKIXRevocationChecker revChecker = null;
         List<PKIXCertPathChecker> checkers =
-                new ArrayList<PKIXCertPathChecker>(params.getCertPathCheckers());
+                new ArrayList<>(params.getCertPathCheckers());
         for (PKIXCertPathChecker checker : checkers) {
             if (checker instanceof PKIXRevocationChecker) {
                 revChecker = (PKIXRevocationChecker) checker;
@@ -803,7 +799,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
         if (anchors.size() <= 1) {
             return anchors;
         }
-        List<TrustAnchor> sortedAnchors = new ArrayList<TrustAnchor>(anchors);
+        List<TrustAnchor> sortedAnchors = new ArrayList<>(anchors);
         Collections.sort(sortedAnchors, TRUST_ANCHOR_COMPARATOR);
         return sortedAnchors;
     }
@@ -848,7 +844,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
         private static final String EKU_msSGC = "1.3.6.1.4.1.311.10.3.3";
 
         private static final Set<String> SUPPORTED_EXTENSIONS
-                = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(EKU_OID)));
+                = Collections.unmodifiableSet(new HashSet<>(Collections.singletonList(EKU_OID)));
 
         private final boolean clientAuth;
         private final X509Certificate leaf;
@@ -859,7 +855,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
         }
 
         @Override
-        public void init(boolean forward) throws CertPathValidatorException {
+        public void init(boolean forward) {
         }
 
         @Override
@@ -946,7 +942,7 @@ public final class TrustManagerImpl extends X509ExtendedTrustManager {
         if (storeAnchors.isEmpty()) {
             return indexedAnchors;
         }
-        Set<TrustAnchor> result = new HashSet<TrustAnchor>(storeAnchors.size());
+        Set<TrustAnchor> result = new HashSet<>(storeAnchors.size());
         for (X509Certificate storeCert : storeAnchors) {
             result.add(trustedCertificateIndex.index(storeCert));
         }

--- a/common/src/main/java/org/conscrypt/ct/CertificateEntry.java
+++ b/common/src/main/java/org/conscrypt/ct/CertificateEntry.java
@@ -42,8 +42,20 @@ import org.conscrypt.OpenSSLX509Certificate;
 @Internal
 public class CertificateEntry {
     public enum LogEntryType {
-        X509_ENTRY,
-        PRECERT_ENTRY
+        X509_ENTRY(0),
+        PRECERT_ENTRY(1)
+        ;
+        private final int value;
+
+        LogEntryType(int value) {
+            this.value = value;
+        }
+
+        int value() {
+            return value;
+        }
+
+
     }
 
     private final LogEntryType entryType;
@@ -124,7 +136,7 @@ public class CertificateEntry {
      * TLS encode the CertificateEntry structure.
      */
     public void encode(OutputStream output) throws SerializationException {
-        Serialization.writeNumber(output, entryType.ordinal(), Constants.LOG_ENTRY_TYPE_LENGTH);
+        Serialization.writeNumber(output, entryType.value(), Constants.LOG_ENTRY_TYPE_LENGTH);
         if (entryType == LogEntryType.PRECERT_ENTRY) {
             Serialization.writeFixedBytes(output, issuerKeyHash);
         }

--- a/common/src/main/java/org/conscrypt/ct/SignedCertificateTimestamp.java
+++ b/common/src/main/java/org/conscrypt/ct/SignedCertificateTimestamp.java
@@ -28,19 +28,40 @@ import org.conscrypt.Internal;
 @Internal
 public class SignedCertificateTimestamp {
     public enum Version {
-        V1
-    };
+            V1(0)
+        ;
+
+        private final int value;
+
+        Version(int value) {
+            this.value = value;
+        }
+
+        int value() {
+            return value;
+        }
+    }
 
     public enum SignatureType {
-        CERTIFICATE_TIMESTAMP,
-        TREE_HASH
-    };
+        CERTIFICATE_TIMESTAMP(0),
+        TREE_HASH(1)
+        ;
+        private final int value;
+
+        SignatureType(int value) {
+            this.value = value;
+        }
+
+        int value() {
+            return value;
+        }
+    }
 
     public enum Origin {
         EMBEDDED,
         TLS_EXTENSION,
         OCSP_RESPONSE
-    };
+    }
 
     private final Version version;
     private final byte[] logId;
@@ -88,7 +109,7 @@ public class SignedCertificateTimestamp {
     public static SignedCertificateTimestamp decode(InputStream input, Origin origin)
             throws SerializationException {
         int version = Serialization.readNumber(input, Constants.VERSION_LENGTH);
-        if (version != Version.V1.ordinal()) {
+        if (version != Version.V1.value()) {
             throw new SerializationException("Unsupported SCT version " + version);
         }
 
@@ -112,8 +133,8 @@ public class SignedCertificateTimestamp {
      */
     public void encodeTBS(OutputStream output, CertificateEntry certEntry)
             throws SerializationException {
-        Serialization.writeNumber(output, version.ordinal(), Constants.VERSION_LENGTH);
-        Serialization.writeNumber(output, SignatureType.CERTIFICATE_TIMESTAMP.ordinal(),
+        Serialization.writeNumber(output, version.value(), Constants.VERSION_LENGTH);
+        Serialization.writeNumber(output, SignatureType.CERTIFICATE_TIMESTAMP.value(),
                 Constants.SIGNATURE_TYPE_LENGTH);
         Serialization.writeNumber(output, timestamp, Constants.TIMESTAMP_LENGTH);
         certEntry.encode(output);

--- a/common/src/test/java/org/conscrypt/ChainStrengthAnalyzerTest.java
+++ b/common/src/test/java/org/conscrypt/ChainStrengthAnalyzerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -361,7 +362,7 @@ public class ChainStrengthAnalyzerTest {
 
     private static X509Certificate createCert(String pem) throws Exception {
         CertificateFactory cf = CertificateFactory.getInstance("X509");
-        InputStream pemInput = new ByteArrayInputStream(pem.getBytes("UTF-8"));
+        InputStream pemInput = new ByteArrayInputStream(pem.getBytes(StandardCharsets.UTF_8));
         return (X509Certificate) cf.generateCertificate(pemInput);
     }
 }

--- a/common/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/KeyPairGeneratorTest.java
@@ -117,19 +117,15 @@ public class KeyPairGeneratorTest {
             });
     }
 
-    private static final Map<String, List<Integer>> KEY_SIZES
-            = new HashMap<String, List<Integer>>();
+    private static final Map<String, List<Integer>> KEY_SIZES = new HashMap<>();
     private static void putKeySize(String algorithm, int keySize) {
-        algorithm = algorithm.toUpperCase();
-        List<Integer> keySizes = KEY_SIZES.get(algorithm);
-        if (keySizes == null) {
-            keySizes = new ArrayList<Integer>();
-            KEY_SIZES.put(algorithm, keySizes);
-        }
+        algorithm = algorithm.toUpperCase(Locale.ROOT);
+        List<Integer> keySizes = KEY_SIZES.
+                computeIfAbsent(algorithm, k -> new ArrayList<>());
         keySizes.add(keySize);
     }
     private static List<Integer> getKeySizes(String algorithm) throws Exception {
-        algorithm = algorithm.toUpperCase();
+        algorithm = algorithm.toUpperCase(Locale.ROOT);
         List<Integer> keySizes = KEY_SIZES.get(algorithm);
         if (keySizes == null) {
             throw new Exception("Unknown key sizes for KeyPairGenerator." + algorithm);
@@ -192,7 +188,7 @@ public class KeyPairGeneratorTest {
             test_KeyPair(kpg, kpg.genKeyPair());
             test_KeyPair(kpg, kpg.generateKeyPair());
 
-            kpg.initialize(keySize, (SecureRandom) null);
+            kpg.initialize(keySize, null);
             test_KeyPair(kpg, kpg.genKeyPair());
             test_KeyPair(kpg, kpg.generateKeyPair());
 
@@ -213,7 +209,7 @@ public class KeyPairGeneratorTest {
                 test_KeyPair(kpg, kpg.genKeyPair());
                 test_KeyPair(kpg, kpg.generateKeyPair());
 
-                kpg.initialize(new ECGenParameterSpec(curveName), (SecureRandom) null);
+                kpg.initialize(new ECGenParameterSpec(curveName), null);
                 test_KeyPair(kpg, kpg.genKeyPair());
                 test_KeyPair(kpg, kpg.generateKeyPair());
 
@@ -235,7 +231,7 @@ public class KeyPairGeneratorTest {
         if (StandardNames.IS_RI && expectedAlgorithm.equals("DIFFIEHELLMAN")) {
             expectedAlgorithm = "DH";
         }
-        assertEquals(expectedAlgorithm, k.getAlgorithm().toUpperCase());
+        assertEquals(expectedAlgorithm, k.getAlgorithm().toUpperCase(Locale.ROOT));
         if (expectedAlgorithm.equals("DH")) {
             if (k instanceof DHPublicKey) {
                 DHPublicKey dhPub = (DHPublicKey) k;
@@ -364,7 +360,7 @@ public class KeyPairGeneratorTest {
     /**
      * DH parameters pre-generated so that the test doesn't take too long.
      * These parameters were generated with:
-     *
+     * <p>
      * openssl gendh 512 | openssl dhparams -C
      */
     private static DHParameterSpec getDHParams() {

--- a/common/src/test/java/org/conscrypt/java/security/MessageDigestTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/MessageDigestTest.java
@@ -20,9 +20,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.conscrypt.TestUtils;
 import org.junit.Test;
@@ -48,44 +48,38 @@ public final class MessageDigestTest {
     }
 
     @Test
-    public void test_getInstance() throws Exception {
+    public void test_getInstance() {
         ServiceTester.test("MessageDigest")
-            .run(new ServiceTester.Test() {
-                @Override
-                public void test(Provider provider, String algorithm) throws Exception {
-                    // MessageDigest.getInstance(String)
-                    MessageDigest md1 = MessageDigest.getInstance(algorithm);
-                    assertEquals(algorithm, md1.getAlgorithm());
-                    test_MessageDigest(md1);
+            .run((provider, algorithm) -> {
+                // MessageDigest.getInstance(String)
+                MessageDigest md1 = MessageDigest.getInstance(algorithm);
+                assertEquals(algorithm, md1.getAlgorithm());
+                test_MessageDigest(md1);
 
-                    // MessageDigest.getInstance(String, Provider)
-                    MessageDigest md2 = MessageDigest.getInstance(algorithm, provider);
-                    assertEquals(algorithm, md2.getAlgorithm());
-                    assertEquals(provider, md2.getProvider());
-                    test_MessageDigest(md2);
+                // MessageDigest.getInstance(String, Provider)
+                MessageDigest md2 = MessageDigest.getInstance(algorithm, provider);
+                assertEquals(algorithm, md2.getAlgorithm());
+                assertEquals(provider, md2.getProvider());
+                test_MessageDigest(md2);
 
-                    // MessageDigest.getInstance(String, String)
-                    MessageDigest md3 = MessageDigest.getInstance(algorithm, provider.getName());
-                    assertEquals(algorithm, md3.getAlgorithm());
-                    assertEquals(provider, md3.getProvider());
-                    test_MessageDigest(md3);
-                }
+                // MessageDigest.getInstance(String, String)
+                MessageDigest md3 = MessageDigest.getInstance(algorithm, provider.getName());
+                assertEquals(algorithm, md3.getAlgorithm());
+                assertEquals(provider, md3.getProvider());
+                test_MessageDigest(md3);
             });
     }
 
     private static final Map<String, Map<String, byte[]>> EXPECTATIONS
-            = new HashMap<String, Map<String, byte[]>>();
+            = new HashMap<>();
     private static void putExpectation(String algorithm, String inputName, byte[] expected) {
-        algorithm = algorithm.toUpperCase();
-        Map<String, byte[]> expectations = EXPECTATIONS.get(algorithm);
-        if (expectations == null) {
-            expectations = new HashMap<String, byte[]>();
-            EXPECTATIONS.put(algorithm, expectations);
-        }
+        algorithm = algorithm.toUpperCase(Locale.ROOT);
+        Map<String, byte[]> expectations =
+                EXPECTATIONS.computeIfAbsent(algorithm, k -> new HashMap<>());
         expectations.put(inputName, expected);
     }
     private static Map<String, byte[]> getExpectations(String algorithm) throws Exception {
-        algorithm = algorithm.toUpperCase();
+        algorithm = algorithm.toUpperCase(Locale.ROOT);
         Map<String, byte[]> expectations = EXPECTATIONS.get(algorithm);
         if (expectations == null) {
             throw new Exception("No expectations for MessageDigest." + algorithm);
@@ -240,7 +234,7 @@ public final class MessageDigestTest {
             if (inputName.equals(INPUT_EMPTY)) {
                 actual = md.digest();
             } else if (inputName.equals(INPUT_256MB)) {
-                byte[] mb = new byte[1 * 1024 * 1024];
+                byte[] mb = new byte[1024 * 1024];
                 for (int i = 0; i < 256; i++) {
                     md.update(mb);
                 }

--- a/common/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/cert/CertificateFactoryTest.java
@@ -429,7 +429,7 @@ public class CertificateFactoryTest {
             // which technically doesn't satisfy the method contract, but we'll accept it
             assertTrue((c == null) && cf.getProvider().getName().equals("BC"));
         } catch (CertificateException maybeExpected) {
-            assertFalse(cf.getProvider().getName().equals("BC"));
+            assertNotEquals("BC", cf.getProvider().getName());
         }
 
         try {
@@ -438,7 +438,7 @@ public class CertificateFactoryTest {
             // which technically doesn't satisfy the method contract, but we'll accept it
             assertTrue((c == null) && cf.getProvider().getName().equals("BC"));
         } catch (CertificateException maybeExpected) {
-            assertFalse(cf.getProvider().getName().equals("BC"));
+            assertNotEquals("BC", cf.getProvider().getName());
         }
 
     }
@@ -486,7 +486,7 @@ public class CertificateFactoryTest {
 
     }
 
-    private void test_generateCertificate_InputStream_Empty(CertificateFactory cf) throws Exception {
+    private void test_generateCertificate_InputStream_Empty(CertificateFactory cf) {
         try {
             Certificate c = cf.generateCertificate(new ByteArrayInputStream(new byte[0]));
             if (!"BC".equals(cf.getProvider().getName())) {
@@ -500,8 +500,7 @@ public class CertificateFactoryTest {
         }
     }
 
-    private void test_generateCertificate_InputStream_InvalidStart_Failure(CertificateFactory cf)
-            throws Exception {
+    private void test_generateCertificate_InputStream_InvalidStart_Failure(CertificateFactory cf) {
         try {
             Certificate c = cf.generateCertificate(new ByteArrayInputStream(
                     "-----BEGIN CERTIFICATE-----".getBytes(Charset.defaultCharset())));
@@ -538,7 +537,7 @@ public class CertificateFactoryTest {
 
         private long mMarked = 0;
 
-        private InputStream mStream;
+        private final InputStream mStream;
 
         public MeasuredInputStream(InputStream is) {
             mStream = is;
@@ -649,12 +648,12 @@ public class CertificateFactoryTest {
         KeyHolder cert2 = generateCertificate(false, cert1);
         KeyHolder cert3 = generateCertificate(false, cert2);
 
-        List<X509Certificate> certs = new ArrayList<X509Certificate>();
+        List<X509Certificate> certs = new ArrayList<>();
         certs.add(cert3.certificate);
         certs.add(cert2.certificate);
         certs.add(cert1.certificate);
 
-        List<X509Certificate> duplicatedCerts = new ArrayList<X509Certificate>(certs);
+        List<X509Certificate> duplicatedCerts = new ArrayList<>(certs);
         duplicatedCerts.add(cert2.certificate);
 
         Provider[] providers = Security.getProviders("CertificateFactory.X509");
@@ -794,7 +793,7 @@ public class CertificateFactoryTest {
         public PrivateKey privateKey;
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation", "JavaUtilDate"})
     private static KeyHolder generateCertificate(boolean isCa, KeyHolder issuer) throws Exception {
         Date startDate = new Date();
 
@@ -812,7 +811,7 @@ public class CertificateFactoryTest {
         PrivateKey caKey;
         if (issuer != null) {
             serial = issuer.certificate.getSerialNumber().add(BigInteger.ONE);
-            subjectPrincipal = new X500Principal("CN=Test Certificate Serial #" + serial.toString());
+            subjectPrincipal = new X500Principal("CN=Test Certificate Serial #" + serial);
             issuerPrincipal = issuer.certificate.getSubjectX500Principal();
             caKey = issuer.privateKey;
         } else {
@@ -924,7 +923,7 @@ public class CertificateFactoryTest {
             // which technically doesn't satisfy the method contract, but we'll accept it
             assertTrue((c == null) && cf.getProvider().getName().equals("BC"));
         } catch (CRLException maybeExpected) {
-            assertFalse(cf.getProvider().getName().equals("BC"));
+            assertNotEquals("BC", cf.getProvider().getName());
         }
 
         try {
@@ -933,7 +932,7 @@ public class CertificateFactoryTest {
             // which technically doesn't satisfy the method contract, but we'll accept it
             assertTrue((c == null) && cf.getProvider().getName().equals("BC"));
         } catch (CRLException maybeExpected) {
-            assertFalse(cf.getProvider().getName().equals("BC"));
+            assertNotEquals("BC", cf.getProvider().getName());
         }
 
     }

--- a/common/src/test/java/org/conscrypt/java/security/cert/X509CRLTest.java
+++ b/common/src/test/java/org/conscrypt/java/security/cert/X509CRLTest.java
@@ -33,6 +33,8 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509CRLEntry;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
+import java.util.Locale;
+
 import org.conscrypt.TestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -127,7 +129,7 @@ public class X509CRLTest {
                     X509Certificate ca = (X509Certificate) cf.generateCertificate(
                             new ByteArrayInputStream(CA_CERT.getBytes(StandardCharsets.US_ASCII)));
 
-                    assertEquals("SHA256WITHRSA", crl.getSigAlgName().toUpperCase());
+                    assertEquals("SHA256WITHRSA", crl.getSigAlgName().toUpperCase(Locale.ROOT));
                     crl.verify(ca.getPublicKey());
                     try {
                         crl.verify(revoked.getPublicKey());

--- a/common/src/test/java/org/conscrypt/javax/crypto/CipherTest.java
+++ b/common/src/test/java/org/conscrypt/javax/crypto/CipherTest.java
@@ -16,8 +16,10 @@
 
 package org.conscrypt.javax.crypto;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -145,7 +147,7 @@ public final class CipherTest {
         return true;
     }
 
-    /**
+    /*
      * Checks for algorithms removed from BC in Android 12 and so not usable for these
      * tests.
      *
@@ -177,20 +179,17 @@ public final class CipherTest {
             return false;
         }
         // AESWRAP should be used instead, fails with BC and SunJCE otherwise.
-        if (algorithm.startsWith("AES") || algorithm.startsWith("DESEDE")) {
-            return false;
-        }
-        return true;
+        return !algorithm.startsWith("AES") && !algorithm.startsWith("DESEDE");
     }
 
-    private synchronized static int getEncryptMode(String algorithm) throws Exception {
+    private synchronized static int getEncryptMode(String algorithm) {
         if (isOnlyWrappingAlgorithm(algorithm)) {
             return Cipher.WRAP_MODE;
         }
         return Cipher.ENCRYPT_MODE;
     }
 
-    private synchronized static int getDecryptMode(String algorithm) throws Exception {
+    private synchronized static int getDecryptMode(String algorithm) {
         if (isOnlyWrappingAlgorithm(algorithm)) {
             return Cipher.UNWRAP_MODE;
         }
@@ -307,7 +306,7 @@ public final class CipherTest {
                 || algorithm.contains("/OAEPWITH");
     }
 
-    private static Map<String, Key> ENCRYPT_KEYS = new HashMap<String, Key>();
+    private static final Map<String, Key> ENCRYPT_KEYS = new HashMap<>();
 
     /**
      * Returns the key meant for enciphering for {@code algorithm}.
@@ -342,7 +341,7 @@ public final class CipherTest {
         return key;
     }
 
-    private static Map<String, Key> DECRYPT_KEYS = new HashMap<String, Key>();
+    private static final Map<String, Key> DECRYPT_KEYS = new HashMap<>();
 
     /**
      * Returns the key meant for deciphering for {@code algorithm}.
@@ -371,7 +370,7 @@ public final class CipherTest {
         return key;
     }
 
-    private static Map<String, Integer> EXPECTED_BLOCK_SIZE = new HashMap<String, Integer>();
+    private static final Map<String, Integer> EXPECTED_BLOCK_SIZE = new HashMap<>();
     static {
         setExpectedBlockSize("AES", 16);
         setExpectedBlockSize("AES/CBC/PKCS5PADDING", 16);
@@ -559,7 +558,7 @@ public final class CipherTest {
         return getExpectedSize(EXPECTED_BLOCK_SIZE, algorithm, mode, provider);
     }
 
-    private static Map<String, Integer> EXPECTED_OUTPUT_SIZE = new HashMap<String, Integer>();
+    private static final Map<String, Integer> EXPECTED_OUTPUT_SIZE = new HashMap<>();
     static {
         setExpectedOutputSize("AES/CBC/NOPADDING", 0);
         setExpectedOutputSize("AES/CFB/NOPADDING", 0);
@@ -780,14 +779,14 @@ public final class CipherTest {
         return getExpectedSize(EXPECTED_OUTPUT_SIZE, algorithm, mode, provider);
     }
 
-    private static byte[] ORIGINAL_PLAIN_TEXT = new byte[] { 0x0a, 0x0b, 0x0c };
-    private static byte[] SIXTEEN_BYTE_BLOCK_PLAIN_TEXT = new byte[] { 0x0a, 0x0b, 0x0c, 0x00,
-                                                                       0x00, 0x00, 0x00, 0x00,
-                                                                       0x00, 0x00, 0x00, 0x00,
-                                                                       0x00, 0x00, 0x00, 0x00 };
-    private static byte[] EIGHT_BYTE_BLOCK_PLAIN_TEXT = new byte[] { 0x0a, 0x0b, 0x0c, 0x00,
-                                                                     0x00, 0x00, 0x00, 0x00 };
-    private static byte[] PKCS1_BLOCK_TYPE_00_PADDED_PLAIN_TEXT = new byte[] {
+    private static final byte[] ORIGINAL_PLAIN_TEXT = new byte[] { 0x0a, 0x0b, 0x0c };
+    private static final byte[] SIXTEEN_BYTE_BLOCK_PLAIN_TEXT = new byte[] { 0x0a, 0x0b, 0x0c, 0x00,
+                                                                             0x00, 0x00, 0x00, 0x00,
+                                                                             0x00, 0x00, 0x00, 0x00,
+                                                                             0x00, 0x00, 0x00, 0x00 };
+    private static final byte[] EIGHT_BYTE_BLOCK_PLAIN_TEXT = new byte[] { 0x0a, 0x0b, 0x0c, 0x00,
+            0x00, 0x00, 0x00, 0x00 };
+    private static final byte[] PKCS1_BLOCK_TYPE_00_PADDED_PLAIN_TEXT = new byte[] {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -805,7 +804,7 @@ public final class CipherTest {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0a, 0x0b, 0x0c
     };
-    private static byte[] PKCS1_BLOCK_TYPE_01_PADDED_PLAIN_TEXT = new byte[] {
+    private static final byte[] PKCS1_BLOCK_TYPE_01_PADDED_PLAIN_TEXT = new byte[] {
         (byte) 0x00, (byte) 0x01, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
@@ -839,7 +838,7 @@ public final class CipherTest {
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0x00, (byte) 0x0a, (byte) 0x0b, (byte) 0x0c
     };
-    private static byte[] PKCS1_BLOCK_TYPE_02_PADDED_PLAIN_TEXT = new byte[] {
+    private static final byte[] PKCS1_BLOCK_TYPE_02_PADDED_PLAIN_TEXT = new byte[] {
         (byte) 0x00, (byte) 0x02, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
         (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
@@ -1032,8 +1031,8 @@ public final class CipherTest {
         final ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(errBuffer);
 
-        Set<String> seenBaseCipherNames = new HashSet<String>();
-        Set<String> seenCiphersWithModeAndPadding = new HashSet<String>();
+        Set<String> seenBaseCipherNames = new HashSet<>();
+        Set<String> seenCiphersWithModeAndPadding = new HashSet<>();
 
         Provider[] providers = Security.getProviders();
         for (Provider provider : providers) {
@@ -1122,7 +1121,7 @@ public final class CipherTest {
 
         out.flush();
         if (errBuffer.size() > 0) {
-            throw new Exception("Errors encountered:\n\n" + errBuffer.toString() + "\n\n");
+            throw new Exception("Errors encountered:\n\n" + errBuffer + "\n\n");
         }
     }
 
@@ -1355,7 +1354,7 @@ public final class CipherTest {
 
     private void assertCorrectAlgorithmParameters(String providerName, String cipherID,
             final AlgorithmParameterSpec spec, AlgorithmParameters params)
-            throws InvalidParameterSpecException, Exception {
+            throws Exception {
         if (spec == null) {
             return;
         }
@@ -1392,7 +1391,7 @@ public final class CipherTest {
     }
 
     private static void assertOAEPParametersEqual(OAEPParameterSpec expectedOaepSpec,
-            OAEPParameterSpec actualOaepSpec) throws Exception {
+            OAEPParameterSpec actualOaepSpec) {
         assertEquals(expectedOaepSpec.getDigestAlgorithm(), actualOaepSpec.getDigestAlgorithm());
 
         assertEquals(expectedOaepSpec.getMGFAlgorithm(), actualOaepSpec.getMGFAlgorithm());
@@ -1434,7 +1433,7 @@ public final class CipherTest {
         }
 
         try {
-            c.init(encryptMode, encryptKey, (AlgorithmParameterSpec) null, (SecureRandom) null);
+            c.init(encryptMode, encryptKey, (AlgorithmParameterSpec) null, null);
         } catch (InvalidAlgorithmParameterException e) {
             if (!isPBE(c.getAlgorithm())) {
                 throw e;
@@ -1450,7 +1449,7 @@ public final class CipherTest {
         }
 
         try {
-            c.init(encryptMode, encryptKey, (AlgorithmParameters) null, (SecureRandom) null);
+            c.init(encryptMode, encryptKey, (AlgorithmParameters) null, null);
         } catch (InvalidAlgorithmParameterException e) {
             if (!isPBE(c.getAlgorithm())) {
                 throw e;
@@ -1472,7 +1471,7 @@ public final class CipherTest {
         }
 
         try {
-            c.init(decryptMode, encryptKey, (AlgorithmParameterSpec) null, (SecureRandom) null);
+            c.init(decryptMode, encryptKey, (AlgorithmParameterSpec) null, null);
             if (needsParameters) {
                 fail("Should throw InvalidAlgorithmParameterException with null parameters");
             }
@@ -1494,7 +1493,7 @@ public final class CipherTest {
         }
 
         try {
-            c.init(decryptMode, encryptKey, (AlgorithmParameters) null, (SecureRandom) null);
+            c.init(decryptMode, encryptKey, (AlgorithmParameters) null, null);
             if (needsParameters) {
                 fail("Should throw InvalidAlgorithmParameterException with null parameters");
             }
@@ -1556,9 +1555,9 @@ public final class CipherTest {
         }
         byte[] plainText = c.doFinal(cipherText);
         byte[] expectedPlainText = getExpectedPlainText(algorithm, provider);
-        assertTrue("Expected " + Arrays.toString(expectedPlainText)
-                + " but was " + Arrays.toString(plainText),
-                Arrays.equals(expectedPlainText, plainText));
+        assertArrayEquals("Expected " + Arrays.toString(expectedPlainText) + " but was "
+                + Arrays.toString(plainText)
+                , expectedPlainText, plainText);
     }
 
     @Test
@@ -1735,7 +1734,7 @@ public final class CipherTest {
         }
     }
 
-    private Certificate certificateWithKeyUsage(int keyUsage) throws Exception {
+    private Certificate certificateWithKeyUsage(int keyUsage) {
         // note the rare usage of non-zero keyUsage
         return new TestKeyStore.Builder()
                 .aliasPrefix("rsa-dsa-ec")
@@ -2581,13 +2580,13 @@ public final class CipherTest {
          */
         c.init(Cipher.ENCRYPT_MODE, privKey);
         byte[] encrypted = c.doFinal(RSA_2048_Vector1);
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_Encrypt_Private, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_Encrypt_Private, encrypted);
 
         c.init(Cipher.DECRYPT_MODE, privKey);
         encrypted = c.doFinal(RSA_2048_Vector1);
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_Encrypt_Private, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_Encrypt_Private, encrypted);
     }
 
     @Test
@@ -2610,14 +2609,14 @@ public final class CipherTest {
         c.init(Cipher.ENCRYPT_MODE, privKey);
         c.update(RSA_2048_Vector1);
         byte[] encrypted = c.doFinal();
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_Encrypt_Private, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_Encrypt_Private, encrypted);
 
         c.init(Cipher.DECRYPT_MODE, privKey);
         c.update(RSA_2048_Vector1);
         encrypted = c.doFinal();
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_Encrypt_Private, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_Encrypt_Private, encrypted);
     }
 
     @Test
@@ -2645,16 +2644,16 @@ public final class CipherTest {
             c.update(RSA_2048_Vector1, i, 1);
         }
         byte[] encrypted = c.doFinal(RSA_2048_Vector1, i, RSA_2048_Vector1.length - i);
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_Encrypt_Private, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_Encrypt_Private, encrypted);
 
         c.init(Cipher.DECRYPT_MODE, privKey);
         for (i = 0; i < RSA_2048_Vector1.length / 2; i++) {
             c.update(RSA_2048_Vector1, i, 1);
         }
         encrypted = c.doFinal(RSA_2048_Vector1, i, RSA_2048_Vector1.length - i);
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_Encrypt_Private, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_Encrypt_Private, encrypted);
     }
 
     @Test
@@ -2680,16 +2679,16 @@ public final class CipherTest {
                 .doFinal(RSA_2048_Vector1, 0, RSA_2048_Vector1.length, encrypted, 0);
         assertEquals("Encrypted size should match expected", RSA_Vector1_Encrypt_Private.length,
                 encryptLen);
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_Encrypt_Private, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_Encrypt_Private, encrypted);
 
         c.init(Cipher.DECRYPT_MODE, privKey);
         final int decryptLen = c
                 .doFinal(RSA_2048_Vector1, 0, RSA_2048_Vector1.length, encrypted, 0);
         assertEquals("Encrypted size should match expected", RSA_Vector1_Encrypt_Private.length,
                 decryptLen);
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_Encrypt_Private, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_Encrypt_Private, encrypted);
     }
 
     @Test
@@ -2836,13 +2835,13 @@ public final class CipherTest {
          */
         c.init(Cipher.ENCRYPT_MODE, pubKey);
         byte[] encrypted = c.doFinal(TooShort_Vector);
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_ZeroPadded_Encrypted, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_ZeroPadded_Encrypted, encrypted);
 
         c.init(Cipher.DECRYPT_MODE, pubKey);
         encrypted = c.doFinal(TooShort_Vector);
-        assertTrue("Encrypted should match expected",
-                Arrays.equals(RSA_Vector1_ZeroPadded_Encrypted, encrypted));
+        assertArrayEquals("Encrypted should match expected",
+                RSA_Vector1_ZeroPadded_Encrypted, encrypted);
     }
 
     @Test
@@ -2916,7 +2915,7 @@ public final class CipherTest {
             c.doFinal(RSA_Vector1_ZeroPadded_Encrypted);
             fail("Should have error when block size is too big.");
         } catch (IllegalBlockSizeException success) {
-            assertFalse(provider, "BC".equals(provider));
+            assertNotEquals("BC", provider);
         } catch (ArrayIndexOutOfBoundsException success) {
             assertEquals("BC", provider);
         }
@@ -2951,7 +2950,7 @@ public final class CipherTest {
             c.doFinal(RSA_Vector1_ZeroPadded_Encrypted);
             fail("Should have error when block size is too big.");
         } catch (IllegalBlockSizeException success) {
-            assertFalse(provider, "BC".equals(provider));
+            assertNotEquals("BC", provider);
         } catch (ArrayIndexOutOfBoundsException success) {
             assertEquals("BC", provider);
         }
@@ -2986,7 +2985,7 @@ public final class CipherTest {
             c.doFinal(tooBig_Vector);
             fail("Should have error when block size is too big.");
         } catch (IllegalBlockSizeException success) {
-            assertFalse(provider, "BC".equals(provider));
+            assertNotEquals("BC", provider);
         } catch (ArrayIndexOutOfBoundsException success) {
             assertEquals("BC", provider);
         }
@@ -3029,6 +3028,7 @@ public final class CipherTest {
             c.getOutputSize(RSA_2048_Vector1.length);
             fail("Should throw IllegalStateException if getOutputSize is called before init");
         } catch (IllegalStateException success) {
+            // Expected.
         }
     }
 
@@ -3528,7 +3528,7 @@ public final class CipherTest {
         }
     }
 
-    private static List<CipherTestParam> DES_CIPHER_TEST_PARAMS = new ArrayList<CipherTestParam>();
+    private static final List<CipherTestParam> DES_CIPHER_TEST_PARAMS = new ArrayList<>();
     static {
         DES_CIPHER_TEST_PARAMS.add(new CipherTestParam(
                 "DESede/CBC/PKCS5Padding",
@@ -3556,7 +3556,7 @@ public final class CipherTest {
                 ));
     }
 
-    private static List<CipherTestParam> ARC4_CIPHER_TEST_PARAMS = new ArrayList<CipherTestParam>();
+    private static final List<CipherTestParam> ARC4_CIPHER_TEST_PARAMS = new ArrayList<>();
     static {
         ARC4_CIPHER_TEST_PARAMS.add(new CipherTestParam(
                 "ARC4",
@@ -3580,7 +3580,7 @@ public final class CipherTest {
         ));
     }
 
-    private static List<CipherTestParam> CIPHER_TEST_PARAMS = new ArrayList<CipherTestParam>();
+    private static final List<CipherTestParam> CIPHER_TEST_PARAMS = new ArrayList<>();
     static {
         CIPHER_TEST_PARAMS.add(new CipherTestParam(
                 "AES/ECB/PKCS5Padding",
@@ -3638,7 +3638,7 @@ public final class CipherTest {
         }
     }
 
-    private static final List<CipherTestParam> RSA_OAEP_CIPHER_TEST_PARAMS = new ArrayList<CipherTestParam>();
+    private static final List<CipherTestParam> RSA_OAEP_CIPHER_TEST_PARAMS = new ArrayList<>();
     static {
         addRsaOaepTest("SHA-1", MGF1ParameterSpec.SHA1, RSA_Vector2_OAEP_SHA1_MGF1_SHA1);
         addRsaOaepTest("SHA-256", MGF1ParameterSpec.SHA1, RSA_Vector2_OAEP_SHA256_MGF1_SHA1);
@@ -3715,7 +3715,7 @@ public final class CipherTest {
         ByteArrayOutputStream errBuffer = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(errBuffer);
         for (CipherTestParam testVector : testVectors) {
-            ArrayList<Provider> providers = new ArrayList<Provider>();
+            ArrayList<Provider> providers = new ArrayList<>();
 
             Provider[] providerArray = Security.getProviders("Cipher." + testVector.transformation);
             if (providerArray != null) {
@@ -3759,7 +3759,7 @@ public final class CipherTest {
         }
         out.flush();
         if (errBuffer.size() > 0) {
-            throw new Exception("Errors encountered:\n\n" + errBuffer.toString() + "\n\n");
+            throw new Exception("Errors encountered:\n\n" + errBuffer + "\n\n");
         }
     }
 
@@ -3775,7 +3775,7 @@ public final class CipherTest {
         }
         out.flush();
         if (errBuffer.size() > 0) {
-            throw new Exception("Errors encountered:\n\n" + errBuffer.toString() + "\n\n");
+            throw new Exception("Errors encountered:\n\n" + errBuffer + "\n\n");
         }
     }
 
@@ -3865,8 +3865,7 @@ public final class CipherTest {
             try {
                 c.updateAAD(new byte[8]);
                 fail("Cipher should not support AAD");
-            } catch (UnsupportedOperationException expected) {
-            } catch (IllegalStateException expected) {
+            } catch (UnsupportedOperationException | IllegalStateException expected) {
             }
         }
 
@@ -4049,7 +4048,7 @@ public final class CipherTest {
             fail("No padding mode delimiter: " + transformation);
         }
         String paddingMode = transformation.substring(paddingModeDelimiterIndex + 1);
-        if (!paddingMode.toLowerCase().endsWith("padding")) {
+        if (!paddingMode.toLowerCase(Locale.ROOT).endsWith("padding")) {
             fail("No padding mode specified:" + transformation);
         }
         return transformation.substring(0, paddingModeDelimiterIndex) + "/NoPadding";
@@ -4135,8 +4134,7 @@ public final class CipherTest {
         try {
             c.updateAAD(new byte[8]);
             fail("should not be able to call updateAAD on non-AEAD cipher");
-        } catch (UnsupportedOperationException expected) {
-        } catch (IllegalStateException expected) {
+        } catch (UnsupportedOperationException | IllegalStateException expected) {
         }
     }
 
@@ -4162,7 +4160,7 @@ public final class CipherTest {
         }
         out.flush();
         if (errBuffer.size() > 0) {
-            throw new Exception("Errors encountered:\n\n" + errBuffer.toString() + "\n\n");
+            throw new Exception("Errors encountered:\n\n" + errBuffer + "\n\n");
         }
     }
 
@@ -4228,25 +4226,10 @@ public final class CipherTest {
         String msg = "update() should throw IllegalStateException [mode=" + opmode + "]";
         final int bs = createAesCipher(opmode).getBlockSize();
         assertEquals(16, bs); // check test is set up correctly
-        assertIllegalStateException(msg, new Runnable() {
-            @Override
-            public void run() {
-                createAesCipher(opmode).update(new byte[0]);
-            }
-        });
-        assertIllegalStateException(msg, new Runnable() {
-            @Override
-            public void run() {
-                createAesCipher(opmode).update(new byte[2 * bs]);
-            }
-        });
-        assertIllegalStateException(msg, new Runnable() {
-            @Override
-            public void run() {
-                createAesCipher(opmode).update(
-                        new byte[2 * bs] /* input */, bs /* inputOffset */, 0 /* inputLen */);
-            }
-        });
+        assertIllegalStateException(msg, () -> createAesCipher(opmode).update(new byte[0]));
+        assertIllegalStateException(msg, () -> createAesCipher(opmode).update(new byte[2 * bs]));
+        assertIllegalStateException(msg, () -> createAesCipher(opmode).update(
+                new byte[2 * bs] /* input */, bs /* inputOffset */, 0 /* inputLen */));
         try {
             createAesCipher(opmode).update(new byte[2*bs] /* input */, 0 /* inputOffset */,
                     2 * bs /* inputLen */, new byte[2 * bs] /* output */, 0 /* outputOffset */);
@@ -4374,8 +4357,7 @@ public final class CipherTest {
             try {
                 c.doFinal(null, 0);
                 fail("Should throw NullPointerException on null output buffer");
-            } catch (NullPointerException expected) {
-            } catch (IllegalArgumentException expected) {
+            } catch (NullPointerException | IllegalArgumentException expected) {
             }
         }
 
@@ -4403,7 +4385,7 @@ public final class CipherTest {
         {
             final byte[] output = new byte[c.getBlockSize()];
             assertEquals(AES_128_ECB_PKCS5Padding_TestVector_1_Encrypted.length, c.doFinal(output, 0));
-            assertTrue(Arrays.equals(AES_128_ECB_PKCS5Padding_TestVector_1_Encrypted, output));
+            assertArrayEquals(AES_128_ECB_PKCS5Padding_TestVector_1_Encrypted, output);
         }
     }
 
@@ -4436,7 +4418,7 @@ public final class CipherTest {
         assertEquals(provider, AES_128_ECB_PKCS5Padding_TestVector_1_Plaintext_Padded.length,
                 output.length);
 
-        assertTrue(provider, Arrays.equals(AES_128_ECB_PKCS5Padding_TestVector_1_Encrypted, output));
+        assertArrayEquals(provider, AES_128_ECB_PKCS5Padding_TestVector_1_Encrypted, output);
     }
 
     private static final byte[] AES_IV_ZEROES = new byte[] {
@@ -4490,7 +4472,7 @@ public final class CipherTest {
         String[] expected = new String[LARGEST_KEY_SIZE - SMALLEST_KEY_SIZE];
 
         /* Find all providers that provide ARC4. We must have at least one! */
-        Map<String, String> filter = new HashMap<String, String>();
+        Map<String, String> filter = new HashMap<>();
         filter.put("Cipher.ARC4", "");
         Provider[] providers = Security.getProviders(filter);
         assertTrue("There must be security providers of Cipher.ARC4", providers.length > 0);
@@ -4599,7 +4581,7 @@ public final class CipherTest {
                 new String(encryptedBuffer, 0, unencryptedBytes, StandardCharsets.US_ASCII));
     }
 
-    /**
+    /*
      * When using padding in decrypt mode, ensure that empty buffers decode to empty strings
      * (no padding needed for the empty buffer).
      * http://b/19186852
@@ -4631,7 +4613,7 @@ public final class CipherTest {
         }
     }
 
-    /**
+    /*
      * Check that RSA with OAEPPadding is supported.
      * http://b/22208820
      */
@@ -4644,7 +4626,7 @@ public final class CipherTest {
         cipher.doFinal(new byte[] {1,2,3,4});
     }
 
-    /**
+    /*
      * Check that initializing with a GCM AlgorithmParameters produces the same result
      * as initializing with a GCMParameterSpec.
      */
@@ -4672,7 +4654,7 @@ public final class CipherTest {
         assertEquals(Arrays.toString(c1.doFinal()), Arrays.toString(c2.doFinal()));
     }
 
-    /**
+    /*
      * http://b/27224566
      * http://b/27994930
      * Check that a PBKDF2WITHHMACSHA1 secret key factory works well with a
@@ -4709,7 +4691,7 @@ public final class CipherTest {
         assertEquals(Arrays.toString(plaintext), Arrays.toString(cipher.doFinal(ciphertext)));
     }
 
-    /**
+    /*
      * http://b/27224566
      * http://b/27994930
      * Check that a PBKDF2WITHHMACSHA1 secret key factory works well with a

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/HttpsURLConnectionTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/HttpsURLConnectionTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketException;
@@ -33,7 +32,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSession;
@@ -41,7 +39,6 @@ import javax.net.ssl.SSLSocketFactory;
 import org.conscrypt.TestUtils;
 import org.conscrypt.VeryBasicHttpServer;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -190,11 +187,7 @@ public class HttpsURLConnectionTest {
             }
             return null;
         });
-        try {
-            future.get(2 * timeoutMillis, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            fail("HttpsURLConnection connection timeout failed.");
-        }
+        future.get(2 * timeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     @Test

--- a/libcore-stub/src/main/java/libcore/net/NetworkSecurityPolicy.java
+++ b/libcore-stub/src/main/java/libcore/net/NetworkSecurityPolicy.java
@@ -27,7 +27,7 @@ package libcore.net;
  * permitted. See {@link #isCleartextTrafficPermitted()}.
  */
 public abstract class NetworkSecurityPolicy {
-    private static volatile NetworkSecurityPolicy instance = new DefaultNetworkSecurityPolicy();
+    private static volatile NetworkSecurityPolicy instance;
 
     public static NetworkSecurityPolicy getInstance() {
         return instance;

--- a/openjdk/src/main/java/org/conscrypt/HostProperties.java
+++ b/openjdk/src/main/java/org/conscrypt/HostProperties.java
@@ -74,7 +74,7 @@ class HostProperties {
          * Returns the value to use when building filenames for this OS.
          */
         public String getFileComponent() {
-            return name().toLowerCase();
+            return name().toLowerCase(Locale.ROOT);
         }
     }
 
@@ -104,7 +104,7 @@ class HostProperties {
          * Returns the value to use when building filenames for this architecture.
          */
         public String getFileComponent() {
-            return name().toLowerCase();
+            return name().toLowerCase(Locale.ROOT);
         }
     }
 
@@ -193,10 +193,10 @@ class HostProperties {
     }
 
     private static String normalize(String value) {
-        return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
+        return value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "");
     }
 
-    /**
+    /*
      * Normalizes the os.name value into the value used by the Maven os plugin
      * (https://github.com/trustin/os-maven-plugin). This plugin is used to generate
      * platform-specific
@@ -241,7 +241,7 @@ class HostProperties {
         return OperatingSystem.UNKNOWN;
     }
 
-    /**
+    /*
      * Normalizes the os.arch value into the value used by the Maven os plugin
      * (https://github.com/trustin/os-maven-plugin). This plugin is used to generate
      * platform-specific

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -124,7 +124,7 @@ final public class Platform {
         prefix = new File(prefix).getName();
         IOException suppressed = null;
         for (int i = 0; i < 10000; i++) {
-            String tempName = String.format(Locale.US, "%s%d%04d%s", prefix, time, i, suffix);
+            String tempName = String.format(Locale.ROOT, "%s%d%04d%s", prefix, time, i, suffix);
             File tempFile = new File(directory, tempName);
             if (!tempName.equals(tempFile.getName())) {
                 // The given prefix or suffix contains path separators.
@@ -646,7 +646,7 @@ final public class Platform {
         }
 
         String property = Security.getProperty("conscrypt.ct.enable");
-        if (property == null || !Boolean.valueOf(property.toLowerCase())) {
+        if (property == null || !Boolean.parseBoolean(property.toLowerCase(Locale.ROOT))) {
             return false;
         }
 
@@ -660,15 +660,14 @@ final public class Platform {
         for (String part : parts) {
             property = Security.getProperty(propertyName + ".*");
             if (property != null) {
-                enable = Boolean.valueOf(property.toLowerCase());
+                enable = Boolean.parseBoolean(property.toLowerCase(Locale.ROOT));
             }
-
             propertyName.append(".").append(part);
         }
 
         property = Security.getProperty(propertyName.toString());
         if (property != null) {
-            enable = Boolean.valueOf(property.toLowerCase());
+            enable = Boolean.parseBoolean(property.toLowerCase(Locale.ROOT));
         }
         return enable;
     }

--- a/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
+++ b/openjdk/src/test/java/org/conscrypt/AbstractSessionContextTest.java
@@ -120,9 +120,6 @@ public abstract class AbstractSessionContextTest<T extends AbstractSessionContex
 
     @Test
     public void testSerializeSession() throws Exception {
-        Certificate mockCert = mock(Certificate.class);
-        when(mockCert.getEncoded()).thenReturn(new byte[] {0x05, 0x06, 0x07, 0x10});
-
         byte[] encodedBytes = new byte[] {0x01, 0x02, 0x03};
         NativeSslSession session = new MockSessionBuilder()
                 .id(new byte[] {0x11, 0x09, 0x03, 0x20})

--- a/openjdk/src/test/java/org/conscrypt/DuckTypedPSKKeyManagerTest.java
+++ b/openjdk/src/test/java/org/conscrypt/DuckTypedPSKKeyManagerTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Arrays;
 import javax.crypto.SecretKey;
@@ -139,7 +140,7 @@ public class DuckTypedPSKKeyManagerTest extends TestCase {
         assertSame(identityHint, mockInvocationHandler.lastInvokedMethodArgs[0]);
         assertSame(mSSLEngine, mockInvocationHandler.lastInvokedMethodArgs[1]);
 
-        SecretKey key = new SecretKeySpec("arbitrary".getBytes("UTF-8"), "RAW");
+        SecretKey key = new SecretKeySpec("arbitrary".getBytes(StandardCharsets.UTF_8), "RAW");
         mockInvocationHandler.returnValue = key;
         assertSame(key, pskKeyManager.getKey(identityHint, identity, mSSLSocket));
         assertEquals("getKey", mockInvocationHandler.lastInvokedMethod.getName());

--- a/openjdk/src/test/java/org/conscrypt/OpenSSLKeyTest.java
+++ b/openjdk/src/test/java/org/conscrypt/OpenSSLKeyTest.java
@@ -18,6 +18,8 @@ package org.conscrypt;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+
 import junit.framework.TestCase;
 
 public class OpenSSLKeyTest extends TestCase {
@@ -83,7 +85,7 @@ public class OpenSSLKeyTest extends TestCase {
         "8872822c7f2832dafa0fe10d9aba22310849e978e51c8aa9da7bc1c07511d883", 16);
 
     public void test_fromPublicKeyPemInputStream() throws Exception {
-        ByteArrayInputStream is = new ByteArrayInputStream(RSA_PUBLIC_KEY.getBytes("UTF-8"));
+        ByteArrayInputStream is = new ByteArrayInputStream(RSA_PUBLIC_KEY.getBytes(StandardCharsets.UTF_8));
         OpenSSLKey key = OpenSSLKey.fromPublicKeyPemInputStream(is);
         OpenSSLRSAPublicKey publicKey = (OpenSSLRSAPublicKey)key.getPublicKey();
         assertEquals(RSA_MODULUS, publicKey.getModulus());
@@ -91,7 +93,7 @@ public class OpenSSLKeyTest extends TestCase {
     }
 
     public void test_fromPrivateKeyPemInputStream() throws Exception {
-        ByteArrayInputStream is = new ByteArrayInputStream(RSA_PRIVATE_KEY.getBytes("UTF-8"));
+        ByteArrayInputStream is = new ByteArrayInputStream(RSA_PRIVATE_KEY.getBytes(StandardCharsets.UTF_8));
         OpenSSLKey key = OpenSSLKey.fromPrivateKeyPemInputStream(is);
         OpenSSLRSAPrivateKey privateKey = (OpenSSLRSAPrivateKey)key.getPrivateKey();
         assertEquals(RSA_MODULUS, privateKey.getModulus());

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -316,7 +316,7 @@ public final class TestUtils {
                 if (index < 0) {
                     throw new IllegalStateException("No = found: line " + lineNumber);
                 }
-                String label = line.substring(0, index).trim().toLowerCase();
+                String label = line.substring(0, index).trim().toLowerCase(Locale.ROOT);
                 String value = line.substring(index + 1).trim();
                 if ("name".equals(label)) {
                     current = new TestVector();
@@ -662,7 +662,7 @@ public final class TestUtils {
     /**
      * Decodes the provided hexadecimal string into a byte array.  Odd-length inputs
      * are not allowed.
-     *
+     * <p>
      * Throws an {@code IllegalArgumentException} if the input is malformed.
      */
     public static byte[] decodeHex(String encoded) throws IllegalArgumentException {
@@ -673,7 +673,7 @@ public final class TestUtils {
      * Decodes the provided hexadecimal string into a byte array. If {@code allowSingleChar}
      * is {@code true} odd-length inputs are allowed and the first character is interpreted
      * as the lower bits of the first result byte.
-     *
+     * <p>
      * Throws an {@code IllegalArgumentException} if the input is malformed.
      */
     public static byte[] decodeHex(String encoded, boolean allowSingleChar) throws IllegalArgumentException {
@@ -683,7 +683,7 @@ public final class TestUtils {
     /**
      * Decodes the provided hexadecimal string into a byte array.  Odd-length inputs
      * are not allowed.
-     *
+     * <p>
      * Throws an {@code IllegalArgumentException} if the input is malformed.
      */
     public static byte[] decodeHex(char[] encoded) throws IllegalArgumentException {
@@ -694,7 +694,7 @@ public final class TestUtils {
      * Decodes the provided hexadecimal string into a byte array. If {@code allowSingleChar}
      * is {@code true} odd-length inputs are allowed and the first character is interpreted
      * as the lower bits of the first result byte.
-     *
+     * <p>
      * Throws an {@code IllegalArgumentException} if the input is malformed.
      */
     public static byte[] decodeHex(char[] encoded, boolean allowSingleChar) throws IllegalArgumentException {

--- a/testing/src/main/java/org/conscrypt/VeryBasicHttpServer.java
+++ b/testing/src/main/java/org/conscrypt/VeryBasicHttpServer.java
@@ -26,6 +26,7 @@ import java.net.Socket;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
@@ -108,6 +109,7 @@ public class VeryBasicHttpServer {
         }
     }
 
+    @SuppressWarnings("StringSplitter") // It's close enough for government work.
     private Request readRequest(Socket socket) throws Exception {
         Request request = new Request();
         request.outputStream = socket.getOutputStream();

--- a/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterAsymmetricHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterAsymmetricHelper.java
@@ -16,12 +16,12 @@
 
 package org.conscrypt.java.security;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.security.AlgorithmParameters;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.util.Arrays;
 import javax.crypto.Cipher;
 
 public class AlgorithmParameterAsymmetricHelper extends TestHelper<AlgorithmParameters> {
@@ -47,10 +47,10 @@ public class AlgorithmParameterAsymmetricHelper extends TestHelper<AlgorithmPara
 
         Cipher cipher = Cipher.getInstance(algorithmName);
         cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), parameters);
-        byte[] bs = cipher.doFinal(plainData.getBytes("UTF-8"));
+        byte[] bs = cipher.doFinal(plainData.getBytes(StandardCharsets.UTF_8));
 
         cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), parameters);
         byte[] decrypted = cipher.doFinal(bs);
-        assertTrue(Arrays.equals(plainData.getBytes("UTF-8"), decrypted));
+        assertArrayEquals(plainData.getBytes(StandardCharsets.UTF_8), decrypted);
     }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSignatureHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSignatureHelper.java
@@ -18,6 +18,7 @@ package org.conscrypt.java.security;
 
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.security.AlgorithmParameters;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -55,11 +56,11 @@ public class AlgorithmParameterSignatureHelper<T extends AlgorithmParameterSpec>
         KeyPair keyPair = generator.genKeyPair();
 
         signature.initSign(keyPair.getPrivate());
-        signature.update(plainData.getBytes("UTF-8"));
+        signature.update(plainData.getBytes(StandardCharsets.UTF_8));
         byte[] signed = signature.sign();
 
         signature.initVerify(keyPair.getPublic());
-        signature.update(plainData.getBytes("UTF-8"));
+        signature.update(plainData.getBytes(StandardCharsets.UTF_8));
         assertTrue("signature should verify", signature.verify(signed));
     }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSymmetricHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/AlgorithmParameterSymmetricHelper.java
@@ -16,11 +16,11 @@
 
 package org.conscrypt.java.security;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
+import java.nio.charset.StandardCharsets;
 import java.security.AlgorithmParameters;
 import java.security.Key;
-import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 
@@ -55,11 +55,11 @@ public class AlgorithmParameterSymmetricHelper extends TestHelper<AlgorithmParam
 
         Cipher cipher = Cipher.getInstance(transformation);
         cipher.init(Cipher.ENCRYPT_MODE, key, parameters);
-        byte[] bs = cipher.doFinal(plainData.getBytes("UTF-8"));
+        byte[] bs = cipher.doFinal(plainData.getBytes(StandardCharsets.UTF_8));
 
         cipher.init(Cipher.DECRYPT_MODE, key, parameters);
         byte[] decrypted = cipher.doFinal(bs);
 
-        assertTrue(Arrays.equals(plainData.getBytes("UTF-8"), decrypted));
+        assertArrayEquals(plainData.getBytes(StandardCharsets.UTF_8), decrypted);
     }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/SignatureHelper.java
+++ b/testing/src/main/java/org/conscrypt/java/security/SignatureHelper.java
@@ -18,6 +18,7 @@ package org.conscrypt.java.security;
 
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -40,11 +41,11 @@ public class SignatureHelper extends TestHelper<KeyPair> {
     public void test(PrivateKey encryptKey, PublicKey decryptKey) throws Exception {
         Signature signature = Signature.getInstance(algorithmName);
         signature.initSign(encryptKey);
-        signature.update(plainData.getBytes("UTF-8"));
+        signature.update(plainData.getBytes(StandardCharsets.UTF_8));
         byte[] signed = signature.sign();
 
         signature.initVerify(decryptKey);
-        signature.update(plainData.getBytes("UTF-8"));
+        signature.update(plainData.getBytes(StandardCharsets.UTF_8));
         assertTrue("signature could not be verified", signature.verify(signed));
     }
 }

--- a/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
+++ b/testing/src/main/java/org/conscrypt/java/security/StandardNames.java
@@ -126,6 +126,8 @@ public final class StandardNames {
         }
         paddings.addAll(Arrays.asList(newPaddings));
     }
+
+    @SuppressWarnings("EnumOrdinal")
     private static void provideSslContextEnabledProtocols(
             String algorithm, TLSVersion minimum, TLSVersion maximum) {
         if (minimum.ordinal() > maximum.ordinal()) {
@@ -138,6 +140,7 @@ public final class StandardNames {
         }
         SSL_CONTEXT_PROTOCOLS_ENABLED.put(algorithm, versionNames);
     }
+
     static {
         // TODO: provideCipherModes and provideCipherPaddings for other Ciphers
         provideCipherModes("AES", new String[] {"CBC", "CFB", "CTR", "CTS", "ECB", "OFB"});

--- a/testing/src/main/java/org/conscrypt/java/security/TestKeyStore.java
+++ b/testing/src/main/java/org/conscrypt/java/security/TestKeyStore.java
@@ -84,7 +84,7 @@ import org.conscrypt.javax.net.ssl.TestTrustManager;
 /**
  * TestKeyStore is a convenience class for other tests that
  * want a canned KeyStore with a variety of key pairs.
- *
+ * <p>
  * Creating a key store is relatively slow, so a singleton instance is
  * accessible via TestKeyStore.get().
  */
@@ -382,13 +382,13 @@ public final class TestKeyStore {
         private PrivateKeyEntry privateEntry;
         private PrivateKeyEntry signer;
         private Certificate rootCa;
-        private final List<KeyPurposeId> extendedKeyUsages = new ArrayList<KeyPurposeId>();
-        private final List<Boolean> criticalExtendedKeyUsages = new ArrayList<Boolean>();
-        private final List<GeneralName> subjectAltNames = new ArrayList<GeneralName>();
+        private final List<KeyPurposeId> extendedKeyUsages = new ArrayList<>();
+        private final List<Boolean> criticalExtendedKeyUsages = new ArrayList<>();
+        private final List<GeneralName> subjectAltNames = new ArrayList<>();
         private final List<GeneralSubtree> permittedNameConstraints =
-                new ArrayList<GeneralSubtree>();
+                new ArrayList<>();
         private final List<GeneralSubtree> excludedNameConstraints =
-                new ArrayList<GeneralSubtree>();
+                new ArrayList<>();
         // Generated randomly if not set
         private BigInteger certificateSerialNumber = null;
 
@@ -549,12 +549,12 @@ public final class TestKeyStore {
          * private alias name. The X509Certificate will be stored on the
          * public alias name and have the given subject distinguished
          * name.
-         *
+         * <p>
          * If a CA is provided, it will be used to sign the generated
          * certificate and OCSP responses. Otherwise, the certificate
          * will be self signed. The certificate will be valid for one
          * day before and one day after the time of creation.
-         *
+         * <p>
          * Based on:
          * org.bouncycastle.jce.provider.test.SigTest
          * org.bouncycastle.jce.provider.test.CertTest
@@ -588,7 +588,6 @@ public final class TestKeyStore {
             if (publicAlias == null && privateAlias == null) {
                 // don't want anything apparently
                 privateKey = null;
-                publicKey = null;
                 x509c = null;
             } else {
                 if (privateEntry == null) {
@@ -617,11 +616,8 @@ public final class TestKeyStore {
                     KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyAlgorithm);
                     if (spec != null) {
                         kpg.initialize(spec);
-                    } else if (keySize != -1) {
-                        kpg.initialize(keySize);
                     } else {
-                        throw new AssertionError(
-                                "Must either have set algorithm parameters or key size!");
+                        kpg.initialize(keySize);
                     }
 
                     KeyPair kp = kpg.generateKeyPair();
@@ -674,14 +670,15 @@ public final class TestKeyStore {
         try {
             X500Principal principal = new X500Principal(subject);
             return createCertificate(publicKey, privateKey, principal, principal, 0, true,
-                    new ArrayList<KeyPurposeId>(), new ArrayList<Boolean>(),
-                    new ArrayList<GeneralName>(), new ArrayList<GeneralSubtree>(),
-                    new ArrayList<GeneralSubtree>(), null /* serialNumber, generated randomly */);
+                    new ArrayList<>(), new ArrayList<>(),
+                    new ArrayList<>(), new ArrayList<>(),
+                    new ArrayList<>(), null /* serialNumber, generated randomly */);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
+    @SuppressWarnings("JavaUtilDate")
     private static X509Certificate createCertificate(PublicKey publicKey, PrivateKey privateKey,
             X500Principal subject, X500Principal issuer, int keyUsage, boolean ca,
             List<KeyPurposeId> extendedKeyUsages, List<Boolean> criticalExtendedKeyUsages,
@@ -744,10 +741,8 @@ public final class TestKeyStore {
         if (!permittedNameConstraints.isEmpty() || !excludedNameConstraints.isEmpty()) {
             x509cg.addExtension(Extension.nameConstraints, true,
                     new NameConstraints(
-                            permittedNameConstraints.toArray(
-                                    new GeneralSubtree[permittedNameConstraints.size()]),
-                            excludedNameConstraints.toArray(
-                                    new GeneralSubtree[excludedNameConstraints.size()])));
+                            permittedNameConstraints.toArray(new GeneralSubtree[0]),
+                            excludedNameConstraints.toArray(new GeneralSubtree[0])));
         }
 
         X509CertificateHolder x509holder =
@@ -796,7 +791,7 @@ public final class TestKeyStore {
         if (index == -1) {
             return algorithm;
         }
-        return algorithm.substring(index + 1, algorithm.length());
+        return algorithm.substring(index + 1);
     }
 
     /**
@@ -920,6 +915,7 @@ public final class TestKeyStore {
         return rootCertificate(keyStore, algorithm);
     }
 
+    @SuppressWarnings("JavaUtilDate")
     private static OCSPResp generateOCSPResponse(PrivateKeyEntry server, PrivateKeyEntry issuer,
             CertificateStatus status) throws CertificateException {
         try {
@@ -949,7 +945,8 @@ public final class TestKeyStore {
         }
     }
 
-    public static byte[] getOCSPResponseForGood(PrivateKeyEntry server, PrivateKeyEntry issuer)
+    @SuppressWarnings({"JavaUtilDate", "unused"}) // TODO(prb): Use this.
+    private static byte[] getOCSPResponseForGood(PrivateKeyEntry server, PrivateKeyEntry issuer)
             throws CertificateException {
         try {
             return generateOCSPResponse(server, issuer, CertificateStatus.GOOD).getEncoded();
@@ -958,7 +955,8 @@ public final class TestKeyStore {
         }
     }
 
-    public static byte[] getOCSPResponseForRevoked(PrivateKeyEntry server, PrivateKeyEntry issuer)
+    @SuppressWarnings({"JavaUtilDate", "unused"}) // TODO(prb): Use this.
+    private static byte[] getOCSPResponseForRevoked(PrivateKeyEntry server, PrivateKeyEntry issuer)
             throws CertificateException {
         try {
             return generateOCSPResponse(
@@ -974,6 +972,7 @@ public final class TestKeyStore {
      * the given algorithm. Throws IllegalStateException if there are
      * are more or less than one.
      */
+    @SuppressWarnings("JavaUtilDate")
     public static X509Certificate rootCertificate(KeyStore keyStore, String algorithm) {
         try {
             X509Certificate found = null;
@@ -1022,11 +1021,7 @@ public final class TestKeyStore {
     public static KeyStore.Entry entryByAlias(KeyStore keyStore, String alias) {
         try {
             return keyStore.getEntry(alias, null);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        } catch (UnrecoverableEntryException e) {
-            throw new RuntimeException(e);
-        } catch (KeyStoreException e) {
+        } catch (NoSuchAlgorithmException | KeyStoreException | UnrecoverableEntryException e) {
             throw new RuntimeException(e);
         }
     }

--- a/testing/src/main/java/org/conscrypt/java/security/cert/FakeX509Certificate.java
+++ b/testing/src/main/java/org/conscrypt/java/security/cert/FakeX509Certificate.java
@@ -25,20 +25,17 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateExpiredException;
-import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.Set;
 
+@SuppressWarnings("serial")
 public class FakeX509Certificate extends X509Certificate {
     @Override
-    public void checkValidity()
-            throws CertificateExpiredException, CertificateNotYetValidException {}
+    public void checkValidity() {}
 
     @Override
-    public void checkValidity(Date date)
-            throws CertificateExpiredException, CertificateNotYetValidException {}
+    public void checkValidity(Date date) {}
 
     @Override
     public int getBasicConstraints() {
@@ -61,11 +58,13 @@ public class FakeX509Certificate extends X509Certificate {
     }
 
     @Override
+    @SuppressWarnings("JavaUtilDate")
     public Date getNotAfter() {
         return new Date(System.currentTimeMillis());
     }
 
     @Override
+    @SuppressWarnings("JavaUtilDate")
     public Date getNotBefore() {
         return new Date(System.currentTimeMillis() - 1000);
     }
@@ -100,7 +99,8 @@ public class FakeX509Certificate extends X509Certificate {
         return new MockPrincipal();
     }
 
-    class MockPrincipal implements Principal {
+    static class MockPrincipal implements Principal {
+        @Override
         public String getName() {
             return null;
         }
@@ -111,7 +111,7 @@ public class FakeX509Certificate extends X509Certificate {
     }
 
     @Override
-    public byte[] getTBSCertificate() throws CertificateEncodingException {
+    public byte[] getTBSCertificate() {
         return null;
     }
 
@@ -132,7 +132,7 @@ public class FakeX509Certificate extends X509Certificate {
 
     @Override
     public String toString() {
-        return null;
+        return "null";
     }
 
     @Override

--- a/testing/src/main/java/org/conscrypt/tlswire/handshake/AlpnHelloExtension.java
+++ b/testing/src/main/java/org/conscrypt/tlswire/handshake/AlpnHelloExtension.java
@@ -18,6 +18,7 @@ package org.conscrypt.tlswire.handshake;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.conscrypt.tlswire.util.IoUtils;
@@ -33,19 +34,16 @@ public class AlpnHelloExtension extends HelloExtension {
     protected void parseData() throws IOException {
         byte[] alpnListBytes = IoUtils.readTlsVariableLengthByteVector(
                 new DataInputStream(new ByteArrayInputStream(data)), 0xffff);
-        protocols = new ArrayList<String>();
+        protocols = new ArrayList<>();
         DataInputStream alpnList = new DataInputStream(new ByteArrayInputStream(alpnListBytes));
         while (alpnList.available() > 0) {
             byte[] alpnValue = IoUtils.readTlsVariableLengthByteVector(alpnList, 0xff);
-            protocols.add(new String(alpnValue, "US-ASCII"));
+            protocols.add(new String(alpnValue, StandardCharsets.US_ASCII));
         }
     }
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("HelloExtension{type: elliptic_curves, protocols: ");
-        sb.append(protocols);
-        sb.append('}');
-        return sb.toString();
+        return "HelloExtension{type: elliptic_curves, protocols: " + protocols + '}';
     }
 }

--- a/testing/src/main/java/org/conscrypt/tlswire/handshake/HelloExtension.java
+++ b/testing/src/main/java/org/conscrypt/tlswire/handshake/HelloExtension.java
@@ -32,7 +32,7 @@ public class HelloExtension {
     public static final int TYPE_PADDING = 21;
     public static final int TYPE_SESSION_TICKET = 35;
     public static final int TYPE_RENEGOTIATION_INFO = 65281;
-    private static final Map<Integer, String> TYPE_TO_NAME = new HashMap<Integer, String>();
+    private static final Map<Integer, String> TYPE_TO_NAME = new HashMap<>();
     static {
         TYPE_TO_NAME.put(TYPE_SERVER_NAME, "server_name");
         TYPE_TO_NAME.put(1, "max_fragment_length");
@@ -91,10 +91,9 @@ public class HelloExtension {
         result.parseData();
         return result;
     }
-    /**
-     * @throws IOException
-     */
+
     protected void parseData() throws IOException {}
+
     @Override
     public String toString() {
         return "HelloExtension{type: " + name + ", data: " + new BigInteger(1, data).toString(16)

--- a/testing/src/main/java/org/conscrypt/tlswire/handshake/ServerNameHelloExtension.java
+++ b/testing/src/main/java/org/conscrypt/tlswire/handshake/ServerNameHelloExtension.java
@@ -18,6 +18,7 @@ package org.conscrypt.tlswire.handshake;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.conscrypt.tlswire.util.IoUtils;
@@ -34,14 +35,14 @@ public class ServerNameHelloExtension extends HelloExtension {
                 new DataInputStream(new ByteArrayInputStream(data)), 0xffff);
         ByteArrayInputStream serverNameListIn = new ByteArrayInputStream(serverNameListBytes);
         DataInputStream in = new DataInputStream(serverNameListIn);
-        hostnames = new ArrayList<String>();
+        hostnames = new ArrayList<>();
         while (serverNameListIn.available() > 0) {
             int type = in.readUnsignedByte();
             if (type != TYPE_HOST_NAME) {
                 throw new IOException("Unsupported ServerName type: " + type);
             }
             byte[] hostnameBytes = IoUtils.readTlsVariableLengthByteVector(in, 0xffff);
-            String hostname = new String(hostnameBytes, "US-ASCII");
+            String hostname = new String(hostnameBytes, StandardCharsets.US_ASCII);
             hostnames.add(hostname);
         }
     }

--- a/testing/src/main/java/tests/util/ServiceTester.java
+++ b/testing/src/main/java/tests/util/ServiceTester.java
@@ -158,7 +158,7 @@ public final class ServiceTester {
         for (Provider.Service s : p.getServices()) {
           if (s.getType().equals(service)
               && !skipAlgorithms.contains(s.getAlgorithm())
-              && !shouldSkipCombination(p.getName(), s.getAlgorithm())) {
+              && shouldUseCombination(p.getName(), s.getAlgorithm())) {
             doTest(test, p, s.getAlgorithm(), errors);
           }
         }
@@ -166,7 +166,7 @@ public final class ServiceTester {
         algorithms.removeAll(skipAlgorithms);
         for (String algorithm : algorithms) {
           if (p.getService(service, algorithm) != null
-              && !shouldSkipCombination(p.getName(), algorithm)) {
+              && shouldUseCombination(p.getName(), algorithm)) {
             doTest(test, p, algorithm, errors);
           }
         }
@@ -174,7 +174,7 @@ public final class ServiceTester {
     }
     errors.flush();
     if (errBuffer.size() > 0) {
-      fail("Tests failed:\n\n" + errBuffer.toString());
+      fail("Tests failed:\n\n" + errBuffer);
     }
   }
 
@@ -182,8 +182,8 @@ public final class ServiceTester {
     return provider + SEPARATOR + algorithm;
   }
 
-  private boolean shouldSkipCombination(String provider, String algorithm) {
-    return skipCombinations.contains(makeCombination(provider, algorithm));
+  private boolean shouldUseCombination(String provider, String algorithm) {
+    return !skipCombinations.contains(makeCombination(provider, algorithm));
   }
 
   private void doTest(Test test, Provider p, String algorithm, PrintStream errors) {


### PR DESCRIPTION
Fixes many new errorprone warnings. In files that I touched due to errorprone I also removed most IDE warnings.

Still a number of warnings left but their fixes probably need to go into individual CLs for cherry-picking fun.

Should be effectively no functional change.  I did remove a couple of very obsolete methods from AbstractConscryptSocket but they still exist on OpenSSLSocketImpl so should be no app compat issues.