### PR TITLE
Fix bug in OpenSSLAeadCipher with empty plaintext.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -392,7 +392,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
             inOffset = 0;
             inLen = bufCount;
         } else {
-            if (inputLen == 0) {
+            if (inputLen == 0 && input == null) {
                 in = EmptyArray.BYTE; // input can be null when inputLen == 0
             } else {
                 in = input;


### PR DESCRIPTION
If the user wants to encrypt and calls doFinal(input, 123, 0); without a prior call to update, it currently fails with an array out of bounds exception.

Instead, it should encrypt the empty string.