### PR TITLE
Add Spake parameter plumbing to Conscrypt

### DIFF
--- a/android-stub/src/main/java/android/pake/PakeClientKeyManagerParameters.java
+++ b/android-stub/src/main/java/android/pake/PakeClientKeyManagerParameters.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.net.ssl;
+
+import static java.util.Objects.requireNonNull;
+
+import libcore.util.NonNull;
+import libcore.util.Nullable;
+
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.net.ssl.ManagerFactoryParameters;
+
+/**
+ * Parameters for configuring a {@code KeyManager} that supports PAKE (Password
+ * Authenticated Key Exchange).
+ *
+ * <p>This class holds the necessary information for the {@code KeyManager} to perform PAKE
+ * authentication, including the IDs of the client and server involved and the available PAKE
+ * options.</p>
+ *
+ * <p>Instances of this class are immutable. Use the {@link Builder} to create
+ * instances.</p>
+ *
+ * @hide
+ */
+public final class PakeClientKeyManagerParameters implements ManagerFactoryParameters {
+    /**
+     * Returns the client identifier.
+     *
+     * @return The client identifier.
+     */
+    public @Nullable byte[] getClientId();
+
+    /**
+     * Returns the server identifier.
+     *
+     * @return The server identifier.
+     */
+    public @Nullable byte[] getServerId();
+
+    /**
+     * Returns a copy of the list of available PAKE options.
+     *
+     * @return A copy of the list of available PAKE options.
+     */
+    public @NonNull List<PakeOption> getOptions();
+
+    /**
+     * A builder for creating {@link PakeClientKeyManagerParameters} instances.
+     *
+     * @hide
+     */
+    public static final class Builder {
+        /**
+         * Sets the ID of the client involved in the PAKE exchange.
+         *
+         * @param clientId The ID of the client involved in the PAKE exchange.
+         * @return This builder.
+         */
+        public @NonNull Builder setClientId(@Nullable byte[] clientId);
+
+        /**
+         * Sets the ID of the server involved in the PAKE exchange.
+         *
+         * @param serverId The ID of the server involved in the PAKE exchange.
+         * @return This builder.
+         */
+        public @NonNull Builder setServerId(@Nullable byte[] serverId);
+
+        /**
+         * Adds a PAKE option.
+         *
+         * @param option The PAKE option to add.
+         * @return This builder.
+         * @throws InvalidParameterException If an option with the same algorithm already exists.
+         */
+        public @NonNull Builder addOption(@NonNull PakeOption option);
+
+        /**
+         * Builds a new {@link PakeClientKeyManagerParameters} instance.
+         *
+         * @return A new {@link PakeClientKeyManagerParameters} instance.
+         * @throws InvalidParameterException If no PAKE options are provided.
+         */
+        public @NonNull PakeClientKeyManagerParameters build();
+    }
+}

--- a/android-stub/src/main/java/android/pake/PakeClientKeyManagerParameters.java
+++ b/android-stub/src/main/java/android/pake/PakeClientKeyManagerParameters.java
@@ -47,21 +47,27 @@ public final class PakeClientKeyManagerParameters implements ManagerFactoryParam
      *
      * @return The client identifier.
      */
-    public @Nullable byte[] getClientId();
+    public @Nullable byte[] getClientId() {
+        throw new RuntimeException("Stub!");
+    }
 
     /**
      * Returns the server identifier.
      *
      * @return The server identifier.
      */
-    public @Nullable byte[] getServerId();
+    public @Nullable byte[] getServerId() {
+        throw new RuntimeException("Stub!");
+    }
 
     /**
      * Returns a copy of the list of available PAKE options.
      *
      * @return A copy of the list of available PAKE options.
      */
-    public @NonNull List<PakeOption> getOptions();
+    public @NonNull List<PakeOption> getOptions() {
+        throw new RuntimeException("Stub!");
+    }
 
     /**
      * A builder for creating {@link PakeClientKeyManagerParameters} instances.
@@ -75,7 +81,9 @@ public final class PakeClientKeyManagerParameters implements ManagerFactoryParam
          * @param clientId The ID of the client involved in the PAKE exchange.
          * @return This builder.
          */
-        public @NonNull Builder setClientId(@Nullable byte[] clientId);
+        public @NonNull Builder setClientId(@Nullable byte[] clientId) {
+            throw new RuntimeException("Stub!");
+        }
 
         /**
          * Sets the ID of the server involved in the PAKE exchange.
@@ -83,7 +91,9 @@ public final class PakeClientKeyManagerParameters implements ManagerFactoryParam
          * @param serverId The ID of the server involved in the PAKE exchange.
          * @return This builder.
          */
-        public @NonNull Builder setServerId(@Nullable byte[] serverId);
+        public @NonNull Builder setServerId(@Nullable byte[] serverId) {
+            throw new RuntimeException("Stub!");
+        }
 
         /**
          * Adds a PAKE option.
@@ -92,7 +102,9 @@ public final class PakeClientKeyManagerParameters implements ManagerFactoryParam
          * @return This builder.
          * @throws InvalidParameterException If an option with the same algorithm already exists.
          */
