### PR TITLE
Fix zero size reads for Engine Socket.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -826,6 +826,9 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl implements SSLParametersIm
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
             waitForHandshake();
+            if (len == 0) {
+                return 0;
+            }
             synchronized (readLock) {
                 return readUntilDataAvailable(b, off, len);
             }


### PR DESCRIPTION
InputStream explicitly allows zero size reads without blocking or attempting IO.  We do this correctly for the fd-socket but missed it for the Engine socket.

Not clear whether zero sized read should trigger a TLS handshake, but it always has on Android so keeping it that way.

Bug manifested as a flaky test hang.  Fixed the test to explicitly check corner cases and removed un-needed concurrency.