### PR TITLE
Remove call to get0_ech_retry_configs in ECH test

### DIFF
--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -496,14 +496,6 @@ public class NativeCryptoTest {
                 NativeCrypto.SSL_set_enable_ech_grease(ssl, null, true);
                 return ssl;
             }
-
-            @Override
-            public void afterHandshake(long session, long ssl, long context, Socket socket,
-                    FileDescriptor fd, SSLHandshakeCallbacks callback) throws Exception {
-                byte[] retryConfigs = NativeCrypto.SSL_get0_ech_retry_configs(ssl, null);
-                assertEquals(5, retryConfigs.length); // should be the invalid ECH Config List
-                super.afterHandshake(session, ssl, context, socket, fd, callback);
-            }
         };
         Hooks sHooks = new ServerHooks(SERVER_PRIVATE_KEY, ENCODED_SERVER_CERTIFICATES) {
             @Override


### PR DESCRIPTION
Tests for ECH were added in commit 354957b734. In
test_SSL_do_handshake_ech_grease_only, SSL_get0_ech_retry_configs was called after the handshake. This function is not expected to be called, as the client is only verifying that GREASE is accepted.

Fixes #1401