-        public @NonNull Builder addOption(@NonNull PakeOption option);
+        public @NonNull Builder addOption(@NonNull PakeOption option) {
+            throw new RuntimeException("Stub!");
+        }
 
         /**
          * Builds a new {@link PakeClientKeyManagerParameters} instance.
@@ -100,6 +112,8 @@ public final class PakeClientKeyManagerParameters implements ManagerFactoryParam
          * @return A new {@link PakeClientKeyManagerParameters} instance.
          * @throws InvalidParameterException If no PAKE options are provided.
          */
-        public @NonNull PakeClientKeyManagerParameters build();
+        public @NonNull PakeClientKeyManagerParameters build() {
+            throw new RuntimeException("Stub!");
+        }
     }
 }

--- a/android-stub/src/main/java/android/pake/PakeOption.java
+++ b/android-stub/src/main/java/android/pake/PakeOption.java
@@ -39,7 +39,9 @@ public final class PakeOption {
      *
      * @return The algorithm of the PAKE algorithm.
      */
-    public @NonNull String getAlgorithm();
+    public @NonNull String getAlgorithm() {
+        throw new RuntimeException("Stub!");
+    }
 
     /**
      * Returns the message component with the given key.
@@ -48,7 +50,9 @@ public final class PakeOption {
      * @return The component data, or {@code null} if no component with the given
      *         key exists.
      */
-    public @Nullable byte[] getMessageComponent(@NonNull String key);
+    public @Nullable byte[] getMessageComponent(@NonNull String key) {
+        throw new RuntimeException("Stub!");
+    }
 
     /**
      * A builder for creating {@link PakeOption} instances.
@@ -62,7 +66,9 @@ public final class PakeOption {
          * @param algorithm The algorithm of the PAKE algorithm.
          * @throws InvalidParameterException If the algorithm is invalid.
          */
-        public Builder(@NonNull String algorithm);
+        public Builder(@NonNull String algorithm) {
+            throw new RuntimeException("Stub!");
+        }
 
         /**
          * Adds a message component.
@@ -72,7 +78,9 @@ public final class PakeOption {
          * @return This builder.
          * @throws InvalidParameterException If the key is invalid.
          */
-        public @NonNull Builder addMessageComponent(@NonNull String key, @Nullable byte[] value);
+        public @NonNull Builder addMessageComponent(@NonNull String key, @Nullable byte[] value) {
+            throw new RuntimeException("Stub!");
+        }
 
         /**
          * Builds a new {@link PakeOption} instance.
@@ -83,6 +91,8 @@ public final class PakeOption {
          * @return A new {@link PakeOption} instance.
          * @throws InvalidParameterException If the message components are invalid.
          */
-        public @NonNull PakeOption build();
+        public @NonNull PakeOption build() {
+            throw new RuntimeException("Stub!");
+        }
     }
 }

--- a/android-stub/src/main/java/android/pake/PakeOption.java
+++ b/android-stub/src/main/java/android/pake/PakeOption.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.net.ssl;
+
+import libcore.util.NonNull;
+import libcore.util.Nullable;
+
+import java.security.InvalidParameterException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An class representing a PAKE (Password Authenticated Key Exchange)
+ * option for TLS connections.
+ *
+ * <p>Instances of this class are immutable. Use the {@link Builder} to create
+ * instances.</p>
+ *
+ * @hide
+ */
+public final class PakeOption {
+    /**
+     * Returns the algorithm of the PAKE algorithm.
+     *
+     * @return The algorithm of the PAKE algorithm.
+     */
+    public @NonNull String getAlgorithm();
+
+    /**
+     * Returns the message component with the given key.
+     *
+     * @param key The algorithm of the component.
+     * @return The component data, or {@code null} if no component with the given
+     *         key exists.
+     */
+    public @Nullable byte[] getMessageComponent(@NonNull String key);
+
+    /**
+     * A builder for creating {@link PakeOption} instances.
+     *
+     * @hide
+     */
+    public static final class Builder {
+        /**
+         * Constructor for the builder.
+         *
+         * @param algorithm The algorithm of the PAKE algorithm.
+         * @throws InvalidParameterException If the algorithm is invalid.
+         */
+        public Builder(@NonNull String algorithm);
+
+        /**
+         * Adds a message component.
+         *
+         * @param key The algorithm of the component.
+         * @param value The component data.
+         * @return This builder.
+         * @throws InvalidParameterException If the key is invalid.
+         */
+        public @NonNull Builder addMessageComponent(@NonNull String key, @Nullable byte[] value);
+
+        /**
+         * Builds a new {@link PakeOption} instance.
+         *
+         * <p>This method performs validation to ensure that the message components
+         * are consistent with the PAKE algorithm.</p>
+         *
+         * @return A new {@link PakeOption} instance.
+         * @throws InvalidParameterException If the message components are invalid.
+         */
+        public @NonNull PakeOption build();
+    }
+}

