### PR TITLE
Call clang-format on NativeCryptoTest.

### DIFF
--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -133,14 +133,16 @@ public class NativeCryptoTest {
         PrivateKeyEntry serverPrivateKeyEntry =
                 TestKeyStore.getServer().getPrivateKey("RSA", "RSA");
         SERVER_PRIVATE_KEY = OpenSSLKey.fromPrivateKey(serverPrivateKeyEntry.getPrivateKey());
-        SERVER_CERTIFICATES_HOLDER = encodeCertificateList(serverPrivateKeyEntry.getCertificateChain());
+        SERVER_CERTIFICATES_HOLDER =
+                encodeCertificateList(serverPrivateKeyEntry.getCertificateChain());
         SERVER_CERTIFICATE_REFS = getCertificateReferences(SERVER_CERTIFICATES_HOLDER);
         ENCODED_SERVER_CERTIFICATES = getEncodedCertificates(SERVER_CERTIFICATES_HOLDER);
 
         PrivateKeyEntry clientPrivateKeyEntry =
                 TestKeyStore.getClientCertificate().getPrivateKey("RSA", "RSA");
         CLIENT_PRIVATE_KEY = OpenSSLKey.fromPrivateKey(clientPrivateKeyEntry.getPrivateKey());
-        CLIENT_CERTIFICATES_HOLDER = encodeCertificateList(clientPrivateKeyEntry.getCertificateChain());
+        CLIENT_CERTIFICATES_HOLDER =
+                encodeCertificateList(clientPrivateKeyEntry.getCertificateChain());
         CLIENT_CERTIFICATE_REFS = getCertificateReferences(CLIENT_CERTIFICATES_HOLDER);
         ENCODED_CLIENT_CERTIFICATES = getEncodedCertificates(CLIENT_CERTIFICATES_HOLDER);
 
@@ -148,20 +150,22 @@ public class NativeCryptoTest {
         String caCertAlias = ks.aliases().nextElement();
         X509Certificate certificate = (X509Certificate) ks.getCertificate(caCertAlias);
         X500Principal principal = certificate.getIssuerX500Principal();
-        CA_PRINCIPALS = new byte[][] { principal.getEncoded() };
+        CA_PRINCIPALS = new byte[][] {principal.getEncoded()};
 
         // NIST P-256 aka SECG secp256r1 aka X9.62 prime256v1
         OpenSSLECGroupContext openSslSpec = OpenSSLECGroupContext.getCurveByName("prime256v1");
         BigInteger s = new BigInteger(
                 "229cdbbf489aea584828a261a23f9ff8b0f66f7ccac98bf2096ab3aee41497c5", 16);
-        CHANNEL_ID_PRIVATE_KEY = new OpenSSLECPrivateKey(new ECPrivateKeySpec(s, openSslSpec.getECParameterSpec()))
-                .getOpenSSLKey();
+        CHANNEL_ID_PRIVATE_KEY =
+                new OpenSSLECPrivateKey(new ECPrivateKeySpec(s, openSslSpec.getECParameterSpec()))
+                        .getOpenSSLKey();
 
         // Channel ID is the concatenation of the X and Y coordinates of the public key.
         CHANNEL_ID = new BigInteger(
                 "702b07871fd7955c320b26f15e244e47eed60272124c92b9ebecf0b42f90069b"
                         + "ab53592ebfeb4f167dbf3ce61513afb0e354c479b1c1b69874fa471293494f77",
-                16).toByteArray();
+                16)
+                             .toByteArray();
 
         // RSA keys are slow to generate, so prefer to reuse the key when possible.
         TEST_RSA_KEY = generateRsaKey();
@@ -532,10 +536,16 @@ public class NativeCryptoTest {
     public void SSL_set_protocol_versions() throws Exception {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c, null);
-        assertEquals(1, NativeCrypto.SSL_set_protocol_versions(s, null, TLS1_VERSION, TLS1_1_VERSION));
-        assertEquals(1, NativeCrypto.SSL_set_protocol_versions(s, null, TLS1_2_VERSION, TLS1_2_VERSION));
-        assertEquals(0, NativeCrypto.SSL_set_protocol_versions(s, null, TLS1_2_VERSION + 413, TLS1_1_VERSION));
-        assertEquals(0, NativeCrypto.SSL_set_protocol_versions(s, null, TLS1_1_VERSION, TLS1_2_VERSION + 413));
+        assertEquals(
+                1, NativeCrypto.SSL_set_protocol_versions(s, null, TLS1_VERSION, TLS1_1_VERSION));
+        assertEquals(
+                1, NativeCrypto.SSL_set_protocol_versions(s, null, TLS1_2_VERSION, TLS1_2_VERSION));
+        assertEquals(0,
+                NativeCrypto.SSL_set_protocol_versions(
+                        s, null, TLS1_2_VERSION + 413, TLS1_1_VERSION));
+        assertEquals(0,
+                NativeCrypto.SSL_set_protocol_versions(
+                        s, null, TLS1_1_VERSION, TLS1_2_VERSION + 413));
         NativeCrypto.SSL_free(s, null);
         NativeCrypto.SSL_CTX_free(c, null);
     }
@@ -714,7 +724,8 @@ public class NativeCryptoTest {
         private final Hooks hooks;
         private final ApplicationProtocolSelectorAdapter alpnSelector;
 
-        TestSSLHandshakeCallbacks(Socket socket, long sslNativePointer, Hooks hooks, ApplicationProtocolSelectorAdapter alpnSelector) {
+        TestSSLHandshakeCallbacks(Socket socket, long sslNativePointer, Hooks hooks,
+                ApplicationProtocolSelectorAdapter alpnSelector) {
             this.socket = socket;
             this.sslNativePointer = sslNativePointer;
             this.hooks = hooks;
@@ -792,8 +803,8 @@ public class NativeCryptoTest {
             if (DEBUG) {
                 System.out.println("ssl=0x" + Long.toString(sslNativePointer, 16)
                         + " clientPSKKeyRequested"
-                        + " identityHint=" + identityHint + " identity capacity=" + identity.length
-                        + " key capacity=" + key.length);
+                        + " identityHint=" + identityHint + " identity capacity="
+                        + identity.length + " key capacity=" + key.length);
             }
             clientPSKKeyRequestedInvoked = true;
             clientPSKKeyRequestedIdentityHint = identityHint;
@@ -923,7 +934,8 @@ public class NativeCryptoTest {
         public long beforeHandshake(long c) throws SSLException {
             long s = super.beforeHandshake(c);
             if (privateKey != null && certificates != null) {
-                NativeCrypto.setLocalCertsAndPrivateKey(s, null, certificates, privateKey.getNativeRef());
+                NativeCrypto.setLocalCertsAndPrivateKey(
+                        s, null, certificates, privateKey.getNativeRef());
             }
             if (channelIdEnabled) {
                 NativeCrypto.SSL_enable_tls_channel_id(s, null);
@@ -982,8 +994,7 @@ public class NativeCryptoTest {
                             return new TestSSLHandshakeCallbacks(socket, 0, null, null);
                         }
                         FileDescriptor fd =
-                                (FileDescriptor) m_Platform_getFileDescriptor.invoke(
-                                        null, socket);
+                                (FileDescriptor) m_Platform_getFileDescriptor.invoke(null, socket);
                         long c = hooks.getContext();
                         long s = hooks.beforeHandshake(c);
                         TestSSLHandshakeCallbacks callback =
@@ -1003,7 +1014,8 @@ public class NativeCryptoTest {
                                 NativeCrypto.SSL_set_accept_state(s, null);
                             }
                             if (alpnProtocols != null) {
-                                NativeCrypto.setApplicationProtocols(s, null, client, alpnProtocols);
+                                NativeCrypto.setApplicationProtocols(
+                                        s, null, client, alpnProtocols);
                             }
                             if (!client && alpnSelector != null) {
                                 NativeCrypto.setHasApplicationProtocolSelector(s, null, true);
@@ -1011,8 +1023,7 @@ public class NativeCryptoTest {
                             NativeCrypto.SSL_do_handshake(s, null, fd, callback, timeout);
                             session = NativeCrypto.SSL_get1_session(s, null);
                             if (DEBUG) {
-                                System.out.println("ssl=0x" + Long.toString(s, 16)
-                                        + " handshake"
+                                System.out.println("ssl=0x" + Long.toString(s, 16) + " handshake"
                                         + " session=0x" + Long.toString(session, 16));
                             }
                         } finally {
@@ -1074,8 +1085,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks clientCallback = client.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
-        assertEqualCertificateChains(
-                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
+        assertEqualCertificateChains(SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertFalse(serverCallback.verifyCertificateChainCalled);
         assertFalse(clientCallback.clientCertificateRequestedCalled);
@@ -1113,8 +1123,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks clientCallback1 = client1.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         TestSSLHandshakeCallbacks serverCallback1 = server1.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback1.verifyCertificateChainCalled);
-        assertEqualCertificateChains(
-                SERVER_CERTIFICATE_REFS, clientCallback1.certificateChainRefs);
+        assertEqualCertificateChains(SERVER_CERTIFICATE_REFS, clientCallback1.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback1.authMethod);
         assertFalse(serverCallback1.verifyCertificateChainCalled);
         assertFalse(clientCallback1.clientCertificateRequestedCalled);
@@ -1155,8 +1164,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks clientCallback2 = client2.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         TestSSLHandshakeCallbacks serverCallback2 = server2.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback2.verifyCertificateChainCalled);
-        assertEqualCertificateChains(
-                SERVER_CERTIFICATE_REFS, clientCallback2.certificateChainRefs);
+        assertEqualCertificateChains(SERVER_CERTIFICATE_REFS, clientCallback2.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback2.authMethod);
         assertFalse(serverCallback2.verifyCertificateChainCalled);
         assertFalse(clientCallback2.clientCertificateRequestedCalled);
@@ -1205,12 +1213,10 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks clientCallback = client.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
-        assertEqualCertificateChains(
-                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
+        assertEqualCertificateChains(SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertTrue(serverCallback.verifyCertificateChainCalled);
-        assertEqualCertificateChains(
-                CLIENT_CERTIFICATE_REFS, serverCallback.certificateChainRefs);
+        assertEqualCertificateChains(CLIENT_CERTIFICATE_REFS, serverCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", serverCallback.authMethod);
 
         assertTrue(clientCallback.clientCertificateRequestedCalled);
@@ -1325,8 +1331,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks clientCallback = client.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
-        assertEqualCertificateChains(
-                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
+        assertEqualCertificateChains(SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertFalse(serverCallback.verifyCertificateChainCalled);
         assertFalse(clientCallback.clientCertificateRequestedCalled);
@@ -1362,8 +1367,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks clientCallback = client.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
-        assertEqualCertificateChains(
-                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
+        assertEqualCertificateChains(SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertFalse(serverCallback.verifyCertificateChainCalled);
         assertFalse(clientCallback.clientCertificateRequestedCalled);
@@ -1399,8 +1403,7 @@ public class NativeCryptoTest {
         TestSSLHandshakeCallbacks clientCallback = client.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         TestSSLHandshakeCallbacks serverCallback = server.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertTrue(clientCallback.verifyCertificateChainCalled);
-        assertEqualCertificateChains(
-                SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
+        assertEqualCertificateChains(SERVER_CERTIFICATE_REFS, clientCallback.certificateChainRefs);
         assertEquals("ECDHE_RSA", clientCallback.authMethod);
         assertFalse(serverCallback.verifyCertificateChainCalled);
         assertFalse(clientCallback.clientCertificateRequestedCalled);
@@ -1642,7 +1645,8 @@ public class NativeCryptoTest {
             @Override
             public void afterHandshake(long session, long ssl, long context, Socket socket,
                     FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
-                assertEqualByteArrays(OCSP_TEST_DATA, NativeCrypto.SSL_get_ocsp_response(ssl, null));
+                assertEqualByteArrays(
+                        OCSP_TEST_DATA, NativeCrypto.SSL_get_ocsp_response(ssl, null));
                 super.afterHandshake(session, ssl, context, socket, fd, callback);
             }
         };
@@ -1773,8 +1777,7 @@ public class NativeCryptoTest {
                         clientSession[0] = session;
                     }
                 };
-                Hooks sHooks = new ServerHooks(
-                        SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
+                Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                     @Override
                     public long getContext() {
                         return serverContext;
@@ -1813,8 +1816,7 @@ public class NativeCryptoTest {
                         super.afterHandshake(NULL, s, NULL, sock, fd, callback);
                     }
                 };
-                Hooks sHooks = new ServerHooks(
-                        SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
+                Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
                     @Override
                     public long getContext() {
                         return serverContext;
@@ -2091,7 +2093,8 @@ public class NativeCryptoTest {
 
         ApplicationProtocolSelector selector = Mockito.mock(ApplicationProtocolSelector.class);
         SSLEngine engine = Mockito.mock(SSLEngine.class);
-        ApplicationProtocolSelectorAdapter adapter = new ApplicationProtocolSelectorAdapter(engine, selector);
+        ApplicationProtocolSelectorAdapter adapter =
+                new ApplicationProtocolSelectorAdapter(engine, selector);
         when(selector.selectApplicationProtocol(same(engine), ArgumentMatchers.<String>anyList()))
                 .thenReturn("spdy/2");
 
@@ -2130,7 +2133,8 @@ public class NativeCryptoTest {
 
         ApplicationProtocolSelector selector = Mockito.mock(ApplicationProtocolSelector.class);
         SSLEngine engine = Mockito.mock(SSLEngine.class);
-        ApplicationProtocolSelectorAdapter adapter = new ApplicationProtocolSelectorAdapter(engine, selector);
+        ApplicationProtocolSelectorAdapter adapter =
+                new ApplicationProtocolSelectorAdapter(engine, selector);
         when(selector.selectApplicationProtocol(same(engine), ArgumentMatchers.<String>anyList()))
                 .thenReturn("h2");
 
@@ -2439,7 +2443,8 @@ public class NativeCryptoTest {
                         }
                     }
                 }.start();
-                assertEquals(-1, NativeCrypto.SSL_read(s, null, fd, callback, new byte[1], 0, 1, 0));
+                assertEquals(
+                        -1, NativeCrypto.SSL_read(s, null, fd, callback, new byte[1], 0, 1, 0));
                 super.afterHandshake(session, s, c, sock, fd, callback);
             }
         };
@@ -2914,9 +2919,22 @@ public class NativeCryptoTest {
      * openssl rand -hex 16
      */
     private static final byte[] AES_128_KEY = new byte[] {
-            (byte) 0x3d, (byte) 0x4f, (byte) 0x89, (byte) 0x70, (byte) 0xb1, (byte) 0xf2,
-            (byte) 0x75, (byte) 0x37, (byte) 0xf4, (byte) 0x0a, (byte) 0x39, (byte) 0x29,
-            (byte) 0x8a, (byte) 0x41, (byte) 0x55, (byte) 0x5f,
+            (byte) 0x3d,
+            (byte) 0x4f,
+            (byte) 0x89,
+            (byte) 0x70,
+            (byte) 0xb1,
+            (byte) 0xf2,
+            (byte) 0x75,
+            (byte) 0x37,
+            (byte) 0xf4,
+            (byte) 0x0a,
+            (byte) 0x39,
+            (byte) 0x29,
+            (byte) 0x8a,
+            (byte) 0x41,
+            (byte) 0x55,
+            (byte) 0x5f,
     };
 
     @Test
@@ -3132,8 +3150,8 @@ public class NativeCryptoTest {
         OpenSSLX509Certificate issuer =
                 OpenSSLX509Certificate.fromX509PemInputStream(openTestFile("ca-cert.pem"));
 
-        byte[] extension = NativeCrypto.get_ocsp_single_extension(
-                ocspResponse, OCSP_SCT_LIST_OID, certificate.getContext(), certificate, issuer.getContext(), issuer);
+        byte[] extension = NativeCrypto.get_ocsp_single_extension(ocspResponse, OCSP_SCT_LIST_OID,
+                certificate.getContext(), certificate, issuer.getContext(), issuer);
 
         assertEqualByteArrays(expected, extension);
     }
@@ -3225,7 +3243,6 @@ public class NativeCryptoTest {
     @Test
     public void EVP_PKEY_CTX_set_rsa_mgf1_md_NullMdCtx() throws Exception {
         long pkeyCtx = getRawPkeyCtxForEncrypt();
-        NativeRef.EVP_PKEY_CTX holder = new NativeRef.EVP_PKEY_CTX(pkeyCtx);
         assertThrows(NullPointerException.class,
                 () -> NativeCrypto.EVP_PKEY_CTX_set_rsa_mgf1_md(pkeyCtx, NULL));
     }
@@ -3239,7 +3256,6 @@ public class NativeCryptoTest {
     @Test
     public void EVP_PKEY_CTX_set_rsa_oaep_md_NullMdCtx() throws Exception {
         long pkeyCtx = getRawPkeyCtxForEncrypt();
-        NativeRef.EVP_PKEY_CTX holder = new NativeRef.EVP_PKEY_CTX(pkeyCtx);
         assertThrows(NullPointerException.class,
                 () -> NativeCrypto.EVP_PKEY_CTX_set_rsa_oaep_md(pkeyCtx, NULL));
     }


### PR DESCRIPTION
Also remove unused variables.