### PR TITLE
Use ByteArrayOutputStream to buffer AAD in AEAD Ciphers.

### DIFF
--- a/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
+++ b/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
@@ -32,4 +32,9 @@ final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
     byte[] array() {
         return buf;
     }
+    
+    /* Manually sets the count. This is only needed when data is written to array() without using write. */
+    void setCountManually(int count) {
+    	this.count = count;
+    }
 }

--- a/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
+++ b/common/src/main/java/org/conscrypt/ExposedByteArrayOutputStream.java
@@ -32,9 +32,11 @@ final class ExposedByteArrayOutputStream extends ByteArrayOutputStream {
     byte[] array() {
         return buf;
     }
-    
-    /* Manually sets the count. This is only needed when data is written to array() without using write. */
+
+    /* Manually sets the count. This is only needed when data is written to array() without using
+     * write.
+     */
     void setCountManually(int count) {
-    	this.count = count;
+        this.count = count;
     }
 }

--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -449,7 +449,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     protected void engineUpdateAAD(byte[] input, int inputOffset, int inputLen) {
         checkInitialization();
         if (aadBuf == null) {
-            aadBuf = new Buffer(inputLen);
+            aadBuf = new ExposedByteArrayOutputStream(inputLen);
         }
         aadBuf.write(input, inputOffset, inputLen);
     }
@@ -460,7 +460,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
         checkInitialization();
         int inputLen = buf.remaining();
         if (aadBuf == null) {
-            aadBuf = new Buffer(inputLen);
+            aadBuf = new ExposedByteArrayOutputStream(inputLen);
             buf.get(aadBuf.array(), 0, inputLen);
             return;
         }

--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -77,8 +77,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     long evpAead;
 
     /**
-     * Additional authenticated data. It is initialized to null because it is only
-     * needed when update is called. So we don't want to allocate it until it is needed.
+     * Additional authenticated data. It is initialized when needed.
      */
     private ExposedByteArrayOutputStream aadBuf = null;
 

--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -460,7 +460,9 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
         int inputLen = buf.remaining();
         if (aadBuf == null) {
             aadBuf = new ExposedByteArrayOutputStream(inputLen);
+            // Directly write the content of buf to aadBuf.array()
             buf.get(aadBuf.array(), 0, inputLen);
+            aadBuf.setCountManually(intputLen);
             return;
         }
         byte[] input = new byte[inputLen];

--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -77,9 +77,10 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     long evpAead;
 
     /**
-     * Additional authenticated data.
+     * Additional authenticated data. It is initialized to null because it is only
+     * needed when update is called. So we don't want to allocate it until it is needed.
      */
-    private byte[] aad;
+    private ExposedByteArrayOutputStream aadBuf = null;
 
     /**
      * The length of the AEAD cipher tag in bytes.
@@ -116,7 +117,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     }
 
     private void reset() {
-        aad = null;
+        aadBuf = null;
         if (buf == null) {
             bufCount = 0;
             return;
@@ -199,7 +200,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
         }
         mustInitialize = false;
         this.iv = iv;
-        aad = null;
+        aadBuf = null;
         if (buf != null) {
             buf.reset();
         }
@@ -348,9 +349,21 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
         }
     }
 
+    private byte[] getAad() {
+        if (aadBuf == null) {
+            return EmptyArray.BYTE;
+        }
+        if (aadBuf.array().length == aadBuf.size()) {
+            // no need to copy.
+            return aadBuf.array();
+        }
+        return aadBuf.toByteArray();
+    }
+
     int doFinalInternal(ByteBuffer input, ByteBuffer output)
             throws ShortBufferException, IllegalBlockSizeException, BadPaddingException {
         checkInitialization();
+        byte[] aad = getAad();
         final int bytesWritten;
         try {
             if (isEncrypting()) {
@@ -395,6 +408,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
             inLen = inputLen;
         }
 
+        byte[] aad = getAad();
         final int bytesWritten;
         try {
             if (isEncrypting()) {
@@ -434,31 +448,25 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
     @SuppressWarnings("MissingOverride")
     protected void engineUpdateAAD(byte[] input, int inputOffset, int inputLen) {
         checkInitialization();
-        if (aad == null) {
-            aad = Arrays.copyOfRange(input, inputOffset, inputOffset + inputLen);
-        } else {
-            int newSize = aad.length + inputLen;
-            byte[] newaad = new byte[newSize];
-            System.arraycopy(aad, 0, newaad, 0, aad.length);
-            System.arraycopy(input, inputOffset, newaad, aad.length, inputLen);
-            aad = newaad;
+        if (aadBuf == null) {
+            aadBuf = new Buffer(inputLen);
         }
+        aadBuf.write(input, inputOffset, inputLen);
     }
 
     // Intentionally missing Override to compile on old versions of Android
     @SuppressWarnings("MissingOverride")
     protected void engineUpdateAAD(ByteBuffer buf) {
         checkInitialization();
-        if (aad == null) {
-            aad = new byte[buf.remaining()];
-            buf.get(aad);
-        } else {
-            int newSize = aad.length + buf.remaining();
-            byte[] newaad = new byte[newSize];
-            System.arraycopy(aad, 0, newaad, 0, aad.length);
-            buf.get(newaad, aad.length, buf.remaining());
-            aad = newaad;
+        int inputLen = buf.remaining();
+        if (aadBuf == null) {
+            aadBuf = new Buffer(inputLen);
+            buf.get(aadBuf.array(), 0, inputLen);
+            return;
         }
+        byte[] input = new byte[inputLen];
+        buf.get(input);
+        aadBuf.write(input, 0, inputLen);
     }
 
     abstract long getEVP_AEAD(int keyLength) throws InvalidKeyException;

--- a/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLAeadCipher.java
@@ -462,7 +462,7 @@ public abstract class OpenSSLAeadCipher extends OpenSSLCipher {
             aadBuf = new ExposedByteArrayOutputStream(inputLen);
             // Directly write the content of buf to aadBuf.array()
             buf.get(aadBuf.array(), 0, inputLen);
-            aadBuf.setCountManually(intputLen);
+            aadBuf.setCountManually(inputLen);
             return;
         }
         byte[] input = new byte[inputLen];

--- a/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
+++ b/common/src/test/java/org/conscrypt/ExposedByteArrayOutputStreamTest.java
@@ -50,6 +50,16 @@ public final class ExposedByteArrayOutputStreamTest {
     }
 
     @Test
+    public void setCountManually_works() throws Exception {
+        ExposedByteArrayOutputStream outputStream = new ExposedByteArrayOutputStream(10);
+        outputStream.array()[9] = 42;
+        outputStream.setCountManually(1);
+
+        assertArrayEquals(new byte[] {42}, outputStream.toByteArray());
+        assertEquals(3, outputStream.size());
+    }
+
+    @Test
     public void array_doesNotCopyArray() throws Exception {
         ExposedByteArrayOutputStream outputStream =
                 new ExposedByteArrayOutputStream(/* initialCapacity= */ 6);


### PR DESCRIPTION
The current implementation is inefficient (quadratic) when updateAAD is called several times.
Using a ByteArrayOutputStream is cleaner and more effcient.

In the normal case where updateAAD is called exactly once, it is as efficient as before:
it allocates one array of the aad size and copies it.