--- a/android-stub/src/main/java/android/pake/PakeServerKeyManagerParameters.java
+++ b/android-stub/src/main/java/android/pake/PakeServerKeyManagerParameters.java
@@ -50,7 +50,9 @@ public final class PakeServerKeyManagerParameters implements ManagerFactoryParam
      *
      * @return The known links.
      */
-    public @NonNull Set<Link> getLinks();
+    public @NonNull Set<Link> getLinks() {
+        throw new RuntimeException("Stub!");
+    }
 
     /**
      * Returns an unmodifiable list of PAKE options for the given {@link Link}.
@@ -59,7 +61,9 @@ public final class PakeServerKeyManagerParameters implements ManagerFactoryParam
      *             {@link #getLinks}.
      * @return An unmodifiable list of PAKE options for the given link.
      */
-    public @NonNull List<PakeOption> getOptions(@NonNull Link link);
+    public @NonNull List<PakeOption> getOptions(@NonNull Link link) {
+        throw new RuntimeException("Stub!");
+    }
 
     /**
      * Returns an unmodifiable list of PAKE options for the given client-server pair.
@@ -69,7 +73,9 @@ public final class PakeServerKeyManagerParameters implements ManagerFactoryParam
      * @return An unmodifiable list of PAKE options for the given link.
      */
     public @NonNull List<PakeOption> getOptions(
-            @Nullable byte[] clientId, @Nullable byte[] serverId);
+            @Nullable byte[] clientId, @Nullable byte[] serverId) {
+        throw new RuntimeException("Stub!");
+    }
 
     /**
      * A PAKE link class combining the client and server IDs.
@@ -83,25 +89,37 @@ public final class PakeServerKeyManagerParameters implements ManagerFactoryParam
          * @param clientId The client identifier for the link.
          * @param serverId The server identifier for the link.
          */
-        private Link(@Nullable byte[] clientId, @Nullable byte[] serverId);
+        private Link(@Nullable byte[] clientId, @Nullable byte[] serverId) {
+            throw new RuntimeException("Stub!");
+        }
 
         /**
          * Returns the client identifier for the link.
          *
          * @return The client identifier for the link.
          */
-        public @Nullable byte[] getClientId();
+        public @Nullable byte[] getClientId() {
+            throw new RuntimeException("Stub!");
+        }
 
         /**
          * Returns the server identifier for the link.
          *
          * @return The server identifier for the link.
          */
-        public @Nullable byte[] getServerId();
+        public @Nullable byte[] getServerId() {
+            throw new RuntimeException("Stub!");
+        }
 
-        @Override public boolean equals(Object o);
+        @Override
+        public boolean equals(Object o) {
+            throw new RuntimeException("Stub!");
+        }
 
-        @Override public int hashCode();
+        @Override
+        public int hashCode() {
+            throw new RuntimeException("Stub!");
+        }
     }
 
     /**
@@ -121,7 +139,9 @@ public final class PakeServerKeyManagerParameters implements ManagerFactoryParam
          * @throws InvalidParameterException If the provided options are invalid.
          */
         public @NonNull Builder setOptions(@Nullable byte[] clientId, @Nullable byte[] serverId,
-                @NonNull List<PakeOption> options);
+                @NonNull List<PakeOption> options) {
+            throw new RuntimeException("Stub!");
+        }
 
         /**
          * Builds a new {@link PakeServerKeyManagerParameters} instance.
@@ -129,6 +149,8 @@ public final class PakeServerKeyManagerParameters implements ManagerFactoryParam
          * @return A new {@link PakeServerKeyManagerParameters} instance.
          * @throws InvalidParameterException If no links are provided.
          */
-        public @NonNull PakeServerKeyManagerParameters build();
+        public @NonNull PakeServerKeyManagerParameters build() {
+            throw new RuntimeException("Stub!");
+        }
     }
 }

