### PR TITLE
Add subclass of ByteArrayOutputStream that exposes the underlying array.

### DIFF
--- a/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
+++ b/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
@@ -1,0 +1,21 @@
+package org.conscrypt;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * ByteArrayOutputStream that exposes the underlying byte array.
+ */
+final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
+
+  ExposedByteArrayOutputStream() {
+    super();
+  }
+
+  ExposedByteArrayOutputStream(int initialCapacity) {
+    super(initialCapacity);
+  }
+
+  byte[] array() {
+      return buf;
+  }
+}

--- a/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
+++ b/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
@@ -6,16 +6,15 @@ import java.io.ByteArrayOutputStream;
  * ByteArrayOutputStream that exposes the underlying byte array.
  */
 final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
+    ExposedByteArrayOutputStream() {
+        super();
+    }
 
-  ExposedByteArrayOutputStream() {
-    super();
-  }
+    ExposedByteArrayOutputStream(int initialCapacity) {
+        super(initialCapacity);
+    }
 
-  ExposedByteArrayOutputStream(int initialCapacity) {
-    super(initialCapacity);
-  }
-
-  byte[] array() {
-      return buf;
-  }
+    byte[] array() {
+        return buf;
+    }
 }

--- a/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
+++ b/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.conscrypt;
 
 import java.io.ByteArrayOutputStream;

--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -16,7 +16,6 @@
 
 package org.conscrypt;
 
-import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
@@ -61,22 +60,11 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
      */
     private boolean mustInitialize;
 
-    // ByteArrayOutputStream that exposes the underlying byte array.
-    private static final class Buffer extends ByteArrayOutputStream {
-        Buffer(int initialCapacity) {
-            super(initialCapacity);
-        }
-
-        byte[] array() {
-            return buf;
-        }
-    }
-
     /**
      * The byte array containing the bytes written. It is initialized to null because it is only
      * needed when update is called. So we don't want to allocate it until it is needed.
      */
-    private Buffer buf = null;
+    private ExposedByteArrayOutputStream buf = null;
 
     /**
      * The number of bytes written.
@@ -314,7 +302,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     void appendToBuf(byte[] input, int inputOffset, int inputLen) {
         ArrayUtils.checkOffsetAndCount(input.length, inputOffset, inputLen);
         if (buf == null) {
-            buf = new Buffer(inputLen);
+            buf = new ExposedByteArrayOutputStream(inputLen);
         }
         buf.write(input, inputOffset, inputLen);
         this.bufCount += inputLen;

--- a/common/src/main/java/org/conscrypt/OpenSslSignatureEdDsa.java
+++ b/common/src/main/java/org/conscrypt/OpenSslSignatureEdDsa.java
@@ -15,7 +15,6 @@
  */
 package org.conscrypt;
 
