### PR TITLE
Restore nonnull assertions for holders in NativeCryptoTest 

### DIFF
--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -3228,6 +3228,7 @@ public class NativeCryptoTest {
         NativeRef.EVP_PKEY_CTX holder = new NativeRef.EVP_PKEY_CTX(pkeyCtx);
         assertThrows(NullPointerException.class,
                 () -> NativeCrypto.EVP_PKEY_CTX_set_rsa_mgf1_md(pkeyCtx, NULL));
+        assertNotNull(holder);
     }
 
     @Test
@@ -3242,6 +3243,7 @@ public class NativeCryptoTest {
         NativeRef.EVP_PKEY_CTX holder = new NativeRef.EVP_PKEY_CTX(pkeyCtx);
         assertThrows(NullPointerException.class,
                 () -> NativeCrypto.EVP_PKEY_CTX_set_rsa_oaep_md(pkeyCtx, NULL));
+        assertNotNull(holder);
     }
 
     @Test


### PR DESCRIPTION
This ensures the ctx is still valid in spite of the nullPointerException and gets rid of errorProne warnings