--- a/android-stub/src/main/java/android/pake/PakeServerKeyManagerParameters.java
+++ b/android-stub/src/main/java/android/pake/PakeServerKeyManagerParameters.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.net.ssl;
+
+import static java.util.Objects.requireNonNull;
+
+import libcore.util.NonNull;
+import libcore.util.Nullable;
+
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.net.ssl.ManagerFactoryParameters;
+
+/**
+ * Parameters for configuring a {@code KeyManager} that supports PAKE
+ * (Password Authenticated Key Exchange) on the server side.
+ *
+ * <p>This class holds the necessary information for the {@code KeyManager} to perform PAKE
+ * authentication, including a mapping of client and server IDs (links) to their corresponding PAKE
+ * options.</p>
+ *
+ * <p>Instances of this class are immutable. Use the {@link Builder} to create
+ * instances.</p>
+ *
+ * @hide
+ */
+public final class PakeServerKeyManagerParameters implements ManagerFactoryParameters {
+    /**
+     * Returns a set of the links.
+     *
+     * @return The known links.
+     */
+    public @NonNull Set<Link> getLinks();
+
+    /**
+     * Returns an unmodifiable list of PAKE options for the given {@link Link}.
+     *
+     * @param link The link for which to retrieve the options. Should have been obtained through
+     *             {@link #getLinks}.
+     * @return An unmodifiable list of PAKE options for the given link.
+     */
+    public @NonNull List<PakeOption> getOptions(@NonNull Link link);
+
+    /**
+     * Returns an unmodifiable list of PAKE options for the given client-server pair.
+     *
+     * @param clientId The client identifier for the link.
+     * @param serverId The server identifier for the link.
+     * @return An unmodifiable list of PAKE options for the given link.
+     */
+    public @NonNull List<PakeOption> getOptions(
+            @Nullable byte[] clientId, @Nullable byte[] serverId);
+
+    /**
+     * A PAKE link class combining the client and server IDs.
+     *
+     * @hide
+     */
+    public static final class Link {
+        /**
+         * Constructs a {@code Link} object.
+         *
+         * @param clientId The client identifier for the link.
+         * @param serverId The server identifier for the link.
+         */
+        private Link(@Nullable byte[] clientId, @Nullable byte[] serverId);
+
+        /**
+         * Returns the client identifier for the link.
+         *
+         * @return The client identifier for the link.
+         */
+        public @Nullable byte[] getClientId();
+
+        /**
+         * Returns the server identifier for the link.
+         *
+         * @return The server identifier for the link.
+         */
+        public @Nullable byte[] getServerId();
+
+        @Override public boolean equals(Object o);
+
+        @Override public int hashCode();
+    }
+
+    /**
+     * A builder for creating {@link PakeServerKeyManagerParameters} instances.
+     *
+     * @hide
+     */
+    public static final class Builder {
+        /**
+         * Adds PAKE options for the given client and server IDs.
+         * Only the first link for SPAKE2PLUS_PRERELEASE will be used.
+         *
+         * @param clientId The client ID.
+         * @param serverId The server ID.
+         * @param options The list of PAKE options to add.
+         * @return This builder.
+         * @throws InvalidParameterException If the provided options are invalid.
+         */
+        public @NonNull Builder setOptions(@Nullable byte[] clientId, @Nullable byte[] serverId,
+                @NonNull List<PakeOption> options);
+
+        /**
+         * Builds a new {@link PakeServerKeyManagerParameters} instance.
+         *
+         * @return A new {@link PakeServerKeyManagerParameters} instance.
+         * @throws InvalidParameterException If no links are provided.
+         */
+        public @NonNull PakeServerKeyManagerParameters build();
+    }
+}

