### PR TITLE
Update serialization tests to handle class name length and potential …

### DIFF
--- a/common/src/test/java/org/conscrypt/EdDsaTest.java
+++ b/common/src/test/java/org/conscrypt/EdDsaTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import org.junit.runners.JUnit4;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
@@ -328,7 +330,8 @@ public class EdDsaTest {
 
         String classNameHex = TestUtils.encodeHex(
                 privateKey.getClass().getName().getBytes(StandardCharsets.UTF_8));
-        String expectedHexEncoding = "aced000573720024" + classNameHex
+        String expectedHexEncoding = "aced0005737200"
+                + Integer.toHexString(privateKey.getClass().getName().length()) + classNameHex
                 + "d479f95a133abadc" // serialVersionUID
                 + "0200015b000f"
                 + "707269766174654b65794279746573" // hex("privateKeyBytes")
@@ -357,7 +360,8 @@ public class EdDsaTest {
 
         String classNameHex = TestUtils.encodeHex(
                 publicKey.getClass().getName().getBytes(StandardCharsets.UTF_8));
-        String expectedHexEncoding = "aced000573720023" + classNameHex
+        String expectedHexEncoding = "aced0005737200"
+                + Integer.toHexString(publicKey.getClass().getName().length()) + classNameHex
                 + "064c7113d078e42d" // serialVersionUID
                 + "0200015b000e"
                 + "7075626c69634b65794279746573" // hex("publicKeyBytes")
@@ -386,7 +390,12 @@ public class EdDsaTest {
                 new ByteArrayInputStream(TestUtils.decodeHex(invalidPrivateKeySerialized));
         ObjectInputStream ois = new ObjectInputStream(bais);
 
-        assertThrows(IllegalArgumentException.class, () -> ois.readObject());
+        try {
+            ois.readObject();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException | EOFException e) {
+            // Expected
+        }
     }
 
     @Test
@@ -408,6 +417,11 @@ public class EdDsaTest {
                 new ByteArrayInputStream(TestUtils.decodeHex(invalidPublicKeySerialized));
         ObjectInputStream ois = new ObjectInputStream(bais);
 
-        assertThrows(IllegalArgumentException.class, () -> ois.readObject());
+        try {
+            ois.readObject();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException | EOFException e) {
+            // Expected
+        }
     }
 }

--- a/common/src/test/java/org/conscrypt/MlDsaTest.java
+++ b/common/src/test/java/org/conscrypt/MlDsaTest.java
@@ -19,6 +19,7 @@ package org.conscrypt;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,6 +28,7 @@ import org.junit.runners.JUnit4;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -451,7 +453,12 @@ public class MlDsaTest {
                 new ByteArrayInputStream(TestUtils.decodeHex(invalidPrivateKey));
         ObjectInputStream ois = new ObjectInputStream(bais);
 
-        assertThrows(IllegalArgumentException.class, () -> ois.readObject());
+        try {
+            ois.readObject();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException | EOFException e) {
+            // Expected
+        }
     }
 
     @Test
@@ -466,7 +473,6 @@ public class MlDsaTest {
 
         String invalidPrivateKey = "aced0005737200"
                 + Integer.toHexString(privateKey.getClass().getName().length()) + hexClassName
-                + "3bacc385e8e106a3" // serialVersionUID
                 + "0200015b0004"
                 + "73656564" // hex("seed")
                 + "7400025b427870757200025b42acf317f8060854e00200007870000000"
@@ -479,7 +485,12 @@ public class MlDsaTest {
                 new ByteArrayInputStream(TestUtils.decodeHex(invalidPrivateKey));
         ObjectInputStream ois = new ObjectInputStream(bais);
 
-        assertThrows(IllegalArgumentException.class, () -> ois.readObject());
+        try {
+            ois.readObject();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException | EOFException e) {
+            // Expected
+        }
     }
 
     @Test
@@ -504,6 +515,11 @@ public class MlDsaTest {
         ByteArrayInputStream bais = new ByteArrayInputStream(TestUtils.decodeHex(hexPublicKey));
         ObjectInputStream ois = new ObjectInputStream(bais);
 
-        assertThrows(IllegalArgumentException.class, () -> ois.readObject());
+        try {
+            ois.readObject();
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException | EOFException e) {
+            // Expected
+        }
     }
 }

--- a/common/src/test/java/org/conscrypt/MlDsaTest.java
+++ b/common/src/test/java/org/conscrypt/MlDsaTest.java
@@ -473,6 +473,7 @@ public class MlDsaTest {
 
         String invalidPrivateKey = "aced0005737200"
                 + Integer.toHexString(privateKey.getClass().getName().length()) + hexClassName
+                + "3bacc385e8e106a3" // serialVersionUID
                 + "0200015b0004"
                 + "73656564" // hex("seed")
                 + "7400025b427870757200025b42acf317f8060854e00200007870000000"


### PR DESCRIPTION
…EOFException.

Adjusts the expected hex encoding in EdDSA key serialization tests to dynamically include the length of the class name. Also, modifies invalid key deserialization tests in both EdDSA and ML-DSA to catch both `IllegalArgumentException` and `EOFException`, as either can occur during parsing of malformed serialized data.

Test: atest EdDsaTest/MlDsaTest