### PR TITLE
Reduce IDE warnings for native code.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -66,6 +66,8 @@ using conscrypt::CompatibilityCloseMonitor;
 using conscrypt::NativeCrypto;
 using conscrypt::SslError;
 
+// NOLINTBEGIN(*-use-auto)
+
 /**
  * Helper function that grabs the casts an ssl pointer and then checks for nullness.
  * If this function returns nullptr and <code>throwIfNull</code> is
@@ -8274,7 +8276,8 @@ static void debug_print_session_key(const SSL* ssl, const char* line) {
     JNI_TRACE_KEYS("ssl=%p KEY_LINE: %s", ssl, line);
 }
 
-static void debug_print_packet_data(const SSL* ssl, char direction, const char* data, size_t len) {
+CONSCRYPT_UNUSED static void debug_print_packet_data(const SSL* ssl, char direction,
+                                                     const char* data, size_t len) {
     static constexpr size_t kDataWidth = 16;
 
     struct timeval tv;
@@ -10504,7 +10507,7 @@ static jlong NativeCrypto_SSL_get_timeout(JNIEnv* env, jclass, jlong ssl_address
     jlong result = SSL_get_timeout(ssl_session);
     result *= 1000;  // OpenSSL uses seconds, Java uses milliseconds.
     JNI_TRACE("ssl_session=%p NativeCrypto_SSL_get_timeout => %lld", ssl_session,
-              (long long)result)  // NOLINT(runtime/int);
+              (long long)result);  // NOLINT(runtime/int);
     return result;
 }
 
@@ -12020,11 +12023,8 @@ static jboolean NativeCrypto_SSL_CTX_ech_enable_server(JNIEnv* env, jclass, jlon
 // TESTING METHODS END
 
 #define CONSCRYPT_NATIVE_METHOD(functionName, signature)             \
-    {                                                                \
-        /* NOLINTNEXTLINE */                                         \
-        (char*)#functionName, (char*)(signature),                    \
-                reinterpret_cast<void*>(NativeCrypto_##functionName) \
-    }
+    {const_cast<char*>(#functionName), const_cast<char*>(signature), \
+     reinterpret_cast<void*>(&NativeCrypto_##functionName)}
 
 #define FILE_DESCRIPTOR "Ljava/io/FileDescriptor;"
 #define SSL_CALLBACKS \
@@ -12400,6 +12400,7 @@ void NativeCrypto::registerNativeMethods(JNIEnv* env) {
             NELEM(sNativeCryptoMethods));
 }
 
+// NOLINTEND(*-use-auto)
 /* Local Variables: */
 /* mode: c++ */
 /* tab-width: 4 */

--- a/common/src/jni/main/include/conscrypt/macros.h
+++ b/common/src/jni/main/include/conscrypt/macros.h
@@ -117,7 +117,7 @@
  * for the purposes of -Werror=unused-parameter. This can be needed when an
  * argument's use is based on an #ifdef.
  */
-#define UNUSED_ARGUMENT(x) ((void)(x));
+#define UNUSED_ARGUMENT(x) ((void)(x))
 
 /**
  * Check array bounds for arguments when an array and offset are given.

--- a/common/src/jni/main/include/conscrypt/trace.h
+++ b/common/src/jni/main/include/conscrypt/trace.h
@@ -64,21 +64,31 @@ constexpr bool kWithJniTracePackets = false;
 }  // namespace trace
 }  // namespace conscrypt
 
-#define JNI_TRACE(...)                                        \
-    if (conscrypt::trace::kWithJniTrace) {                    \
-        CONSCRYPT_LOG(LOG_INFO, LOG_TAG "-jni", __VA_ARGS__); \
-    }
-#define JNI_TRACE_MD(...)                                     \
-    if (conscrypt::trace::kWithJniTraceMd) {                  \
-        CONSCRYPT_LOG(LOG_INFO, LOG_TAG "-jni", __VA_ARGS__); \
-    }
-#define JNI_TRACE_KEYS(...)                                   \
-    if (conscrypt::trace::kWithJniTraceKeys) {                \
-        CONSCRYPT_LOG(LOG_INFO, LOG_TAG "-jni", __VA_ARGS__); \
-    }
-#define JNI_TRACE_PACKET_DATA(ssl, dir, data, len)    \
-    if (conscrypt::trace::kWithJniTracePackets) {     \
-        debug_print_packet_data(ssl, dir, data, len); \
-    }
+#define JNI_TRACE(...)                                            \
+    do {                                                          \
+        if constexpr (conscrypt::trace::kWithJniTrace) {          \
+            CONSCRYPT_LOG(LOG_INFO, LOG_TAG "-jni", __VA_ARGS__); \
+        }                                                         \
+    } while (0)
 
+#define JNI_TRACE_MD(...)                                         \
+    do {                                                          \
+        if constexpr (conscrypt::trace::kWithJniTraceMd) {        \
+            CONSCRYPT_LOG(LOG_INFO, LOG_TAG "-jni", __VA_ARGS__); \
+        }                                                         \
+    } while (0)
+
+#define JNI_TRACE_KEYS(...)                                       \
+    do {                                                          \
+        if constexpr (conscrypt::trace::kWithJniTraceKeys) {      \
+            CONSCRYPT_LOG(LOG_INFO, LOG_TAG "-jni", __VA_ARGS__); \
+        }                                                         \
+    } while (0)
+
+#define JNI_TRACE_PACKET_DATA(ssl, dir, data, len)              \
+    do {                                                        \
+        if constexpr (conscrypt::trace::kWithJniTracePackets) { \
+            debug_print_packet_data(ssl, dir, data, len);       \
+        }                                                       \
+    } while (0)
 #endif  // CONSCRYPT_TRACE_H_


### PR DESCRIPTION
No functional change but defines some native helper macros a bit better to get rid of hundreds of IDE warnings.

Also suppresses clang-tidy lints to use auto for variables which are initialised by a cast, removing many more.

Still leaves a lot of spurious "unused function" warnings that I can't find a good solution for (neither NOLINT nor noinspection seem to work).

But at least after this, the _real_ lint warnings are a bit easier to follow in Studio.