### PR TITLE
Revert git-clang-format hook and restore import ordering changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,27 +27,6 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-  clang_format_check:
-    # Only run on pull requests.
-    if: ${{ startsWith(github.ref, 'refs/pull/') }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get git-clang-format
-        # Uses the most recent clang-format on Ubuntu.
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get -qq install -y --no-install-recommends clang-format
-
-      - name: Run git-clang-format against source branch
-        run: |
-          git clang-format --style=file --diff origin/$GITHUB_BASE_REF '*.c' '*.h' '*.cc' '*.cpp' '*.java'
-
   build:
     needs: boringssl_clone
 

--- a/common/src/main/java/org/conscrypt/TrustManagerImpl.java
+++ b/common/src/main/java/org/conscrypt/TrustManagerImpl.java
@@ -62,7 +62,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
-
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;

--- a/common/src/main/java/org/conscrypt/ct/CertificateTransparency.java
+++ b/common/src/main/java/org/conscrypt/ct/CertificateTransparency.java
@@ -16,15 +16,14 @@
 
 package org.conscrypt.ct;
 
-import org.conscrypt.Internal;
-import org.conscrypt.Platform;
-import org.conscrypt.metrics.CertificateTransparencyVerificationReason;
-import org.conscrypt.metrics.StatsLog;
-
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Objects;
+import org.conscrypt.Internal;
+import org.conscrypt.Platform;
+import org.conscrypt.metrics.CertificateTransparencyVerificationReason;
+import org.conscrypt.metrics.StatsLog;
 
 /**
  * Certificate Transparency subsystem. The implementation contains references

--- a/common/src/main/java/org/conscrypt/ct/VerificationResult.java
+++ b/common/src/main/java/org/conscrypt/ct/VerificationResult.java
@@ -16,12 +16,12 @@
 
 package org.conscrypt.ct;
 
-import org.conscrypt.Internal;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
+import org.conscrypt.Internal;
+
 
 /**
  * Container for verified SignedCertificateTimestamp.

--- a/common/src/main/java/org/conscrypt/metrics/StatsLogImpl.java
+++ b/common/src/main/java/org/conscrypt/metrics/StatsLogImpl.java
@@ -30,19 +30,15 @@ import static org.conscrypt.metrics.ConscryptStatsLog.CERTIFICATE_TRANSPARENCY_V
 import static org.conscrypt.metrics.ConscryptStatsLog.CERTIFICATE_TRANSPARENCY_VERIFICATION_REPORTED__RESULT__RESULT_UNKNOWN;
 import static org.conscrypt.metrics.ConscryptStatsLog.TLS_HANDSHAKE_REPORTED;
 
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import org.conscrypt.Internal;
 import org.conscrypt.Platform;
 import org.conscrypt.ct.LogStore;
 import org.conscrypt.ct.PolicyCompliance;
 import org.conscrypt.ct.VerificationResult;
-
-import java.lang.Thread.UncaughtExceptionHandler;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Implements logging for Conscrypt metrics.

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -16,6 +16,7 @@
 
 package org.conscrypt.javax.net.ssl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -24,24 +25,6 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import org.conscrypt.TestUtils;
-import org.conscrypt.java.security.StandardNames;
-import org.conscrypt.java.security.TestKeyStore;
-import org.conscrypt.tlswire.TlsTester;
-import org.conscrypt.tlswire.handshake.CipherSuite;
-import org.conscrypt.tlswire.handshake.ClientHello;
-import org.conscrypt.tlswire.handshake.CompressionMethod;
-import org.conscrypt.tlswire.handshake.EllipticCurve;
-import org.conscrypt.tlswire.handshake.EllipticCurvesHelloExtension;
-import org.conscrypt.tlswire.handshake.HelloExtension;
-import org.conscrypt.tlswire.util.TlsProtocolVersion;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -65,23 +48,33 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLProtocolException;
-import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
-
+import org.conscrypt.TestUtils;
+import org.conscrypt.java.security.StandardNames;
+import org.conscrypt.java.security.TestKeyStore;
+import org.conscrypt.tlswire.TlsTester;
+import org.conscrypt.tlswire.handshake.CipherSuite;
+import org.conscrypt.tlswire.handshake.ClientHello;
+import org.conscrypt.tlswire.handshake.CompressionMethod;
+import org.conscrypt.tlswire.handshake.EllipticCurve;
+import org.conscrypt.tlswire.handshake.EllipticCurvesHelloExtension;
+import org.conscrypt.tlswire.handshake.HelloExtension;
+import org.conscrypt.tlswire.util.TlsProtocolVersion;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import tests.net.DelegatingSSLSocketFactory;
 import tests.util.ForEachRunner;
 import tests.util.Pair;

--- a/platform/src/main/java/org/conscrypt/ct/LogStoreImpl.java
+++ b/platform/src/main/java/org/conscrypt/ct/LogStoreImpl.java
@@ -19,19 +19,9 @@ package org.conscrypt.ct;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.conscrypt.ByteArray;
-import org.conscrypt.Internal;
-import org.conscrypt.OpenSSLKey;
-import org.conscrypt.Platform;
-import org.conscrypt.metrics.StatsLog;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.InvalidKeyException;
@@ -48,6 +38,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.conscrypt.ByteArray;
+import org.conscrypt.Internal;
+import org.conscrypt.OpenSSLKey;
+import org.conscrypt.Platform;
+import org.conscrypt.metrics.StatsLog;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 @Internal
 public class LogStoreImpl implements LogStore {

--- a/platform/src/test/java/org/conscrypt/AndroidHpkeSpiTest.java
+++ b/platform/src/test/java/org/conscrypt/AndroidHpkeSpiTest.java
@@ -55,3 +55,4 @@ public class AndroidHpkeSpiTest {
         }
     }
 }
+

--- a/platform/src/test/java/org/conscrypt/ct/LogStoreImplTest.java
+++ b/platform/src/test/java/org/conscrypt/ct/LogStoreImplTest.java
@@ -16,30 +16,22 @@
 
 package org.conscrypt.ct;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Base64;
 import org.conscrypt.OpenSSLKey;
 import org.conscrypt.metrics.NoopStatsLog;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.security.PublicKey;
-import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Base64;
 
 @RunWith(JUnit4.class)
 public class LogStoreImplTest {

--- a/platform/src/test/java/org/conscrypt/ct/PolicyImplTest.java
+++ b/platform/src/test/java/org/conscrypt/ct/PolicyImplTest.java
@@ -20,15 +20,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
 import org.conscrypt.java.security.cert.FakeX509Certificate;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.security.PublicKey;
-import java.security.cert.X509Certificate;
 
 @RunWith(JUnit4.class)
 public class PolicyImplTest {

--- a/platform/src/test/java/org/conscrypt/metrics/MetricsTest.java
+++ b/platform/src/test/java/org/conscrypt/metrics/MetricsTest.java
@@ -23,7 +23,6 @@ import org.conscrypt.TestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.conscrypt.metrics.OptionalMethod;
 
 @RunWith(JUnit4.class)
 public class MetricsTest {


### PR DESCRIPTION
The new git-clang-format organizes imports in a way that is not accepted by gms and thus causes a lot of problems in downstreaming. This cl reverts that hooks and organises imports according to what is expected within gms in order to avoid future conflicts. We should readd the hook when we manage to ensure import ordering is consistent across repos.

I think I've got all import changes but let me know if I've missed any. Some of these changes will have to be pushed into aosp afterwards.

TESTED=n/a