### PR TITLE
Restrict Spake testing to platform/

### DIFF
--- a/common/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/KeyManagerFactoryTest.java
@@ -22,6 +22,16 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.conscrypt.KeyManagerFactoryImpl;
+import org.conscrypt.PakeKeyManagerFactory;
+import org.conscrypt.TestUtils;
+import org.conscrypt.java.security.StandardNames;
+import org.conscrypt.java.security.TestKeyStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -42,20 +52,14 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.KeyStoreBuilderParameters;
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509KeyManager;
-import org.conscrypt.KeyManagerFactoryImpl;
-import org.conscrypt.TestUtils;
-import org.conscrypt.java.security.StandardNames;
-import org.conscrypt.java.security.TestKeyStore;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+
 import tests.util.ServiceTester;
 
 @RunWith(JUnit4.class)
@@ -146,6 +150,7 @@ public class KeyManagerFactoryTest {
         }
 
         if (kmf.getAlgorithm() == "PAKE") {
+            assertThrows(KeyStoreException.class, () -> kmf.init(null, null));
             return;
         }
 

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -24,9 +24,6 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.conscrypt.TestUtils;
 import org.conscrypt.java.security.StandardNames;
@@ -47,8 +44,6 @@ import org.junit.runners.JUnit4;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
@@ -71,7 +66,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.net.SocketFactory;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.ManagerFactoryParameters;
@@ -84,8 +78,6 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
 
 import tests.net.DelegatingSSLSocketFactory;