-import java.io.ByteArrayOutputStream;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.PrivateKey;
@@ -36,17 +35,7 @@ public class OpenSslSignatureEdDsa extends SignatureSpi {
      */
     private OpenSSLKey key;
 
-    // Buffer provides access to the underlying byte array without making a copy.
-    private static final class Buffer extends ByteArrayOutputStream {
-        byte[] array() {
-            return buf;
-        }
-    }
-
-    /**
-     * buffer to hold value to be signed or verified.
-     */
-    private final Buffer buffer = new Buffer();
+    private final ExposedByteArrayOutputStream buffer = new ExposedByteArrayOutputStream();
 
     public OpenSslSignatureEdDsa() {}
 

--- a/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
+++ b/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
@@ -1,0 +1,64 @@
+package org.conscrypt;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ExposedByteArrayOutputStreamTest {
+
+  @Test
+  public void write_works() throws Exception {
+    ExposedByteArrayOutputStream outputStream = new ExposedByteArrayOutputStream();
+
+    outputStream.write(new byte[] { 1, 2, 3});
+    outputStream.write(new byte[] {127, 4, 5, 127}, /* off= */ 1, /* len= */ 2);
+    outputStream.write(6);
+
+    assertArrayEquals(new byte[] { 1, 2, 3, 4, 5, 6}, outputStream.toByteArray());
+    assertEquals(6, outputStream.size());
+  }
+
+  @Test
+  public void reset_works() throws Exception {
+    ExposedByteArrayOutputStream outputStream = new ExposedByteArrayOutputStream();
+    outputStream.write(new byte[] { 1, 2, 3});
+
+    outputStream.reset();
+    outputStream.write(new byte[] { 7, 8, 9});
+
+    assertArrayEquals(new byte[] { 7, 8, 9}, outputStream.toByteArray());
+    assertEquals(3, outputStream.size());
+  }
+
+  @Test
+  public void array_doesNotCopyArray() throws Exception {
+    ExposedByteArrayOutputStream outputStream =
+        new ExposedByteArrayOutputStream(/* initialCapacity= */ 6);
+    byte[] array = outputStream.array();
+    // Because array is not a copy, any write will change the array, if it is large enough.
+    outputStream.write(new byte[] { 1, 2, 3});
+    assertArrayEquals(new byte[] { 1, 2, 3, 0, 0, 0}, array);
+  }
+
+  @Test
+  public void createWithCapacity_works() throws Exception {
+    ExposedByteArrayOutputStream outputStream =
+        new ExposedByteArrayOutputStream(/* initialCapacity= */ 77);
+    assertEquals(77, outputStream.array().length);
+  }
+
+  @Test
+  public void capacityTooSmall_resizes() throws Exception  {
+    ExposedByteArrayOutputStream outputStream =
+        new ExposedByteArrayOutputStream(/* initialCapacity= */ 3);
+    assertEquals(3, outputStream.array().length);
+    outputStream.write(new byte[] { 1, 2, 3, 4});
+    assertTrue(outputStream.array().length > 3);
+  }
+}

--- a/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
+++ b/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
@@ -4,61 +4,59 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public final class ExposedByteArrayOutputStreamTest {
+    @Test
+    public void write_works() throws Exception {
+        ExposedByteArrayOutputStream outputStream = new ExposedByteArrayOutputStream();
 
-  @Test
-  public void write_works() throws Exception {
-    ExposedByteArrayOutputStream outputStream = new ExposedByteArrayOutputStream();
+        outputStream.write(new byte[] {1, 2, 3});
+        outputStream.write(new byte[] {127, 4, 5, 127}, /* off= */ 1, /* len= */ 2);
+        outputStream.write(6);
 
-    outputStream.write(new byte[] { 1, 2, 3});
-    outputStream.write(new byte[] {127, 4, 5, 127}, /* off= */ 1, /* len= */ 2);
-    outputStream.write(6);
+        assertArrayEquals(new byte[] {1, 2, 3, 4, 5, 6}, outputStream.toByteArray());
+        assertEquals(6, outputStream.size());
+    }
 
-    assertArrayEquals(new byte[] { 1, 2, 3, 4, 5, 6}, outputStream.toByteArray());
-    assertEquals(6, outputStream.size());
-  }
+    @Test
+    public void reset_works() throws Exception {
+        ExposedByteArrayOutputStream outputStream = new ExposedByteArrayOutputStream();
+        outputStream.write(new byte[] {1, 2, 3});
 
-  @Test
-  public void reset_works() throws Exception {
-    ExposedByteArrayOutputStream outputStream = new ExposedByteArrayOutputStream();
-    outputStream.write(new byte[] { 1, 2, 3});
+        outputStream.reset();
+        outputStream.write(new byte[] {7, 8, 9});
 
-    outputStream.reset();
-    outputStream.write(new byte[] { 7, 8, 9});
+        assertArrayEquals(new byte[] {7, 8, 9}, outputStream.toByteArray());
+        assertEquals(3, outputStream.size());
+    }
 
-    assertArrayEquals(new byte[] { 7, 8, 9}, outputStream.toByteArray());
-    assertEquals(3, outputStream.size());
-  }
+    @Test
+    public void array_doesNotCopyArray() throws Exception {
+        ExposedByteArrayOutputStream outputStream =
+                new ExposedByteArrayOutputStream(/* initialCapacity= */ 6);
+        byte[] array = outputStream.array();
+        // Because array is not a copy, any write will change the array, if it is large enough.
+        outputStream.write(new byte[] {1, 2, 3});
+        assertArrayEquals(new byte[] {1, 2, 3, 0, 0, 0}, array);
+    }
 
-  @Test
-  public void array_doesNotCopyArray() throws Exception {
-    ExposedByteArrayOutputStream outputStream =
-        new ExposedByteArrayOutputStream(/* initialCapacity= */ 6);
-    byte[] array = outputStream.array();
-    // Because array is not a copy, any write will change the array, if it is large enough.
-    outputStream.write(new byte[] { 1, 2, 3});
-    assertArrayEquals(new byte[] { 1, 2, 3, 0, 0, 0}, array);
-  }
+    @Test
+    public void createWithCapacity_works() throws Exception {
+        ExposedByteArrayOutputStream outputStream =
+                new ExposedByteArrayOutputStream(/* initialCapacity= */ 77);
+        assertEquals(77, outputStream.array().length);
+    }
 
-  @Test
-  public void createWithCapacity_works() throws Exception {
-    ExposedByteArrayOutputStream outputStream =
-        new ExposedByteArrayOutputStream(/* initialCapacity= */ 77);
-    assertEquals(77, outputStream.array().length);
-  }
-
-  @Test
-  public void capacityTooSmall_resizes() throws Exception  {
-    ExposedByteArrayOutputStream outputStream =
-        new ExposedByteArrayOutputStream(/* initialCapacity= */ 3);
-    assertEquals(3, outputStream.array().length);
-    outputStream.write(new byte[] { 1, 2, 3, 4});
-    assertTrue(outputStream.array().length > 3);
-  }
+    @Test
+    public void capacityTooSmall_resizes() throws Exception {
+        ExposedByteArrayOutputStream outputStream =
+                new ExposedByteArrayOutputStream(/* initialCapacity= */ 3);
+        assertEquals(3, outputStream.array().length);
+        outputStream.write(new byte[] {1, 2, 3, 4});
+        assertTrue(outputStream.array().length > 3);
+    }
 }

--- a/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
+++ b/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
@@ -39,7 +39,8 @@ public final class ExposedByteArrayOutputStreamTest {
         ExposedByteArrayOutputStream outputStream =
                 new ExposedByteArrayOutputStream(/* initialCapacity= */ 6);
         byte[] array = outputStream.array();
-        // Because array is not a copy, any write will change the array, if it is large enough.
+        assertEquals(6, array.length);
+        // Because array is not a copy and there is enough space, write 3 bytes will change array.
         outputStream.write(new byte[] {1, 2, 3});
         assertArrayEquals(new byte[] {1, 2, 3, 0, 0, 0}, array);
     }
@@ -56,7 +57,9 @@ public final class ExposedByteArrayOutputStreamTest {
         ExposedByteArrayOutputStream outputStream =
                 new ExposedByteArrayOutputStream(/* initialCapacity= */ 3);
         assertEquals(3, outputStream.array().length);
-        outputStream.write(new byte[] {1, 2, 3, 4});
+        outputStream.write(new byte[] {1, 2});
+        outputStream.write(new byte[] {3, 4});
         assertTrue(outputStream.array().length > 3);
+        assertArrayEquals(new byte[] {1, 2, 3, 4}, outputStream.toByteArray());
     }
 }

--- a/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
+++ b/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.conscrypt;
 
 import static org.junit.Assert.assertArrayEquals;


### PR DESCRIPTION
This is already used twice, and may be needed in other places in the future.
It's better to move it into its own class.