### PR TITLE
CI and Testing Improvements.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,10 +172,7 @@ jobs:
 
       - name: Test with Gradle
         shell: bash
-        run: ./gradlew test -PcheckErrorQueue
-
-      - name: Other checks with Gradle
-        shell: bash
+        timeout-minutes: 15
         run: ./gradlew check -PcheckErrorQueue
 
       - name: Publish to local Maven repo

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -323,7 +323,6 @@ def testFdSocket = tasks.register("testFdSocket", Test) {
     systemProperties = test.systemProperties
     systemProperty "org.conscrypt.useEngineSocketByDefault", false
 }
-check.dependsOn testFdSocket
 
 // Tests that involve interoperation with the OpenJDK TLS provider (generally to
 // test renegotiation, since we don't support initiating renegotiation but do


### PR DESCRIPTION
* Don't run both `test` and `check` in CI as `check` includes all of `test`.

* Add timeouts to the above

* Don't make check depend on `testFdSocket`.  This is deprecated on OpenJDK so no point wasting cycles doing it.  Can still be run by hand.

The above should speed up CI and get rid of most hangs. There are still some occurences of tests hanging without testFdSocket, and I can't see an easy way to get stack dumps...