### PR TITLE
Remove password verifiers as Spake2Plus options.

### DIFF
--- a/common/src/main/java/org/conscrypt/NativeSsl.java
+++ b/common/src/main/java/org/conscrypt/NativeSsl.java
@@ -96,9 +96,6 @@ final class NativeSsl {
         byte[] idProverArray = spakeKeyManager.getIdProver();
         byte[] idVerifierArray = spakeKeyManager.getIdVerifier();
         byte[] pwArray = spakeKeyManager.getPassword();
-        byte[] w0Array = spakeKeyManager.getW0();
-        byte[] w1Array = spakeKeyManager.getW1();
-        byte[] lArray = spakeKeyManager.getL();
         boolean isClient = spakeKeyManager.isClient();
 
         // TODO: uncomment this once the native code is ready.
@@ -107,14 +104,6 @@ final class NativeSsl {
             NativeCrypto.SSL_CTX_set_spake_credential(
                 context, pwArray, idProverArray,
                 idVerifierArray, isClient, this);
-        } else if (isClient && w0Array != null && w1Array != null) {
-            NativeCrypto.SSL_CTX_set_spake_credential_client(
-                context, w0Array, w1Array,
-                idProverArray, idVerifierArray, this);
-        } else if (!isClient && w0Array != null && lArray != null) {
-            NativeCrypto.SSL_CTX_set_spake_credential_server(
-                context, w0Array, lArray,
-                idProverArray, idVerifierArray, this);
         }
         */
     }

--- a/common/src/main/java/org/conscrypt/Spake2PlusKeyManager.java
+++ b/common/src/main/java/org/conscrypt/Spake2PlusKeyManager.java
@@ -27,26 +27,20 @@ import javax.net.ssl.SSLEngine;
  */
 @Internal
 public class Spake2PlusKeyManager implements KeyManager {
-  private final byte[] context;
-  private final byte[] password;
-  private final byte[] w0;
-  private final byte[] w1;
-  private final byte[] l;
-  private final byte[] idProver;
-  private final byte[] idVerifier;
-  private final boolean isClient;
+    private final byte[] context;
+    private final byte[] password;
+    private final byte[] idProver;
+    private final byte[] idVerifier;
+    private final boolean isClient;
 
-  Spake2PlusKeyManager(byte[] context, byte[] password, byte[] w0, byte[] w1, byte[] l,
-          byte[] idProver, byte[] idVerifier, boolean isClient) {
-      this.context = context;
-      this.password = password;
-      this.w0 = w0;
-      this.w1 = w1;
-      this.l = l;
-      this.idProver = idProver;
-      this.idVerifier = idVerifier;
-      this.isClient = isClient;
-  }
+    Spake2PlusKeyManager(
+            byte[] context, byte[] password, byte[] idProver, byte[] idVerifier, boolean isClient) {
+        this.context = context == null ? new byte[0] : context;
+        this.password = password;
+        this.idProver = idProver == null ? new byte[0] : idProver;
+        this.idVerifier = idVerifier == null ? new byte[0] : idVerifier;
+        this.isClient = isClient;
+    }
 
     public String chooseEngineAlias(String keyType, Principal[] issuers, SSLEngine engine) {
         throw new UnsupportedOperationException("Not implemented");
@@ -64,18 +58,6 @@ public class Spake2PlusKeyManager implements KeyManager {
         return password;
     }
 
-  public byte[] getW0() {
-      return w0;
-  }
-
-  public byte[] getW1() {
-      return w1;
-  }
-
-  public byte[] getL() {
-      return l;
-  }
-
     public byte[] getIdProver() {
         return idProver;
     }
@@ -84,7 +66,7 @@ public class Spake2PlusKeyManager implements KeyManager {
         return idVerifier;
     }
 
-  public boolean isClient() {
-    return isClient;
-  }
+    public boolean isClient() {
+        return isClient;
+    }
 }

--- a/platform/src/main/java/org/conscrypt/PakeKeyManagerFactory.java
+++ b/platform/src/main/java/org/conscrypt/PakeKeyManagerFactory.java
@@ -107,14 +107,8 @@ public class PakeKeyManagerFactory extends KeyManagerFactorySpi {
             byte[] context = option.getMessageComponent("context");
             byte[] password = option.getMessageComponent("password");
             if (password != null) {
-                return new KeyManager[] {new Spake2PlusKeyManager(
-                        context, password, null, null, null, idProver, idVerifier, true)};
-            }
-            byte[] w0 = option.getMessageComponent("w0");
-            byte[] w1 = option.getMessageComponent("w1");
-            if (w0 != null && w1 != null) {
-                return new KeyManager[] {new Spake2PlusKeyManager(
-                        context, null, w0, w1, null, idProver, idVerifier, true)};
+                return new KeyManager[] {
+                        new Spake2PlusKeyManager(context, password, idProver, idVerifier, true)};
             }
             break;
         }
@@ -135,13 +129,7 @@ public class PakeKeyManagerFactory extends KeyManagerFactorySpi {
                 byte[] password = option.getMessageComponent("password");
                 if (password != null) {
                     return new KeyManager[] {new Spake2PlusKeyManager(
-                            context, password, null, null, null, idProver, idVerifier, false)};
-                }
-                byte[] w0 = option.getMessageComponent("w0");
-                byte[] l = option.getMessageComponent("L");
-                if (w0 != null && l != null) {
-                    return new KeyManager[] {new Spake2PlusKeyManager(
-                            context, null, w0, null, l, idProver, idVerifier, false)};
+                            context, password, idProver, idVerifier, false)};
                 }
                 break;
             }


### PR DESCRIPTION
From the discussion within aosp/3477972 it seems we only need to support the password case for the time being, so this disallows passing password verifier values into conscrypt.

Also ensures that if null values are passed in for context, or client/server verifiers, these will later be transformed to empty arrays

Change-Id: I57ac9cc028a9c0f3ce7ce20ad3f514ccaf417265
Test: atest PakeOptionTest/PakeClient/ServerKeyManagerParametersTest/SpakeTest
Bug: 382233100