### PR TITLE
Rename registration_record to L for SPAKE2+ parameters

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -96,9 +96,9 @@ final class NativeSsl {
         byte[] idProverArray = spakeKeyManager.getIdProver();
         byte[] idVerifierArray = spakeKeyManager.getIdVerifier();
         byte[] pwArray = spakeKeyManager.getPassword();
-        byte[] w0Array = spakeKeyManager.getw0();
-        byte[] w1Array = spakeKeyManager.getw1();
-        byte[] registrationRecordArray = spakeKeyManager.getRegistrationRecord();
+        byte[] w0Array = spakeKeyManager.getW0();
+        byte[] w1Array = spakeKeyManager.getW1();
+        byte[] lArray = spakeKeyManager.getL();
         boolean isClient = spakeKeyManager.isClient();
 
         // TODO: uncomment this once the native code is ready.
@@ -111,9 +111,9 @@ final class NativeSsl {
             NativeCrypto.SSL_CTX_set_spake_credential_client(
                 context, w0Array, w1Array,
                 idProverArray, idVerifierArray, this);
-        } else if (!isClient && w0Array != null && registrationRecordArray != null) {
+        } else if (!isClient && w0Array != null && lArray != null) {
             NativeCrypto.SSL_CTX_set_spake_credential_server(
-                context, w0Array, registrationRecordArray,
+                context, w0Array, lArray,
                 idProverArray, idVerifierArray, this);
         }
         */

--- a/common/src/main/java/org/conscrypt/Spake2PlusKeyManager.java
+++ b/common/src/main/java/org/conscrypt/Spake2PlusKeyManager.java
@@ -27,26 +27,26 @@ import javax.net.ssl.SSLEngine;
  */
 @Internal
 public class Spake2PlusKeyManager implements KeyManager {
-    private final byte[] context;
-    private final byte[] password;
-    private final byte[] w0;
-    private final byte[] w1;
-    private final byte[] registrationRecord;
-    private final byte[] idProver;
-    private final byte[] idVerifier;
-    private final boolean isClient;
+  private final byte[] context;
+  private final byte[] password;
+  private final byte[] w0;
+  private final byte[] w1;
+  private final byte[] l;
+  private final byte[] idProver;
+  private final byte[] idVerifier;
+  private final boolean isClient;
 
-    Spake2PlusKeyManager(byte[] context, byte[] password, byte[] w0, byte[] w1,
-            byte[] registrationRecord, byte[] idProver, byte[] idVerifier, boolean isClient) {
-        this.context = context;
-        this.password = password;
-        this.w0 = w0;
-        this.w1 = w1;
-        this.registrationRecord = registrationRecord;
-        this.idProver = idProver;
-        this.idVerifier = idVerifier;
-        this.isClient = isClient;
-    }
+  Spake2PlusKeyManager(byte[] context, byte[] password, byte[] w0, byte[] w1, byte[] l,
+          byte[] idProver, byte[] idVerifier, boolean isClient) {
+      this.context = context;
+      this.password = password;
+      this.w0 = w0;
+      this.w1 = w1;
+      this.l = l;
+      this.idProver = idProver;
+      this.idVerifier = idVerifier;
+      this.isClient = isClient;
+  }
 
     public String chooseEngineAlias(String keyType, Principal[] issuers, SSLEngine engine) {
         throw new UnsupportedOperationException("Not implemented");
@@ -64,17 +64,17 @@ public class Spake2PlusKeyManager implements KeyManager {
         return password;
     }
 
-    public byte[] getw0() {
-        return w0;
-    }
+  public byte[] getW0() {
+      return w0;
+  }
 
-    public byte[] getw1() {
-        return w1;
-    }
+  public byte[] getW1() {
+      return w1;
+  }
 
-    public byte[] getRegistrationRecord() {
-        return registrationRecord;
-    }
+  public byte[] getL() {
+      return l;
+  }
 
     public byte[] getIdProver() {
         return idProver;
@@ -84,7 +84,7 @@ public class Spake2PlusKeyManager implements KeyManager {
         return idVerifier;
     }
 
-    public boolean isClient() {
-        return isClient;
-    }
+  public boolean isClient() {
+    return isClient;
+  }
 }

--- a/platform/src/main/java/org/conscrypt/PakeKeyManagerFactory.java
+++ b/platform/src/main/java/org/conscrypt/PakeKeyManagerFactory.java
@@ -137,10 +137,10 @@ public class PakeKeyManagerFactory extends KeyManagerFactorySpi {
                             context, password, null, null, null, idProver, idVerifier, false)};
                 }
                 byte[] w0 = option.getMessageComponent("w0");
-                byte[] registrationRecord = option.getMessageComponent("registrationRecord");
-                if (w0 != null && registrationRecord != null) {
-                    return new KeyManager[] {new Spake2PlusKeyManager(context, null, w0, null,
-                            registrationRecord, idProver, idVerifier, false)};
+                byte[] l = option.getMessageComponent("L");
+                if (w0 != null && l != null) {
+                    return new KeyManager[] {new Spake2PlusKeyManager(
+                            context, null, w0, null, l, idProver, idVerifier, false)};
                 }
                 break;
             }


### PR DESCRIPTION
Bug: 382233100
Test: atest CtsLibcoreTestCases:android.net.ssl
Change-Id: I6f4965a08ed020739659fb1869699c91aa4ff31e