### PR TITLE
Publsh Javadoc from conscrypt-openjdk with Uber Jar.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,12 @@ jobs:
           name: boringssl-source
           path: ${{ runner.temp }}/boringssl
 
+      - name: Checkout BoringSSL master branch
+        shell: bash
+        run: |
+          cd "$BORINGSSL_HOME"
+          git checkout --progress --force -B master
+
       - name: Make fake BoringSSL directories
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Linux environment
+        run: |
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+
+          sudo dpkg --add-architecture i386
+          sudo add-apt-repository ppa:openjdk-r/ppa
+          sudo apt-get -qq update
+          sudo apt-get -qq install -y --no-install-recommends \
+            gcc-multilib \
+            g++-multilib \
+            ninja-build \
+            openjdk-11-jre-headless
+
       - name: Set runner-specific environment variables
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,15 +224,24 @@ jobs:
           cd "$BORINGSSL_HOME"
           git checkout --progress --force -B master
 
-      - name: Make fake BoringSSL directories
-        shell: bash
+      - name: Build BoringSSL 64-bit Linux
         run: |
-          # TODO: remove this when the check is only performed when building.
-          # BoringSSL is not needed during the UberJAR build, but the
-          # assertion to check happens regardless of whether the project
-          # needs it.
-          mkdir -p "${{ runner.temp }}/boringssl/build64"
-          mkdir -p "${{ runner.temp }}/boringssl/include"
+          mkdir -p "$BORINGSSL_HOME/build64"
+          pushd "$BORINGSSL_HOME/build64"
+          cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_BUILD_TYPE=Release -GNinja ..
+          ninja
+          popd
+
+      # TODO(prb) remove build dependency above and go back to this.
+      # - name: Make fake BoringSSL directories
+      #   shell: bash
+      #   run: |
+      #     # TODO: remove this when the check is only performed when building.
+      #     # BoringSSL is not needed during the UberJAR build, but the
+      #     # assertion to check happens regardless of whether the project
+      #     # needs it.
+      #     mkdir -p "${{ runner.temp }}/boringssl/build64"
+      #     mkdir -p "${{ runner.temp }}/boringssl/include"
 
       - name: Download Maven repository for Linux
         uses: actions/download-artifact@v4

--- a/openjdk-uber/build.gradle
+++ b/openjdk-uber/build.gradle
@@ -1,12 +1,14 @@
 description = 'Conscrypt: OpenJdk UberJAR'
 
+Directory buildTop = layout.buildDirectory.get()
 ext {
     buildUberJar = Boolean.parseBoolean(System.getProperty('org.conscrypt.openjdk.buildUberJar', 'false'))
     uberJarClassifiers = (System.getProperty('org.conscrypt.openjdk.uberJarClassifiers',
             'osx-x86_64,osx-aarch_64,linux-x86_64,windows-x86_64')).split(',')
-    classesDir = "${buildDir}/classes"
-    resourcesDir = "${buildDir}/resources"
-    sourcesDir = "${buildDir}/sources"
+    classesDir = buildTop.dir('classes')
+    resourcesDir = buildTop.dir('resources')
+    sourcesDir = buildTop.dir('sources')
+    javadocDir = buildTop.dir('docs/javadoc')
 }
 
 if (buildUberJar) {
@@ -20,6 +22,7 @@ if (buildUberJar) {
     jar {
         from classesDir
         from resourcesDir
+        from javadocDir
     }
 
     sourcesJar {
@@ -68,15 +71,28 @@ if (buildUberJar) {
     }
 
     def copySources = tasks.register("copySources", Copy) {
-        dependsOn ":conscrypt-openjdk:sourcesJar"
-        from {
-            project(":conscrypt-openjdk").sourceSets.main.java
-        }
+        dependsOn copyJavadocs
+        dependsOn ":conscrypt-constants:runGen"
+        from project(":conscrypt-openjdk").sourceSets.main.java
         into file(sourcesDir)
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }
     tasks.named("sourcesJar").configure {
         dependsOn copySources
+    }
+
+    def copyJavadocs = tasks.register("copyJavadocs", Copy) {
+        dependsOn ':conscrypt-openjdk:javadoc'
+        from project(':conscrypt-openjdk').layout.buildDirectory
+        include('docs/**/*')
+        into layout.buildDirectory
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+    tasks.named('javadocJar').configure {
+        dependsOn copyJavadocs
+    }
+    tasks.named('jar').configure {
+        dependsOn copyJavadocs
     }
 
     // Note that this assumes that the version of BoringSSL for each

--- a/openjdk/build.gradle
+++ b/openjdk/build.gradle
@@ -177,6 +177,11 @@ processResources {
     dependsOn generateProperties
 }
 
+sourcesJar {
+    dependsOn generateProperties
+    dependsOn ':conscrypt-constants:runGen'
+}
+
 tasks.register("platformJar", Jar) {
     from sourceSets.platform.output
 }


### PR DESCRIPTION
Looks like we've been publishing an empty javadoc jar alongside the uber jar basically forever.

Also fixed a few Gradle inter-task dependency warnings.