### PR TITLE
Add Spake parameter plumbing to Conscrypt

### DIFF
--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -975,4 +975,8 @@ final public class Platform {
     public static boolean isTlsV1Supported() {
         return ENABLED_TLS_V1;
     }
+
+    public static boolean isPakeSupported() {
+        return false;
+    }
 }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -110,7 +110,9 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl implements SSLParametersIm
     private static ConscryptEngine newEngine(
             SSLParametersImpl sslParameters, final ConscryptEngineSocket socket) {
         SSLParametersImpl modifiedParams;
-        if (Platform.supportsX509ExtendedTrustManager()) {
+        if (sslParameters.isSpake()) {
+            modifiedParams = sslParameters.cloneWithSpake();
+        } else if (Platform.supportsX509ExtendedTrustManager()) {
             modifiedParams = sslParameters.cloneWithTrustManager(
                 getDelegatingTrustManager(sslParameters.getX509TrustManager(), socket));
         } else {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -961,6 +961,11 @@ public final class NativeCrypto {
             "TLS_PSK_WITH_AES_256_CBC_SHA",
     };
 
+    /** TLS-SPAKE */
+    static final String[] DEFAULT_SPAKE_CIPHER_SUITES = new String[] {
+            "TLS1_3_NAMED_PAKE_SPAKE2PLUSV1",
+    };
+
     static String[] getSupportedCipherSuites() {
         return SSLUtils.concat(SUPPORTED_TLS_1_3_CIPHER_SUITES, SUPPORTED_TLS_1_2_CIPHER_SUITES.clone());
     }
@@ -1208,6 +1213,11 @@ public final class NativeCrypto {
             if (SUPPORTED_TLS_1_2_CIPHER_SUITES_SET.contains(cipherSuites[i])) {
                 continue;
             }
+            // Not sure if we need to do this for SPAKE, but the SPAKE cipher suite
+            // not registered at the moment.
+            if (DEFAULT_SPAKE_CIPHER_SUITES[0] == cipherSuites[i]) {
+                continue;
+            }
 
             // For backwards compatibility, it's allowed for |cipherSuite| to
             // be an OpenSSL-style cipher-suite name.
@@ -1324,18 +1334,16 @@ public final class NativeCrypto {
                 throws CertificateException;
 
         /**
-         * Called on an SSL client when the server requests (or
-         * requires a certificate). The client can respond by using
-         * SSL_use_certificate and SSL_use_PrivateKey to set a
-         * certificate if has an appropriate one available, similar to
-         * how the server provides its certificate.
+         * Called on an SSL client when the server requests (or requires a certificate). The client
+         * can respond by using SSL_use_certificate and SSL_use_PrivateKey to set a certificate if
+         * has an appropriate one available, similar to how the server provides its certificate.
          *
-         * @param keyTypes key types supported by the server,
-         * convertible to strings with #keyType
+         * @param keyTypes key types supported by the server, convertible to strings with #keyType
          * @param asn1DerEncodedX500Principals CAs known to the server
          */
-        @SuppressWarnings("unused") void clientCertificateRequested(byte[] keyTypes, int[] signatureAlgs,
-                byte[][] asn1DerEncodedX500Principals)
+        @SuppressWarnings("unused")
+        void clientCertificateRequested(
+                byte[] keyTypes, int[] signatureAlgs, byte[][] asn1DerEncodedX500Principals)
                 throws CertificateEncodingException, SSLException;
 
         /**

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -29,6 +29,7 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -84,6 +85,38 @@ final class NativeSsl {
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    void initSpake() throws SSLException, InvalidAlgorithmParameterException {
+        Spake2PlusKeyManager spakeKeyManager = parameters.getSpake2PlusKeyManager();
+        byte[] context =
+                spakeKeyManager.getContext() == null
+                        ? "spake2+".getBytes()
+                        : spakeKeyManager.getContext();
+        byte[] idProverArray = spakeKeyManager.getIdProver();
+        byte[] idVerifierArray = spakeKeyManager.getIdVerifier();
+        byte[] pwArray = spakeKeyManager.getPassword();
+        byte[] w0Array = spakeKeyManager.getw0();
+        byte[] w1Array = spakeKeyManager.getw1();
+        byte[] registrationRecordArray = spakeKeyManager.getRegistrationRecord();
+        boolean isClient = spakeKeyManager.isClient();
+
+        // TODO: uncomment this once the native code is ready.
+        /*
+        if (pwArray != null) {
+            NativeCrypto.SSL_CTX_set_spake_credential(
+                context, pwArray, idProverArray,
+                idVerifierArray, isClient, this);
+        } else if (isClient && w0Array != null && w1Array != null) {
+            NativeCrypto.SSL_CTX_set_spake_credential_client(
+                context, w0Array, w1Array,
+                idProverArray, idVerifierArray, this);
+        } else if (!isClient && w0Array != null && registrationRecordArray != null) {
+            NativeCrypto.SSL_CTX_set_spake_credential_server(
+                context, w0Array, registrationRecordArray,
+                idProverArray, idVerifierArray, this);
+        }
+        */
     }
 
     void offerToResumeSession(long sslSessionNativePointer) throws SSLException {
@@ -273,6 +306,14 @@ final class NativeSsl {
     }
 
     void initialize(String hostname, OpenSSLKey channelIdPrivateKey) throws IOException {
+        if (parameters.isSpake()) {
+            try {
+                initSpake();
+            } catch (Exception e) {
+                throw new SSLHandshakeException("Spake initialization failed " + e.getMessage());
+            }
+        }
+
         boolean enableSessionCreation = parameters.getEnableSessionCreation();
         if (!enableSessionCreation) {
             NativeCrypto.SSL_set_session_creation_enabled(ssl, this, false);
@@ -308,8 +349,12 @@ final class NativeSsl {
                     + " are no longer supported and were filtered from the list");
         }
         NativeCrypto.setEnabledProtocols(ssl, this, parameters.enabledProtocols);
-        NativeCrypto.setEnabledCipherSuites(
-            ssl, this, parameters.enabledCipherSuites, parameters.enabledProtocols);
+        // Not sure if we need to do this for SPAKE, but the SPAKE cipher suite
+        // not registered at the moment.
+        if (!parameters.isSpake()) {
+            NativeCrypto.setEnabledCipherSuites(
+                ssl, this, parameters.enabledCipherSuites, parameters.enabledProtocols);
+        }
 
         if (parameters.applicationProtocols.length > 0) {
             NativeCrypto.setApplicationProtocols(ssl, this, isClient(), parameters.applicationProtocols);
@@ -349,7 +394,9 @@ final class NativeSsl {
         // with TLSv1 and SSLv3).
         NativeCrypto.SSL_set_mode(ssl, this, SSL_MODE_CBC_RECORD_SPLITTING);
 
-        setCertificateValidation();
+        if (!parameters.isSpake()) {
+          setCertificateValidation();
+        }
         setTlsChannelId(channelIdPrivateKey);
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -547,6 +547,12 @@ public final class OpenSSLProvider extends Provider {
                 baseClass + "$X25519_CHACHA20");
         put("Alg.Alias.ConscryptHpke.DHKEM_X25519_HKDF_SHA256_HKDF_SHA256_GhpkeCHACHA20POLY1305",
                 "DHKEM_X25519_HKDF_SHA256/HKDF_SHA256/CHACHA20POLY1305");
+
+        /* === PAKE === */
+        if (Platform.isPakeSupported()) {
+            put("TrustManagerFactory.PAKE", PREFIX + "PakeTrustManagerFactory");
+            put("KeyManagerFactory.PAKE", PREFIX + "PakeKeyManagerFactory");
+        }
     }
 
     private boolean classExists(String classname) {

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -69,6 +69,10 @@ final class SSLParametersImpl implements Cloneable {
     private final PSKKeyManager pskKeyManager;
     // source of X.509 certificate based authentication trust decisions or null if not provided
     private final X509TrustManager x509TrustManager;
+    // source of Spake trust or null if not provided
+    private final Spake2PlusTrustManager spake2PlusTrustManager;
+    // source of Spake authentication or null if not provided
+    private final Spake2PlusKeyManager spake2PlusKeyManager;
 
     // protocols enabled for SSL connection
     String[] enabledProtocols;
@@ -126,21 +130,42 @@ final class SSLParametersImpl implements Cloneable {
         this.serverSessionContext = serverSessionContext;
         this.clientSessionContext = clientSessionContext;
 
+
         // initialize key managers
         if (kms == null) {
             x509KeyManager = getDefaultX509KeyManager();
             // There's no default PSK key manager
             pskKeyManager = null;
+            spake2PlusKeyManager = null;
         } else {
             x509KeyManager = findFirstX509KeyManager(kms);
             pskKeyManager = findFirstPSKKeyManager(kms);
+            spake2PlusKeyManager = findFirstSpake2PlusKeyManager(kms);
+            if (spake2PlusKeyManager != null) {
+                if (x509KeyManager != null || pskKeyManager != null) {
+                    throw new KeyManagementException(
+                            "Spake2PlusManagers should not be set with X509KeyManager,"
+                                + " x509TrustManager or PSKKeyManager");
+                }
+                setUseClientMode(spake2PlusKeyManager.isClient());
+            }
         }
 
         // initialize x509TrustManager
         if (tms == null) {
             x509TrustManager = getDefaultX509TrustManager();
+            spake2PlusTrustManager = null;
         } else {
             x509TrustManager = findFirstX509TrustManager(tms);
+            spake2PlusTrustManager = findFirstSpake2PlusTrustManager(tms);
+            if (spake2PlusTrustManager != null && x509TrustManager != null) {
+                throw new KeyManagementException(
+                        "Spake2PlusTrustManager should not be set with X509TrustManager");
+            }
+        }
+        if ((spake2PlusTrustManager != null) != (spake2PlusKeyManager != null)) {
+            throw new KeyManagementException(
+                    "Spake2PlusTrustManager and Spake2PlusKeyManager should be set together");
         }
 
         // initialize the list of cipher suites and protocols enabled by default
@@ -161,31 +186,37 @@ final class SSLParametersImpl implements Cloneable {
         boolean x509CipherSuitesNeeded = (x509KeyManager != null) || (x509TrustManager != null);
         boolean pskCipherSuitesNeeded = pskKeyManager != null;
         enabledCipherSuites = getDefaultCipherSuites(
-                x509CipherSuitesNeeded, pskCipherSuitesNeeded);
+                x509CipherSuitesNeeded, pskCipherSuitesNeeded, isSpake());
 
         // We ignore the SecureRandom passed in by the caller. The native code below
         // directly accesses /dev/urandom, which makes it irrelevant.
     }
 
     // Copy constructor for the purposes of changing the final fields
-    @SuppressWarnings("deprecation")  // for PSKKeyManager
-    private SSLParametersImpl(ClientSessionContext clientSessionContext,
-        ServerSessionContext serverSessionContext,
-        X509KeyManager x509KeyManager,
-        PSKKeyManager pskKeyManager,
-        X509TrustManager x509TrustManager,
-        SSLParametersImpl sslParams) {
+    @SuppressWarnings("deprecation") // for PSKKeyManager
+    private SSLParametersImpl(
+            ClientSessionContext clientSessionContext,
+            ServerSessionContext serverSessionContext,
+            X509KeyManager x509KeyManager,
+            PSKKeyManager pskKeyManager,
+            X509TrustManager x509TrustManager,
+            Spake2PlusTrustManager spake2PlusTrustManager,
+            Spake2PlusKeyManager spake2PlusKeyManager,
+            SSLParametersImpl sslParams) {
         this.clientSessionContext = clientSessionContext;
         this.serverSessionContext = serverSessionContext;
         this.x509KeyManager = x509KeyManager;
         this.pskKeyManager = pskKeyManager;
         this.x509TrustManager = x509TrustManager;
+        this.spake2PlusKeyManager = spake2PlusKeyManager;
+        this.spake2PlusTrustManager = spake2PlusTrustManager;
 
         this.enabledProtocols =
-            (sslParams.enabledProtocols == null) ? null : sslParams.enabledProtocols.clone();
+                (sslParams.enabledProtocols == null) ? null : sslParams.enabledProtocols.clone();
         this.isEnabledProtocolsFiltered = sslParams.isEnabledProtocolsFiltered;
-        this.enabledCipherSuites =
-            (sslParams.enabledCipherSuites == null) ? null : sslParams.enabledCipherSuites.clone();
+        this.enabledCipherSuites = (sslParams.enabledCipherSuites == null)
+                ? null
+                : sslParams.enabledCipherSuites.clone();
         this.client_mode = sslParams.client_mode;
         this.need_client_auth = sslParams.need_client_auth;
         this.want_client_auth = sslParams.want_client_auth;
@@ -194,11 +225,12 @@ final class SSLParametersImpl implements Cloneable {
         this.useCipherSuitesOrder = sslParams.useCipherSuitesOrder;
         this.ctVerificationEnabled = sslParams.ctVerificationEnabled;
         this.sctExtension =
-            (sslParams.sctExtension == null) ? null : sslParams.sctExtension.clone();
+                (sslParams.sctExtension == null) ? null : sslParams.sctExtension.clone();
         this.ocspResponse =
-            (sslParams.ocspResponse == null) ? null : sslParams.ocspResponse.clone();
-        this.applicationProtocols =
-            (sslParams.applicationProtocols == null) ? null : sslParams.applicationProtocols.clone();
+                (sslParams.ocspResponse == null) ? null : sslParams.ocspResponse.clone();
+        this.applicationProtocols = (sslParams.applicationProtocols == null)
+                ? null
+                : sslParams.applicationProtocols.clone();
         this.applicationProtocolSelector = sslParams.applicationProtocolSelector;
         this.useSessionTickets = sslParams.useSessionTickets;
         this.useSni = sslParams.useSni;
@@ -246,6 +278,13 @@ final class SSLParametersImpl implements Cloneable {
     @SuppressWarnings("deprecation") // PSKKeyManager is deprecated, but in our own package
     PSKKeyManager getPSKKeyManager() {
         return pskKeyManager;
+    }
+
+    /*
+     * Returns Spake key manager or null for none.
+     */
+    Spake2PlusKeyManager getSpake2PlusKeyManager() {
+        return spake2PlusKeyManager;
     }
 
     /*
@@ -498,7 +537,8 @@ final class SSLParametersImpl implements Cloneable {
      * For abstracting the X509KeyManager calls between
      * X509KeyManager#chooseClientAlias(String[], java.security.Principal[], java.net.Socket)
      * and
-     * X509ExtendedKeyManager#chooseEngineClientAlias(String[], java.security.Principal[], javax.net.ssl.SSLEngine)
+     * X509ExtendedKeyManager#chooseEngineClientAlias(String[], java.security.Principal[],
+     * javax.net.ssl.SSLEngine)
      */
     interface AliasChooser {
         String chooseClientAlias(X509KeyManager keyManager, X500Principal[] issuers,
@@ -533,7 +573,12 @@ final class SSLParametersImpl implements Cloneable {
 
     SSLParametersImpl cloneWithTrustManager(X509TrustManager newTrustManager) {
         return new SSLParametersImpl(clientSessionContext, serverSessionContext,
-            x509KeyManager, pskKeyManager, newTrustManager, this);
+            x509KeyManager, pskKeyManager, newTrustManager, null, null, this);
+    }
+
+    SSLParametersImpl cloneWithSpake() {
+        return new SSLParametersImpl(clientSessionContext, serverSessionContext,
+            null, null, null, spake2PlusTrustManager, spake2PlusKeyManager, this);
     }
 
     private static X509KeyManager getDefaultX509KeyManager() throws KeyManagementException {
@@ -597,10 +642,21 @@ final class SSLParametersImpl implements Cloneable {
     }
 
     /*
+     * Returns the first Spake2PlusKeyManager element in the provided array.
+     */
+    private static Spake2PlusKeyManager findFirstSpake2PlusKeyManager(KeyManager[] kms) {
+        for (KeyManager km : kms) {
+            if (km instanceof Spake2PlusKeyManager) {
+                return (Spake2PlusKeyManager) km;
+            }
+        }
+        return null;
+    }
+
+    /*
      * Returns the default X.509 trust manager.
      */
-    static X509TrustManager getDefaultX509TrustManager()
-            throws KeyManagementException {
+    static X509TrustManager getDefaultX509TrustManager() throws KeyManagementException {
         X509TrustManager result = defaultX509TrustManager;
         if (result == null) {
             // single-check idiom
@@ -637,6 +693,18 @@ final class SSLParametersImpl implements Cloneable {
         for (TrustManager tm : tms) {
             if (tm instanceof X509TrustManager) {
                 return (X509TrustManager) tm;
+            }
+        }
+        return null;
+    }
+
+    /*
+     * Returns the first Spake2PlusTrustManager element in the provided array.
+     */
+    private static Spake2PlusTrustManager findFirstSpake2PlusTrustManager(TrustManager[] tms) {
+        for (TrustManager tm : tms) {
+            if (tm instanceof Spake2PlusTrustManager) {
+                return (Spake2PlusTrustManager) tm;
             }
         }
         return null;
@@ -679,7 +747,11 @@ final class SSLParametersImpl implements Cloneable {
 
     private static String[] getDefaultCipherSuites(
             boolean x509CipherSuitesNeeded,
-            boolean pskCipherSuitesNeeded) {
+            boolean pskCipherSuitesNeeded,
+            boolean spake2PlusCipherSuitesNeeded) {
+        if (spake2PlusCipherSuitesNeeded) {
+            return NativeCrypto.DEFAULT_SPAKE_CIPHER_SUITES;
+        }
         if (x509CipherSuitesNeeded) {
             // X.509 based cipher suites need to be listed.
             if (pskCipherSuitesNeeded) {
@@ -723,5 +795,9 @@ final class SSLParametersImpl implements Cloneable {
             return true;
         }
         return Platform.isCTVerificationRequired(hostname);
+    }
+
+    boolean isSpake() {
+        return spake2PlusKeyManager != null;
     }
 }

--- a/common/src/main/java/org/conscrypt/Spake2PlusKeyManager.java
+++ b/common/src/main/java/org/conscrypt/Spake2PlusKeyManager.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import java.util.List;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.KeyManager;
+import java.security.Principal;
+
+/**
+ * @hide This class is not part of the Android public SDK API
+ */
+@Internal
+public class Spake2PlusKeyManager implements KeyManager {
+  private final byte[] context;
+  private final byte[] password;
+  private final byte[] w0;
+  private final byte[] w1;
+  private final byte[] registrationRecord;
+  private final byte[] idProver;
+  private final byte[] idVerifier;
+  private final boolean isClient;
+
+  Spake2PlusKeyManager(byte[] context, byte[] password,
+      byte[] w0, byte[] w1, byte[] registrationRecord,
+      byte[] idProver, byte[] idVerifier, boolean isClient) {
+    this.context = context;
+    this.password = password;
+    this.w0 = w0;
+    this.w1 = w1;
+    this.registrationRecord = registrationRecord;
+    this.idProver = idProver;
+    this.idVerifier = idVerifier;
+    this.isClient = isClient;
+  }
+
+  public String chooseEngineAlias(String keyType,
+          Principal[] issuers, SSLEngine engine) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  public String chooseEngineClientAlias(String[] keyType,
+          Principal[] issuers, SSLEngine engine) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  public byte[] getContext() {
+    return context;
+  }
+
+  public byte[] getPassword() {
+    return password;
+  }
+
+  public byte[] getw0() {
+    return w0;
+  }
+
+  public byte[] getw1() {
+    return w1;
+  }
+
+  public byte[] getRegistrationRecord() {
+    return registrationRecord;
+  }
+
+  public byte[] getIdProver() {
+    return idProver;
+  }
+
+  public byte[] getIdVerifier() {
+    return idVerifier;
+  }
+
+  public boolean isClient() {
+    return isClient;
+  }
+}

--- a/common/src/main/java/org/conscrypt/Spake2PlusTrustManager.java
+++ b/common/src/main/java/org/conscrypt/Spake2PlusTrustManager.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import javax.net.ssl.TrustManager;
+
+/**
+ * @hide This class is not part of the Android public SDK API
+ */
+@Internal
+public class Spake2PlusTrustManager implements TrustManager {
+
+  Spake2PlusTrustManager() {}
+
+  public void checkClientTrusted() {}
+
+  public void checkServerTrusted() {}
+}

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
@@ -50,6 +50,7 @@ import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
 import org.conscrypt.KeyManagerFactoryImpl;
 import org.conscrypt.TestUtils;
+import org.conscrypt.PakeKeyManagerFactory;
 import org.conscrypt.java.security.StandardNames;
 import org.conscrypt.java.security.TestKeyStore;
 import org.junit.Before;
@@ -104,6 +105,10 @@ public class KeyManagerFactoryTest {
         assertNotNull(kmf);
         assertNotNull(kmf.getAlgorithm());
         assertNotNull(kmf.getProvider());
+
+        if (kmf.getAlgorithm() == "PAKE") {
+            return;
+        }
 
         // before init
         try {

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
@@ -150,6 +150,10 @@ public class KeyManagerFactoryTest {
             }
         }
 
+        if (kmf.getAlgorithm() == "PAKE") {
+            return;
+        }
+
         // init with null for default behavior
         kmf.init(null, null);
         test_KeyManagerFactory_getKeyManagers(kmf, true);
@@ -522,3 +526,4 @@ public class KeyManagerFactoryTest {
         }
     }
 }
+

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -498,10 +498,6 @@ public class SSLSocketTest {
                         // By the point of the handshake where we're validating certificates,
                         // the hostname is known and the cipher suite should be agreed
                         assertEquals(referenceContext.host.getHostName(), session.getPeerHost());
-
-                        // The negotiated cipher suite should be one of the enabled ones, but
-                        // BoringSSL may have reordered them based on things like hardware support,
-                        // so we don't know which one may have been negotiated.
                         String sessionSuite = session.getCipherSuite();
                         List<String> enabledSuites =
                             Arrays.asList(referenceClientSocket.getEnabledCipherSuites());
@@ -1306,3 +1302,4 @@ public class SSLSocketTest {
         }
     }
 }
+

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/TrustManagerFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/TrustManagerFactoryTest.java
@@ -83,6 +83,10 @@ public class TrustManagerFactoryTest {
         assertNotNull(tmf.getAlgorithm());
         assertNotNull(tmf.getProvider());
 
+        if (tmf.getAlgorithm() == "PAKE") {
+            return;
+        }
+
         // before init
         try {
             tmf.getTrustManagers();
@@ -231,6 +235,9 @@ public class TrustManagerFactoryTest {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
                     TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
+                    if (tmf.getAlgorithm() == "PAKE") {
+                        return;
+                    }
                     tmf.init(keyStore);
                     TrustManager[] trustManagers = tmf.getTrustManagers();
                     for (TrustManager trustManager : trustManagers) {

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -858,4 +858,8 @@ final public class Platform {
     public static boolean isTlsV1Supported() {
         return ENABLED_TLS_V1;
     }
+
+    public static boolean isPakeSupported() {
+        return false;
+    }
 }

--- a/platform/src/main/java/org/conscrypt/PakeKeyManagerFactory.java
+++ b/platform/src/main/java/org/conscrypt/PakeKeyManagerFactory.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt;
+
+import static java.util.Objects.requireNonNull;
+import static android.net.ssl.PakeServerKeyManagerParameters.Link;
+
+import android.net.ssl.PakeClientKeyManagerParameters;
+import android.net.ssl.PakeServerKeyManagerParameters;
+import android.net.ssl.PakeOption;
+
+import org.conscrypt.io.IoUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Set;
+import java.util.List;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactorySpi;
+import javax.net.ssl.ManagerFactoryParameters;
+
+/**
+ * PakeKeyManagerFactory implementation.
+ * @see KeyManagerFactorySpi
+ * @hide This class is not part of the Android public SDK API
+ */
+@Internal
+public class PakeKeyManagerFactory extends KeyManagerFactorySpi {
+    PakeClientKeyManagerParameters clientParams;
+    PakeServerKeyManagerParameters serverParams;
+
+    /**
+     * @see KeyManagerFactorySpi#engineInit(KeyStore ks, char[] password)
+     */
+    @Override
+    public void engineInit(KeyStore ks, char[] password)
+            throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+        throw new KeyStoreException("KeyStore not supported");
+    }
+
+    /**
+     * @see KeyManagerFactorySpi#engineInit(ManagerFactoryParameters spec)
+     */
+    @Override
+    public void engineInit(ManagerFactoryParameters spec)
+            throws InvalidAlgorithmParameterException {
+        if (clientParams != null || serverParams != null) {
+            throw new IllegalStateException("PakeKeyManagerFactory is already initialized");
+        }
+        requireNonNull(spec);
+        if (spec instanceof PakeClientKeyManagerParameters) {
+            clientParams = (PakeClientKeyManagerParameters) spec;
+        } else if (spec instanceof PakeServerKeyManagerParameters) {
+            serverParams = (PakeServerKeyManagerParameters) spec;
+        } else {
+            throw new InvalidAlgorithmParameterException("ManagerFactoryParameters not supported");
+        }
+    }
+
+    /**
+     * @see KeyManagerFactorySpi#engineGetKeyManagers()
+     */
+    @Override
+    public KeyManager[] engineGetKeyManagers() {
+        if (clientParams == null && serverParams == null) {
+            throw new IllegalStateException("PakeKeyManagerFactory is not initialized");
+        }
+        if (clientParams != null) {
+            return initClient();
+        } else {
+            return initServer();
+        }
+    }
+
+    private KeyManager[] initClient() {
+        List<PakeOption> options = clientParams.getOptions();
+        for (PakeOption option : options) {
+            if (!option.getAlgorithm().equals("SPAKE2PLUS_PRERELEASE")) {
+                continue;
+            }
+            byte[] idProver = clientParams.getClientId();
+            byte[] idVerifier = clientParams.getServerId();
+            byte[] context = option.getMessageComponent("context");
+            byte[] password = option.getMessageComponent("password");
+            if (password != null) {
+                return new KeyManager[] { new Spake2PlusKeyManager(
+                        context, password, null, null, null, idProver, idVerifier, true) };
+            }
+            byte[] w0 = option.getMessageComponent("w0");
+            byte[] w1 = option.getMessageComponent("w1");
+            if (w0 != null && w1 != null) {
+                return new KeyManager[] { new Spake2PlusKeyManager(
+                        context, null, w0, w1, null, idProver, idVerifier, true) };
+            }
+            break;
+        }
+        return new KeyManager[] {};
+    }
+
+    private KeyManager[] initServer() {
+        Set<Link> links = serverParams.getLinks();
+        for (Link link : links) {
+            List<PakeOption> options = serverParams.getOptions(link);
+            for (PakeOption option : options) {
+                if (!option.getAlgorithm().equals("SPAKE2PLUS_PRERELEASE")) {
+                    continue;
+                }
+                byte[] idProver = link.getClientId();
+                byte[] idVerifier = link.getServerId();
+                byte[] context = option.getMessageComponent("context");
+                byte[] password = option.getMessageComponent("password");
+                if (password != null) {
+                    return new KeyManager[] { new Spake2PlusKeyManager(
+                            context, password, null, null, null, idProver, idVerifier, false) };
+                }
+                byte[] w0 = option.getMessageComponent("w0");
+                byte[] registrationRecord = option.getMessageComponent("registrationRecord");
+                if (w0 != null && registrationRecord != null) {
+                    return new KeyManager[] { new Spake2PlusKeyManager(
+                            context, null, w0, null, registrationRecord, idProver, idVerifier, false) };
+                }
+                break;
+            }
+        }
+        return new KeyManager[] {};
+    }
+}
+

--- a/platform/src/main/java/org/conscrypt/PakeTrustManagerFactory.java
+++ b/platform/src/main/java/org/conscrypt/PakeTrustManagerFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static java.util.Objects.requireNonNull;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.TrustManagerFactorySpi;
+
+/**
+ * A factory for creating {@link SpakeTrustManager} instances that use SPAKE2.
+ * @hide This class is not part of the Android public SDK API
+ */
+@Internal
+public class PakeTrustManagerFactory extends TrustManagerFactorySpi {
+    /**
+     * @see javax.net.ssl.TrustManagerFactorySpi#engineInit(KeyStore)
+     */
+    @Override
+    public void engineInit(KeyStore ks) throws KeyStoreException {
+        if (ks != null) {
+            throw new KeyStoreException("KeyStore not supported");
+        }
+    }
+
+    /**
+     * @see javax.net.ssl#engineInit(ManagerFactoryParameters)
+     */
+    @Override
+    public void engineInit(ManagerFactoryParameters spec)
+            throws InvalidAlgorithmParameterException {
+        if (spec != null) {
+            throw new InvalidAlgorithmParameterException("ManagerFactoryParameters not supported");
+        }
+    }
+
+    /**
+     * @see javax.net.ssl#engineGetTrustManagers()
+     */
+    @Override
+    public TrustManager[] engineGetTrustManagers() {
+        return new TrustManager[] { new Spake2PlusTrustManager() };
+    }
+}

--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -579,6 +579,10 @@ final public class Platform {
         return ENABLED_TLS_V1;
     }
 
+    public static boolean isPakeSupported() {
+        return true;
+    }
+
     static Object getTargetSdkVersion() {
         try {
             Class<?> vmRuntimeClass = Class.forName("dalvik.system.VMRuntime");

--- a/platform/src/test/java/org/conscrypt/PakeManagerFactoriesTest.java
+++ b/platform/src/test/java/org/conscrypt/PakeManagerFactoriesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import android.net.ssl.PakeClientKeyManagerParameters;
+import android.net.ssl.PakeOption;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.ManagerFactoryParameters;
+import java.security.KeyStoreException;
+import java.security.InvalidAlgorithmParameterException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * @hide This class is not part of the Android public SDK API
+ */
+public class PakeManagerFactoriesTest {
+    private static final byte[] CLIENT_ID = new byte[] {4, 5, 6};
+    private static final byte[] SERVER_ID = new byte[] {7, 8, 9};
+
+    @Test
+    public void testEngineInitParameters() throws InvalidAlgorithmParameterException {
+        PakeKeyManagerFactory keyManagerFactory = new PakeKeyManagerFactory();
+
+        byte[] password = new byte[] {1, 2, 3};
+        PakeOption option =
+                new PakeOption.Builder("SPAKE2PLUS_PRERELEASE")
+                        .addMessageComponent("password", password)
+                        .build();
+
+        assertThrows(KeyStoreException.class, () -> keyManagerFactory.engineInit(null, null));
+
+        PakeClientKeyManagerParameters params =
+                new PakeClientKeyManagerParameters.Builder().addOption(option).build();
+        // Initialize with valid parameters
+        keyManagerFactory.engineInit(params);
+        // Try to initialize again
+        assertThrows(IllegalStateException.class, () -> keyManagerFactory.engineInit(params));
+
+        PakeTrustManagerFactory trustManagerFactory = new PakeTrustManagerFactory();
+        // The trust manager factory does not accept parameters
+        assertThrows(
+                InvalidAlgorithmParameterException.class,
+                () -> trustManagerFactory.engineInit(params));
+        trustManagerFactory.engineInit((ManagerFactoryParameters) null);
+    }
+
+    @Test
+    public void testEngineGetKeyManagers() throws InvalidAlgorithmParameterException {
+        PakeKeyManagerFactory factory = new PakeKeyManagerFactory();
+        assertThrows(IllegalStateException.class, () -> factory.engineGetKeyManagers());
+
+        byte[] password = new byte[] {1, 2, 3};
+        PakeOption option =
+                new PakeOption.Builder("SPAKE2PLUS_PRERELEASE")
+                        .addMessageComponent("password", password)
+                        .build();
+
+        PakeClientKeyManagerParameters params =
+                new PakeClientKeyManagerParameters.Builder()
+                        .setClientId(CLIENT_ID.clone())
+                        .setServerId(SERVER_ID.clone())
+                        .addOption(option)
+                        .build();
+
+        factory.engineInit(params);
+        KeyManager[] keyManagers = factory.engineGetKeyManagers();
+        assertEquals(1, keyManagers.length);
+
+        Spake2PlusKeyManager keyManager = (Spake2PlusKeyManager) keyManagers[0];
+        assertArrayEquals(password, keyManager.getPassword());
+        assertArrayEquals(new byte[] {4, 5, 6}, keyManager.getIdProver());
+        assertArrayEquals(new byte[] {7, 8, 9}, keyManager.getIdVerifier());
+    }
+
+    @Test
+    public void testEngineGetTrustManagers() {
+        PakeTrustManagerFactory factory = new PakeTrustManagerFactory();
+        TrustManager[] trustManagers = factory.engineGetTrustManagers();
+        assertEquals(1, trustManagers.length);
+        assertEquals(Spake2PlusTrustManager.class, trustManagers[0].getClass());
+    }
+}


### PR DESCRIPTION
This cl:
- Adds Key/TrustManagerFactories and Key/TrustManagers for Spake
- Modifies OpenSSLParameters to accept Spake
- Adds Spake setup within NativeSSL
- Includes miscellaneous changes to make the above work
- Adds tests for the above.

TEST=atest SSLSocketTest/SpakeManagerFactoriesTest/SpakeKeyManagerParametersTest BUG=382233100

Change-Id: I5203a651fa74fe90cabd234bc2b1a94cfc9d3e88