### PR TITLE
In the AEAD Cipher implementation, avoid copying input in doFinal when update was not called before.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -241,7 +241,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
             throw new IllegalArgumentException("Cannot write to Read Only ByteBuffer");
         }
         if (bufCount != 0) {
-            return super.engineDoFinal(input, output);// traditional case
+            return super.engineDoFinal(input, output); // traditional case
         }
         int bytesWritten;
         if (!input.isDirect()) {


### PR DESCRIPTION
In OpenSSLAeadCipher.java, we add an additional input parameters to doFinalInternal.
This allows us to avoid copying input to buf if buf is empty, which is the case if update has not been called before.

- This save copying the input, which in my tests gave a 5% performance improvement.
- For Cipher object that are re-used, this reduces their memory footprint,
  because buf does not increase its size to the max input size.
- For Cipher objects that are newly created, this avoids a memory allocation of the size of the input. 
  Here, the performance improvement in my tests were about 20%.

Also, I extract a new helper function appendToBuf to make the code more readable.