### PR TITLE
Give threads in ConscryptStatsLog a name

### DIFF
--- a/common/src/main/java/org/conscrypt/metrics/StatsLogImpl.java
+++ b/common/src/main/java/org/conscrypt/metrics/StatsLogImpl.java
@@ -49,7 +49,7 @@ public final class StatsLogImpl implements StatsLog {
     private static final ExecutorService e = Executors.newSingleThreadExecutor(new ThreadFactory() {
         @Override
         public Thread newThread(Runnable r) {
-            Thread thread = new Thread(r);
+            Thread thread = new Thread(r, "ConscryptStatsLog");
             thread.setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
                 @Override
                 public void uncaughtException(Thread t, Throwable e) {


### PR DESCRIPTION
Give unnamed threads a name so we can add them to the exemption list.