### PR TITLE
Fix Gradle build.

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(../common/src/jni/main/include/
                     ${BORINGSSL_HOME}/include)
 
 find_library(android-log-lib log)
-target_link_libraries(conscrypt_jni ${android-log-lib} ssl)
+target_link_libraries(conscrypt_jni ${android-log-lib} ssl crypto)
 
 add_definitions(-DANDROID
                 -fvisibility=hidden


### PR DESCRIPTION
BoringSSL merged crypto/CMakelists into the top level so it no longer exists.

NB Syncing past this change will require you to update your local boringssl tree to HEAD, but the change is required now as our CI runs with BoringSSL HEAD.