### PR TITLE
Fix TlsV1 defaults

### DIFF
--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -160,8 +160,8 @@ public final class Conscrypt {
         private String name = Platform.getDefaultProviderName();
         private boolean provideTrustManager = Platform.provideTrustManagerByDefault();
         private String defaultTlsProtocol = NativeCrypto.SUPPORTED_PROTOCOL_TLSV1_3;
-        private boolean deprecatedTlsV1 = true;
-        private boolean enabledTlsV1 = false;
+        private boolean deprecatedTlsV1 = Platform.isTlsV1Deprecated();
+        private boolean enabledTlsV1 = Platform.isTlsV1Supported();
 
         private ProviderBuilder() {}
 

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -97,7 +97,7 @@ final public class Platform {
     private static final Method GET_CURVE_NAME_METHOD;
     static boolean DEPRECATED_TLS_V1 = true;
     static boolean ENABLED_TLS_V1 = false;
-    private static boolean FILTERED_TLS_V1 = true;
+    private static boolean FILTERED_TLS_V1 = false;
 
     static {
         NativeCrypto.setTlsV1DeprecationStatus(DEPRECATED_TLS_V1, ENABLED_TLS_V1);


### PR DESCRIPTION
Better to use the platform references in Conscrypt.java and to actually throw an exception if people are requesting v1.

Change-Id: I4c5e3ac8b31b167dc9dc64480f9480966ffd7107