### PR TITLE
Correctly convert non-canonical public keys into XECPublicKeySpec.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLXDHKeyFactory.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLXDHKeyFactory.java
@@ -211,6 +211,13 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
         }
     }
 
+    // See https://datatracker.ietf.org/doc/html/rfc7748#section-5.
+    private BigInteger uToBigInteger(byte[] u) {
+        byte[] reversedU = ArrayUtils.reverse(u);
+        reversedU[0] &= (byte) ((1 << (255 % 8)) - 1);
+        return new BigInteger(1, reversedU);
+    }
+
     private KeySpec constructJavaXecPublicKeySpec(OpenSSLX25519PublicKey publicKey)
             throws InvalidKeySpecException {
         if (OpenSSLXDHKeyFactory.javaXecPublicKeySpec == null) {
@@ -220,8 +227,8 @@ public final class OpenSSLXDHKeyFactory extends KeyFactorySpi {
             Constructor<?> c = OpenSSLXDHKeyFactory.javaXecPublicKeySpec.getConstructor(
                     AlgorithmParameterSpec.class, BigInteger.class);
             @SuppressWarnings("unchecked")
-            KeySpec result = (KeySpec) c.newInstance(javaX25519AlgorithmSpec,
-                    new BigInteger(1, ArrayUtils.reverse(publicKey.getU())));
+            KeySpec result =
+              (KeySpec) c.newInstance(javaX25519AlgorithmSpec, uToBigInteger(publicKey.getU()));
             return result;
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
                  InvocationTargetException e) {

--- a/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyFactoryTest.java
+++ b/common/src/test/java/org/conscrypt/javax/crypto/XdhKeyFactoryTest.java
@@ -195,6 +195,33 @@ public class XdhKeyFactoryTest {
     }
 
     @Test
+    public void getKeySpec_xECPublicKeySpec_success() throws Exception {
+        TestUtils.assumeXecClassesAvailable();
+        @SuppressWarnings("unchecked")
+        Class<? extends KeySpec> javaClass = (Class<? extends KeySpec>)
+                TestUtils.findClass("java.security.spec.XECPublicKeySpec");
+        Method getUMethod = javaClass.getMethod("getU");
+
+        // Test vector from https://datatracker.ietf.org/doc/html/rfc7748#section-5.2.
+        byte[][] uAsBytes = new byte[][] {
+                decodeHex("0900000000000000000000000000000000000000000000000000000000000000"),
+                decodeHex("e6db6867583030db3594c1a424b15f7c726624ec26b3353b10a903a6d0ab1c4c"),
+                decodeHex("e5210f12786811d3f4b7959d0538ae2c31dbe7106fc03c3efc4cd549c715a493")};
+        BigInteger[] expectedUAsBigIntegers = new BigInteger[] {BigInteger.valueOf(9),
+                new BigInteger("3442643403391959445115510778118882165131616721530663157499622662110"
+                        + "2155684838"),
+                new BigInteger("8883857351183929894090759386610649319417338800022198945255395922347"
+                        + "792736741")};
+        assertEquals(uAsBytes.length, expectedUAsBigIntegers.length);
+        for (int i = 0; i < uAsBytes.length; i++) {
+            PublicKey publicKey = factory.generatePublic(new XdhKeySpec(uAsBytes[i]));
+            KeySpec publicKeySpec = factory.getKeySpec(publicKey, javaClass);
+            BigInteger u = (BigInteger) getUMethod.invoke(publicKeySpec);
+            assertEquals(u, expectedUAsBigIntegers[i]);
+        }
+    }
+
+    @Test
     @Ignore("Inconsistent results across platforms")
     public void xecPrivateKeySpec() throws Exception {
         TestUtils.assumeXecClassesAvailable();


### PR DESCRIPTION
If a X25519 public key that is in a non-canonical form is converted into a XECPublicKeySpec, the output may
be wrong. This fixes that.

We also add some tests (using the test vectors from RFC 7748, Section 5) that confirm that the conversion is now working.

We don't expect that this breaks any users, because all valid public keys should be in the canonical form.
But the RFC requires to accept keys in non-canonical form, so it is better to fix this.