### PR TITLE
Remove unused (and incorrect) implementation of getOutputSizeForFinal.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -436,12 +436,6 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
         return 0;
     }
 
-    @Override
-    int getOutputSizeForFinal(int inputLen) {
-        return bufCount + inputLen
-                + (isEncrypting() ? NativeCrypto.EVP_AEAD_max_overhead(evpAead) : 0);
-    }
-
     // Intentionally missing Override to compile on old versions of Android
     @SuppressWarnings("MissingOverride")
     protected void engineUpdateAAD(byte[] input, int inputOffset, int inputLen) {


### PR DESCRIPTION
This method gets overwritten by both its subclasses, so this implementation is never used.

Also, it is incorrect, because it doesn't subtract the tag size on decryption.