### PR TITLE
Mark kotlin target JVM as 1.8

### DIFF
--- a/api-doclet/build.gradle
+++ b/api-doclet/build.gradle
@@ -6,6 +6,9 @@ description = 'Conscrypt: API Doclet'
 
 kotlin {
     jvmToolchain(11)
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
There is a conflict between the compiler used for Java and Kotlin, even if this is defined in the root project's build.gradle. Explicitly note that the targeted jvm version is 1.8.

This was reported by Gradle and prevents the upgrade to Gradle 8.x.