--- a/platform/src/test/java/org/conscrypt/SpakeTest.java
+++ b/platform/src/test/java/org/conscrypt/SpakeTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.conscrypt;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.net.ssl.PakeClientKeyManagerParameters;
+import android.net.ssl.PakeOption;
+import android.net.ssl.PakeServerKeyManagerParameters;
+
+import org.conscrypt.Spake2PlusKeyManager;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+@RunWith(JUnit4.class)
+public class SpakeTest {
+    private static final byte[] CLIENT_ID = new byte[] {4, 5, 6};
+    private static final byte[] SERVER_ID = new byte[] {7, 8, 9};
+    private final ThreadGroup threadGroup = new ThreadGroup("SpakeTest");
+    private final ExecutorService executor =
+            Executors.newCachedThreadPool(t -> new Thread(threadGroup, t));
+
+    @Test
+    public void testSpake2Plus() throws Exception {
+        InetAddress hostC = TestUtils.getLoopbackAddress();
+        InetAddress hostS = TestUtils.getLoopbackAddress();
+
+        byte[] password = new byte[] {1, 2, 3};
+
+        PakeOption option = new PakeOption.Builder("SPAKE2PLUS_PRERELEASE")
+                                    .addMessageComponent("password", password)
+                                    .build();
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PAKE");
+        tmf.init((ManagerFactoryParameters) null);
+
+        PakeClientKeyManagerParameters kmfParamsClient =
+                new PakeClientKeyManagerParameters.Builder()
+                        .setClientId(CLIENT_ID.clone())
+                        .setServerId(SERVER_ID.clone())
+                        .addOption(option)
+                        .build();
+
+        KeyManagerFactory kmfClient = KeyManagerFactory.getInstance("PAKE");
+        kmfClient.init(kmfParamsClient);
+        KeyManager[] keyManagersClient = kmfClient.getKeyManagers();
+        assertTrue(keyManagersClient.length == 1);
+        assertTrue(keyManagersClient[0] instanceof Spake2PlusKeyManager);
+        Spake2PlusKeyManager spake2PlusKeyManagerClient =
+                (Spake2PlusKeyManager) keyManagersClient[0];
+        assertTrue(spake2PlusKeyManagerClient.isClient());
+
+        SSLContext contextClient = SSLContext.getInstance("TlsV1.3");
+        contextClient.init(keyManagersClient, tmf.getTrustManagers(), null);
+
+        PakeServerKeyManagerParameters kmfParamsServer =
+                new PakeServerKeyManagerParameters.Builder()
+                        .setOptions(CLIENT_ID.clone(), SERVER_ID.clone(), Arrays.asList(option))
+                        .build();
+
+        KeyManagerFactory kmfServer = KeyManagerFactory.getInstance("PAKE");
+        kmfServer.init(kmfParamsServer);
+        KeyManager[] keyManagersServer = kmfServer.getKeyManagers();
+        assertTrue(keyManagersServer.length == 1);
+        assertTrue(keyManagersServer[0] instanceof Spake2PlusKeyManager);
+        Spake2PlusKeyManager spakeKeyManagerServer = (Spake2PlusKeyManager) keyManagersServer[0];
+        assertFalse(spakeKeyManagerServer.isClient());
+
+        SSLContext contextServer = SSLContext.getInstance("TlsV1.3");
+        contextServer.init(keyManagersServer, tmf.getTrustManagers(), null);
+
+        SSLServerSocket serverSocket =
+                (SSLServerSocket) contextServer.getServerSocketFactory().createServerSocket();
+        serverSocket.bind(new InetSocketAddress(hostS, 0));
+        SSLSocket client = (SSLSocket) contextClient.getSocketFactory().createSocket(
+                hostC, serverSocket.getLocalPort());
+        SSLSocket server = (SSLSocket) serverSocket.accept();
+
+        assertTrue(client.getUseClientMode());
+        Future<Void> s = runAsync(() -> {
+            server.startHandshake();
+            return null;
+        });
+        try {
+            client.startHandshake();
+            s.get();
+            fail();
+        } catch (SSLHandshakeException e) {
+            // Expected
+        }
+        server.close();
+        client.close();
+    }
+
+    @Test
+    public void testSpake2PlusAndOthersInvalid() throws Exception {
+        byte[] password = new byte[] {1, 2, 3};
+
+        PakeOption option = new PakeOption.Builder("SPAKE2PLUS_PRERELEASE")
+                                    .addMessageComponent("password", password)
+                                    .build();
+
+        PakeClientKeyManagerParameters pakeParams = new PakeClientKeyManagerParameters.Builder()
+                                                            .setClientId(CLIENT_ID.clone())
+                                                            .setServerId(SERVER_ID.clone())
+                                                            .addOption(option)
+                                                            .build();
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("PAKE");
+        kmf.init(pakeParams);
+
+        KeyManager[] keyManagers = kmf.getKeyManagers();
+
+        KeyManagerFactory kmf2 =
+                KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf2.init(null, null);
+
+        // Add a x509 key manager to the array.
+        KeyManager[] keyManagersWithx509 = Arrays.copyOf(keyManagers, keyManagers.length + 1);
+
+        keyManagersWithx509[keyManagers.length] = kmf2.getKeyManagers()[0];
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PAKE");
+        tmf.init((ManagerFactoryParameters) null);
+        TrustManager[] trustManagers = tmf.getTrustManagers();
+
+        SSLContext sslContext = SSLContext.getInstance("TlsV1.3");
+        // Should throw due to both SPAKE and x509 key managers
+        assertThrows(KeyManagementException.class,
+                () -> sslContext.init(keyManagersWithx509, trustManagers, null));
+    }
+
+    @Test
+    public void testSpake2PlusNoTrustOrKeyInvalid() throws Exception {
+        byte[] password = new byte[] {1, 2, 3};
+
+        PakeOption option = new PakeOption.Builder("SPAKE2PLUS_PRERELEASE")
+                                    .addMessageComponent("password", password)
+                                    .build();
+
+        PakeClientKeyManagerParameters pakeParams = new PakeClientKeyManagerParameters.Builder()
+                                                            .setClientId(CLIENT_ID.clone())
+                                                            .setServerId(SERVER_ID.clone())
+                                                            .addOption(option)
+                                                            .build();
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("PAKE");
+        kmf.init(pakeParams);
+
+        KeyManager[] keyManagers = kmf.getKeyManagers();
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("PAKE");
+        tmf.init((ManagerFactoryParameters) null);
+        TrustManager[] trustManagers = tmf.getTrustManagers();
+
+        SSLContext sslContext = SSLContext.getInstance("TlsV1.3");
+        assertThrows(KeyManagementException.class, () -> sslContext.init(keyManagers, null, null));
+
+        assertThrows(
+                KeyManagementException.class, () -> sslContext.init(null, trustManagers, null));
+    }
+
+    private <T> Future<T> runAsync(Callable<T> callable) {
+        return executor.submit(callable);
+    }
+}


### PR DESCRIPTION
This will make it possible to upstream/downstream without modifying code within common/

Test=atest SpakeTest/KeyManagerTest

Change-Id: Ie81805129192e3a0c067b10db90e5b80fed4844d