### PR TITLE
clang-format some XDH tests.

### DIFF
--- a/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyFactoryTest.java
@@ -25,6 +25,15 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import org.conscrypt.OpenSSLX25519PrivateKey;
+import org.conscrypt.OpenSSLX25519PublicKey;
+import org.conscrypt.TestUtils;
+import org.conscrypt.XdhKeySpec;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyFactory;
@@ -39,15 +48,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
-
-import org.conscrypt.OpenSSLX25519PrivateKey;
-import org.conscrypt.OpenSSLX25519PublicKey;
-import org.conscrypt.TestUtils;
-import org.conscrypt.XdhKeySpec;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class XdhKeyFactoryTest {
@@ -65,8 +65,7 @@ public class XdhKeyFactoryTest {
     private final byte[] publicKeyRawBytes = ((OpenSSLX25519PublicKey) publicKey).getU();
     private final byte[] privateKeyRawBytes = ((OpenSSLX25519PrivateKey) privateKey).getU();
 
-    public XdhKeyFactoryTest() throws NoSuchAlgorithmException, InvalidKeySpecException {
-    }
+    public XdhKeyFactoryTest() throws NoSuchAlgorithmException, InvalidKeySpecException {}
 
     @Test
     public void constructor() {
@@ -77,7 +76,6 @@ public class XdhKeyFactoryTest {
 
         assertEquals("PKCS#8", privateKey.getFormat());
         assertArrayEquals(privateKeyPkcs8Bytes, privateKey.getEncoded());
-
     }
     @Test
     public void generatePublic() throws Exception {
@@ -97,7 +95,7 @@ public class XdhKeyFactoryTest {
     }
 
     @Test
-    public void generatePrivate() throws Exception{
+    public void generatePrivate() throws Exception {
         PrivateKey key = factory.generatePrivate(new XdhKeySpec(privateKeyRawBytes));
         assertTrue(key instanceof OpenSSLX25519PrivateKey);
         assertEquals("PKCS#8", key.getFormat());
@@ -149,16 +147,19 @@ public class XdhKeyFactoryTest {
                 () -> factory.getKeySpec(publicKey, PKCS8EncodedKeySpec.class));
         assertThrows(InvalidKeySpecException.class,
                 () -> factory.getKeySpec(privateKey, X509EncodedKeySpec.class));
-        assertThrows(InvalidKeySpecException.class, () -> factory.getKeySpec(
-                new TestPublicKeyWrongEncoding(), X509EncodedKeySpec.class));
-        assertThrows(InvalidKeySpecException.class, () -> factory.getKeySpec(
-                new TestPrivateKeyWrongEncoding(), PKCS8EncodedKeySpec.class));
+        assertThrows(InvalidKeySpecException.class,
+                ()
+                        -> factory.getKeySpec(
+                                new TestPublicKeyWrongEncoding(), X509EncodedKeySpec.class));
+        assertThrows(InvalidKeySpecException.class,
+                ()
+                        -> factory.getKeySpec(
+                                new TestPrivateKeyWrongEncoding(), PKCS8EncodedKeySpec.class));
 
         assertThrows(InvalidKeySpecException.class,
                 () -> factory.getKeySpec(publicKey, TestKeySpecWrongEncoding.class));
         assertThrows(InvalidKeySpecException.class,
                 () -> factory.getKeySpec(privateKey, TestKeySpecWrongEncoding.class));
-
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         KeyPair kp = kpg.generateKeyPair();
@@ -246,10 +247,8 @@ public class XdhKeyFactoryTest {
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         KeyPair kp = kpg.generateKeyPair();
-        assertThrows(InvalidKeyException.class,
-                () -> factory.translateKey(kp.getPublic()));
-        assertThrows(InvalidKeyException.class,
-                () -> factory.translateKey(kp.getPrivate()));
+        assertThrows(InvalidKeyException.class, () -> factory.translateKey(kp.getPublic()));
+        assertThrows(InvalidKeyException.class, () -> factory.translateKey(kp.getPrivate()));
     }
 
     /**

--- a/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyTest.java
+++ b/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyTest.java
@@ -21,15 +21,6 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.Arrays;
-import javax.crypto.KeyAgreement;
 import org.conscrypt.ArrayUtils;
 import org.conscrypt.OpenSSLX25519PrivateKey;
 import org.conscrypt.OpenSSLX25519PublicKey;
@@ -39,13 +30,25 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+
+import javax.crypto.KeyAgreement;
+
 @RunWith(JUnit4.class)
 public class XdhKeyTest {
     private final OpenSSLXDHKeyPairGenerator generator = new OpenSSLXDHKeyPairGenerator();
     private final KeyPair keyPair = generator.generateKeyPair();
     private final OpenSSLX25519PublicKey publicKey = (OpenSSLX25519PublicKey) keyPair.getPublic();
     private final byte[] publicKeyBytes = publicKey.getU();
-    private final OpenSSLX25519PrivateKey privateKey = (OpenSSLX25519PrivateKey) keyPair.getPrivate();
+    private final OpenSSLX25519PrivateKey privateKey =
+            (OpenSSLX25519PrivateKey) keyPair.getPrivate();
     private final byte[] privateKeyBytes = privateKey.getU();
 
     @Test
@@ -100,8 +103,6 @@ public class XdhKeyTest {
         assertEquals(publicKey, copy);
         assertNotSame(publicKey, copy);
         assertKeysWork(copy, privateKey);
-
-
     }
 
     @Test
@@ -142,12 +143,14 @@ public class XdhKeyTest {
         assertNotSame(privateKey, copy);
         assertKeysWork(publicKey, copy);
 
-        assertThrows(InvalidKeySpecException.class, () ->
-                new OpenSSLX25519PrivateKey(new X509EncodedKeySpec(pkcs8Bytes)));
-        assertThrows(InvalidKeySpecException.class, () ->
-                new OpenSSLX25519PrivateKey(new PKCS8EncodedKeySpec(flipBit(pkcs8Bytes))));
-        assertThrows(InvalidKeySpecException.class, () ->
-                new OpenSSLX25519PrivateKey(new PKCS8EncodedKeySpec(loseOneByte(pkcs8Bytes))));
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PrivateKey(new X509EncodedKeySpec(pkcs8Bytes)));
+        assertThrows(InvalidKeySpecException.class,
+                () -> new OpenSSLX25519PrivateKey(new PKCS8EncodedKeySpec(flipBit(pkcs8Bytes))));
+        assertThrows(InvalidKeySpecException.class,
+                ()
+                        -> new OpenSSLX25519PrivateKey(
+                                new PKCS8EncodedKeySpec(loseOneByte(pkcs8Bytes))));
 
         // EVP_parse_private_key ignores extra data for JCA compatibility.
         copy = new OpenSSLX25519PrivateKey(new PKCS8EncodedKeySpec(gainOneByte(pkcs8Bytes)));
@@ -157,8 +160,10 @@ public class XdhKeyTest {
 
         KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
         KeyPair keyPair = keyPairGenerator.generateKeyPair();
-        assertThrows(InvalidKeySpecException.class, () -> new OpenSSLX25519PrivateKey(
-                new PKCS8EncodedKeySpec(keyPair.getPrivate().getEncoded())));
+        assertThrows(InvalidKeySpecException.class,
+                ()
+                        -> new OpenSSLX25519PrivateKey(
+                                new PKCS8EncodedKeySpec(keyPair.getPrivate().getEncoded())));
     }
 
     @Test


### PR DESCRIPTION
I just ran clang-format for two XDH tests.

This will make it easier to add tests later and keep the formatting correct.