--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -977,4 +977,8 @@ final public class Platform {
     public static boolean isTlsV1Supported() {
         return ENABLED_TLS_V1;
     }
+
+    public static boolean isPakeSupported() {
+        return false;
+    }
 }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -110,7 +110,9 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl implements SSLParametersIm
     private static ConscryptEngine newEngine(
             SSLParametersImpl sslParameters, final ConscryptEngineSocket socket) {
         SSLParametersImpl modifiedParams;
-        if (Platform.supportsX509ExtendedTrustManager()) {
+        if (sslParameters.isSpake()) {
+            modifiedParams = sslParameters.cloneWithSpake();
+        } else if (Platform.supportsX509ExtendedTrustManager()) {
             modifiedParams = sslParameters.cloneWithTrustManager(
                 getDelegatingTrustManager(sslParameters.getX509TrustManager(), socket));
         } else {

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -961,6 +961,11 @@ public final class NativeCrypto {
             "TLS_PSK_WITH_AES_256_CBC_SHA",
     };
 
+    /** TLS-SPAKE */
+    static final String[] DEFAULT_SPAKE_CIPHER_SUITES = new String[] {
+            "TLS1_3_NAMED_PAKE_SPAKE2PLUSV1",
+    };
+
     static String[] getSupportedCipherSuites() {
         return SSLUtils.concat(SUPPORTED_TLS_1_3_CIPHER_SUITES, SUPPORTED_TLS_1_2_CIPHER_SUITES.clone());
     }
@@ -1208,6 +1213,11 @@ public final class NativeCrypto {
             if (SUPPORTED_TLS_1_2_CIPHER_SUITES_SET.contains(cipherSuites[i])) {
                 continue;
             }
+            // Not sure if we need to do this for SPAKE, but the SPAKE cipher suite
+            // not registered at the moment.
+            if (DEFAULT_SPAKE_CIPHER_SUITES[0] == cipherSuites[i]) {
+                continue;
+            }
 
             // For backwards compatibility, it's allowed for |cipherSuite| to
             // be an OpenSSL-style cipher-suite name.
@@ -1324,18 +1334,16 @@ public final class NativeCrypto {
                 throws CertificateException;
 
         /**
-         * Called on an SSL client when the server requests (or
-         * requires a certificate). The client can respond by using
-         * SSL_use_certificate and SSL_use_PrivateKey to set a
-         * certificate if has an appropriate one available, similar to
-         * how the server provides its certificate.
+         * Called on an SSL client when the server requests (or requires a certificate). The client
+         * can respond by using SSL_use_certificate and SSL_use_PrivateKey to set a certificate if
+         * has an appropriate one available, similar to how the server provides its certificate.
          *
-         * @param keyTypes key types supported by the server,
-         * convertible to strings with #keyType
+         * @param keyTypes key types supported by the server, convertible to strings with #keyType
          * @param asn1DerEncodedX500Principals CAs known to the server
          */
-        @SuppressWarnings("unused") void clientCertificateRequested(byte[] keyTypes, int[] signatureAlgs,
-                byte[][] asn1DerEncodedX500Principals)
+        @SuppressWarnings("unused")
+        void clientCertificateRequested(
+                byte[] keyTypes, int[] signatureAlgs, byte[][] asn1DerEncodedX500Principals)
                 throws CertificateEncodingException, SSLException;
 
         /**

--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -25,10 +25,15 @@ import static org.conscrypt.NativeConstants.SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 import static org.conscrypt.NativeConstants.SSL_VERIFY_NONE;
 import static org.conscrypt.NativeConstants.SSL_VERIFY_PEER;
 
+import org.conscrypt.NativeCrypto.SSLHandshakeCallbacks;
+import org.conscrypt.SSLParametersImpl.AliasChooser;
+import org.conscrypt.SSLParametersImpl.PSKCallbacks;
+
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -39,15 +44,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import javax.crypto.SecretKey;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
-import org.conscrypt.NativeCrypto.SSLHandshakeCallbacks;
-import org.conscrypt.SSLParametersImpl.AliasChooser;
-import org.conscrypt.SSLParametersImpl.PSKCallbacks;
 
 /**
  * A utility wrapper that abstracts operations on the underlying native SSL instance.
@@ -84,6 +87,36 @@ final class NativeSsl {
         } catch (SSLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    void initSpake() throws SSLException, InvalidAlgorithmParameterException {
+        Spake2PlusKeyManager spakeKeyManager = parameters.getSpake2PlusKeyManager();
+        byte[] context = spakeKeyManager.getContext() == null ? "spake2+".getBytes()
+                                                              : spakeKeyManager.getContext();
+        byte[] idProverArray = spakeKeyManager.getIdProver();
+        byte[] idVerifierArray = spakeKeyManager.getIdVerifier();
+        byte[] pwArray = spakeKeyManager.getPassword();
+        byte[] w0Array = spakeKeyManager.getw0();
+        byte[] w1Array = spakeKeyManager.getw1();
+        byte[] registrationRecordArray = spakeKeyManager.getRegistrationRecord();
+        boolean isClient = spakeKeyManager.isClient();
+
+        // TODO: uncomment this once the native code is ready.
+        /*
+        if (pwArray != null) {
+            NativeCrypto.SSL_CTX_set_spake_credential(
+                context, pwArray, idProverArray,
+                idVerifierArray, isClient, this);
+        } else if (isClient && w0Array != null && w1Array != null) {
+            NativeCrypto.SSL_CTX_set_spake_credential_client(
+                context, w0Array, w1Array,
+                idProverArray, idVerifierArray, this);
+        } else if (!isClient && w0Array != null && registrationRecordArray != null) {
+            NativeCrypto.SSL_CTX_set_spake_credential_server(
+                context, w0Array, registrationRecordArray,
+                idProverArray, idVerifierArray, this);
+        }
+        */
     }
 
     void offerToResumeSession(long sslSessionNativePointer) throws SSLException {
@@ -273,6 +306,14 @@ final class NativeSsl {
     }
 
     void initialize(String hostname, OpenSSLKey channelIdPrivateKey) throws IOException {
+        if (parameters.isSpake()) {
+            try {
+                initSpake();
+            } catch (Exception e) {
+                throw new SSLHandshakeException("Spake initialization failed " + e.getMessage());
+            }
+        }
+
         boolean enableSessionCreation = parameters.getEnableSessionCreation();
         if (!enableSessionCreation) {
             NativeCrypto.SSL_set_session_creation_enabled(ssl, this, false);
@@ -308,8 +349,12 @@ final class NativeSsl {
                     + " are no longer supported and were filtered from the list");
         }
         NativeCrypto.setEnabledProtocols(ssl, this, parameters.enabledProtocols);
-        NativeCrypto.setEnabledCipherSuites(
-            ssl, this, parameters.enabledCipherSuites, parameters.enabledProtocols);
+        // Not sure if we need to do this for SPAKE, but the SPAKE cipher suite
+        // not registered at the moment.
+        if (!parameters.isSpake()) {
+            NativeCrypto.setEnabledCipherSuites(
+                    ssl, this, parameters.enabledCipherSuites, parameters.enabledProtocols);
+        }
 
         if (parameters.applicationProtocols.length > 0) {
             NativeCrypto.setApplicationProtocols(ssl, this, isClient(), parameters.applicationProtocols);
@@ -349,7 +394,9 @@ final class NativeSsl {
         // with TLSv1 and SSLv3).
         NativeCrypto.SSL_set_mode(ssl, this, SSL_MODE_CBC_RECORD_SPLITTING);
 
-        setCertificateValidation();
+        if (!parameters.isSpake()) {
+            setCertificateValidation();
+        }
         setTlsChannelId(channelIdPrivateKey);
     }
 

--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -547,6 +547,12 @@ public final class OpenSSLProvider extends Provider {
                 baseClass + "$X25519_CHACHA20");
         put("Alg.Alias.ConscryptHpke.DHKEM_X25519_HKDF_SHA256_HKDF_SHA256_GhpkeCHACHA20POLY1305",
                 "DHKEM_X25519_HKDF_SHA256/HKDF_SHA256/CHACHA20POLY1305");
+
+        /* === PAKE === */
+        if (Platform.isPakeSupported()) {
+            put("TrustManagerFactory.PAKE", PREFIX + "PakeTrustManagerFactory");
+            put("KeyManagerFactory.PAKE", PREFIX + "PakeKeyManagerFactory");
+        }
     }
 
     private boolean classExists(String classname) {

--- a/common/src/main/java/org/conscrypt/Spake2PlusKeyManager.java
+++ b/common/src/main/java/org/conscrypt/Spake2PlusKeyManager.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import java.security.Principal;
+import java.util.List;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLEngine;
+
+/**
+ * @hide This class is not part of the Android public SDK API
+ */
+@Internal
+public class Spake2PlusKeyManager implements KeyManager {
+    private final byte[] context;
+    private final byte[] password;
+    private final byte[] w0;
+    private final byte[] w1;
+    private final byte[] registrationRecord;
+    private final byte[] idProver;
+    private final byte[] idVerifier;
+    private final boolean isClient;
+
+    Spake2PlusKeyManager(byte[] context, byte[] password, byte[] w0, byte[] w1,
+            byte[] registrationRecord, byte[] idProver, byte[] idVerifier, boolean isClient) {
+        this.context = context;
+        this.password = password;
+        this.w0 = w0;
+        this.w1 = w1;
+        this.registrationRecord = registrationRecord;
+        this.idProver = idProver;
+        this.idVerifier = idVerifier;
+        this.isClient = isClient;
+    }
+
+    public String chooseEngineAlias(String keyType, Principal[] issuers, SSLEngine engine) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public String chooseEngineClientAlias(String[] keyType, Principal[] issuers, SSLEngine engine) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    public byte[] getContext() {
+        return context;
+    }
+
+    public byte[] getPassword() {
+        return password;
+    }
+
+    public byte[] getw0() {
+        return w0;
+    }
+
+    public byte[] getw1() {
+        return w1;
+    }
+
+    public byte[] getRegistrationRecord() {
+        return registrationRecord;
+    }
+
+    public byte[] getIdProver() {
+        return idProver;
+    }
+
+    public byte[] getIdVerifier() {
+        return idVerifier;
+    }
+
+    public boolean isClient() {
+        return isClient;
+    }
+}

--- a/common/src/main/java/org/conscrypt/Spake2PlusTrustManager.java
+++ b/common/src/main/java/org/conscrypt/Spake2PlusTrustManager.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import javax.net.ssl.TrustManager;
+
+/**
+ * @hide This class is not part of the Android public SDK API
+ */
+@Internal
+public class Spake2PlusTrustManager implements TrustManager {
+    Spake2PlusTrustManager() {}
+
+    public void checkClientTrusted() {}
+
+    public void checkServerTrusted() {}
+}

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
@@ -145,6 +145,10 @@ public class KeyManagerFactoryTest {
             }
         }
 
+        if (kmf.getAlgorithm() == "PAKE") {
+            return;
+        }
+
         // init with null for default behavior
         kmf.init(null, null);
         test_KeyManagerFactory_getKeyManagers(kmf, true);

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/TrustManagerFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/TrustManagerFactoryTest.java
@@ -83,6 +83,10 @@ public class TrustManagerFactoryTest {
         assertNotNull(tmf.getAlgorithm());
         assertNotNull(tmf.getProvider());
 
+        if (tmf.getAlgorithm() == "PAKE") {
+            return;
+        }
+
         // before init
         try {
             tmf.getTrustManagers();
@@ -231,6 +235,9 @@ public class TrustManagerFactoryTest {
                 @Override
                 public void test(Provider p, String algorithm) throws Exception {
                     TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
+                    if (tmf.getAlgorithm() == "PAKE") {
+                        return;
+                    }
                     tmf.init(keyStore);
                     TrustManager[] trustManagers = tmf.getTrustManagers();
                     for (TrustManager trustManager : trustManagers) {

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -861,4 +861,8 @@ final public class Platform {
     public static boolean isTlsV1Supported() {
         return ENABLED_TLS_V1;
     }
+
+    public static boolean isPakeSupported() {
+        return false;
+    }
 }

--- a/platform/src/main/java/org/conscrypt/PakeKeyManagerFactory.java
+++ b/platform/src/main/java/org/conscrypt/PakeKeyManagerFactory.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.conscrypt;
+
+import static android.net.ssl.PakeServerKeyManagerParameters.Link;
+
+import static java.util.Objects.requireNonNull;
+
+import android.net.ssl.PakeClientKeyManagerParameters;
+import android.net.ssl.PakeOption;
+import android.net.ssl.PakeServerKeyManagerParameters;
+
+import org.conscrypt.io.IoUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.List;
+import java.util.Set;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactorySpi;
+import javax.net.ssl.ManagerFactoryParameters;
+
+/**
+ * PakeKeyManagerFactory implementation.
+ * @see KeyManagerFactorySpi
+ * @hide This class is not part of the Android public SDK API
+ */
+@Internal
+public class PakeKeyManagerFactory extends KeyManagerFactorySpi {
+    PakeClientKeyManagerParameters clientParams;
+    PakeServerKeyManagerParameters serverParams;
+
+    /**
+     * @see KeyManagerFactorySpi#engineInit(KeyStore ks, char[] password)
+     */
+    @Override
+    public void engineInit(KeyStore ks, char[] password)
+            throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
+        throw new KeyStoreException("KeyStore not supported");
+    }
+
+    /**
+     * @see KeyManagerFactorySpi#engineInit(ManagerFactoryParameters spec)
+     */
+    @Override
+    public void engineInit(ManagerFactoryParameters spec)
+            throws InvalidAlgorithmParameterException {
+        if (clientParams != null || serverParams != null) {
+            throw new IllegalStateException("PakeKeyManagerFactory is already initialized");
+        }
+        requireNonNull(spec);
+        if (spec instanceof PakeClientKeyManagerParameters) {
+            clientParams = (PakeClientKeyManagerParameters) spec;
+        } else if (spec instanceof PakeServerKeyManagerParameters) {
+            serverParams = (PakeServerKeyManagerParameters) spec;
+        } else {
+            throw new InvalidAlgorithmParameterException("ManagerFactoryParameters not supported");
+        }
+    }
+
+    /**
+     * @see KeyManagerFactorySpi#engineGetKeyManagers()
+     */
+    @Override
+    public KeyManager[] engineGetKeyManagers() {
+        if (clientParams == null && serverParams == null) {
+            throw new IllegalStateException("PakeKeyManagerFactory is not initialized");
+        }
+        if (clientParams != null) {
+            return initClient();
+        } else {
+            return initServer();
+        }
+    }
+
+    private KeyManager[] initClient() {
+        List<PakeOption> options = clientParams.getOptions();
+        for (PakeOption option : options) {
+            if (!option.getAlgorithm().equals("SPAKE2PLUS_PRERELEASE")) {
+                continue;
+            }
+            byte[] idProver = clientParams.getClientId();
+            byte[] idVerifier = clientParams.getServerId();
+            byte[] context = option.getMessageComponent("context");
+            byte[] password = option.getMessageComponent("password");
+            if (password != null) {
+                return new KeyManager[] {new Spake2PlusKeyManager(
+                        context, password, null, null, null, idProver, idVerifier, true)};
+            }
+            byte[] w0 = option.getMessageComponent("w0");
+            byte[] w1 = option.getMessageComponent("w1");
+            if (w0 != null && w1 != null) {
+                return new KeyManager[] {new Spake2PlusKeyManager(
+                        context, null, w0, w1, null, idProver, idVerifier, true)};
+            }
+            break;
+        }
+        return new KeyManager[] {};
+    }
+
+    private KeyManager[] initServer() {
+        Set<Link> links = serverParams.getLinks();
+        for (Link link : links) {
+            List<PakeOption> options = serverParams.getOptions(link);
+            for (PakeOption option : options) {
+                if (!option.getAlgorithm().equals("SPAKE2PLUS_PRERELEASE")) {
+                    continue;
+                }
+                byte[] idProver = link.getClientId();
+                byte[] idVerifier = link.getServerId();
+                byte[] context = option.getMessageComponent("context");
+                byte[] password = option.getMessageComponent("password");
+                if (password != null) {
+                    return new KeyManager[] {new Spake2PlusKeyManager(
+                            context, password, null, null, null, idProver, idVerifier, false)};
+                }
+                byte[] w0 = option.getMessageComponent("w0");
+                byte[] registrationRecord = option.getMessageComponent("registrationRecord");
+                if (w0 != null && registrationRecord != null) {
+                    return new KeyManager[] {new Spake2PlusKeyManager(context, null, w0, null,
+                            registrationRecord, idProver, idVerifier, false)};
+                }
+                break;
+            }
+        }
+        return new KeyManager[] {};
+    }
+}

--- a/platform/src/main/java/org/conscrypt/PakeTrustManagerFactory.java
+++ b/platform/src/main/java/org/conscrypt/PakeTrustManagerFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static java.util.Objects.requireNonNull;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.TrustManagerFactorySpi;
+
+/**
+ * A factory for creating {@link SpakeTrustManager} instances that use SPAKE2.
+ * @hide This class is not part of the Android public SDK API
+ */
+@Internal
+public class PakeTrustManagerFactory extends TrustManagerFactorySpi {
+    /**
+     * @see javax.net.ssl.TrustManagerFactorySpi#engineInit(KeyStore)
+     */
+    @Override
+    public void engineInit(KeyStore ks) throws KeyStoreException {
+        if (ks != null) {
+            throw new KeyStoreException("KeyStore not supported");
+        }
+    }
+
+    /**
+     * @see javax.net.ssl#engineInit(ManagerFactoryParameters)
+     */
+    @Override
+    public void engineInit(ManagerFactoryParameters spec)
+            throws InvalidAlgorithmParameterException {
+        if (spec != null) {
+            throw new InvalidAlgorithmParameterException("ManagerFactoryParameters not supported");
+        }
+    }
+
+    /**
+     * @see javax.net.ssl#engineGetTrustManagers()
+     */
+    @Override
+    public TrustManager[] engineGetTrustManagers() {
+        return new TrustManager[] {new Spake2PlusTrustManager()};
+    }
+}

--- a/platform/src/main/java/org/conscrypt/Platform.java
+++ b/platform/src/main/java/org/conscrypt/Platform.java
@@ -592,6 +592,10 @@ final public class Platform {
         return ENABLED_TLS_V1;
     }
 
+    public static boolean isPakeSupported() {
+        return true;
+    }
+
     static Object getTargetSdkVersion() {
         try {
             Class<?> vmRuntimeClass = Class.forName("dalvik.system.VMRuntime");

--- a/platform/src/test/java/org/conscrypt/PakeManagerFactoriesTest.java
+++ b/platform/src/test/java/org/conscrypt/PakeManagerFactoriesTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import android.net.ssl.PakeClientKeyManagerParameters;
+import android.net.ssl.PakeOption;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStoreException;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.TrustManager;
+
+/**
+ * @hide This class is not part of the Android public SDK API
+ */
+public class PakeManagerFactoriesTest {
+    private static final byte[] CLIENT_ID = new byte[] {4, 5, 6};
+    private static final byte[] SERVER_ID = new byte[] {7, 8, 9};
+
+    @Test
+    public void testEngineInitParameters() throws InvalidAlgorithmParameterException {
+        PakeKeyManagerFactory keyManagerFactory = new PakeKeyManagerFactory();
+
+        byte[] password = new byte[] {1, 2, 3};
+        PakeOption option = new PakeOption.Builder("SPAKE2PLUS_PRERELEASE")
+                                    .addMessageComponent("password", password)
+                                    .build();
+
+        assertThrows(KeyStoreException.class, () -> keyManagerFactory.engineInit(null, null));
+
+        PakeClientKeyManagerParameters params =
+                new PakeClientKeyManagerParameters.Builder().addOption(option).build();
+        // Initialize with valid parameters
+        keyManagerFactory.engineInit(params);
+        // Try to initialize again
+        assertThrows(IllegalStateException.class, () -> keyManagerFactory.engineInit(params));
+
+        PakeTrustManagerFactory trustManagerFactory = new PakeTrustManagerFactory();
+        // The trust manager factory does not accept parameters
+        assertThrows(InvalidAlgorithmParameterException.class,
+                () -> trustManagerFactory.engineInit(params));
+        trustManagerFactory.engineInit((ManagerFactoryParameters) null);
+    }
+
+    @Test
+    public void testEngineGetKeyManagers() throws InvalidAlgorithmParameterException {
+        PakeKeyManagerFactory factory = new PakeKeyManagerFactory();
+        assertThrows(IllegalStateException.class, () -> factory.engineGetKeyManagers());
+
+        byte[] password = new byte[] {1, 2, 3};
+        PakeOption option = new PakeOption.Builder("SPAKE2PLUS_PRERELEASE")
+                                    .addMessageComponent("password", password)
+                                    .build();
+
+        PakeClientKeyManagerParameters params = new PakeClientKeyManagerParameters.Builder()
+                                                        .setClientId(CLIENT_ID.clone())
+                                                        .setServerId(SERVER_ID.clone())
+                                                        .addOption(option)
+                                                        .build();
+
+        factory.engineInit(params);
+        KeyManager[] keyManagers = factory.engineGetKeyManagers();
+        assertEquals(1, keyManagers.length);
+
+        Spake2PlusKeyManager keyManager = (Spake2PlusKeyManager) keyManagers[0];
+        assertArrayEquals(password, keyManager.getPassword());
+        assertArrayEquals(new byte[] {4, 5, 6}, keyManager.getIdProver());
+        assertArrayEquals(new byte[] {7, 8, 9}, keyManager.getIdVerifier());
+    }
+
+    @Test
+    public void testEngineGetTrustManagers() {
+        PakeTrustManagerFactory factory = new PakeTrustManagerFactory();
+        TrustManager[] trustManagers = factory.engineGetTrustManagers();
+        assertEquals(1, trustManagers.length);
+        assertEquals(Spake2PlusTrustManager.class, trustManagers[0].getClass());
+    }
+}


### PR DESCRIPTION
This cl:
- Adds Key/TrustManagerFactories and Key/TrustManagers for Spake
- Modifies OpenSSLParameters to accept Spake
- Adds Spake setup within NativeSSL
- Includes miscellaneous changes to make the above work
- Adds tests for the above.

TEST=atest SSLSocketTest/SpakeManagerFactoriesTest/SpakeKeyManagerParametersTest BUG=382233100

Change-Id: I5203a651fa74fe90cabd234bc2b1a94cfc9d3e88