### PR TITLE
Update .clang-format import groups order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,5 +13,15 @@ BasedOnStyle: Google
 ColumnLimit: 100
 IndentWidth: 4
 ContinuationIndentWidth: 8
-...
-
+JavaImportGroups:
+- android
+- androidx
+- com.android
+- dalvik
+- libcore
+- com
+- junit
+- net
+- org
+- java
+- javax


### PR DESCRIPTION
Match the import order to the style guide[1]. This is based on art/.clang-format.

[1] https://source.android.com/docs/setup/contribute/code-style#order-import-statements

Test: repo upload .
Change-Id: Ifd5c45fce2e20adf818d1cf03637f07b10786122