### PR TITLE
Fix null checks for engine unwrap buffer lists.

### DIFF
--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -753,8 +753,8 @@ final class ConscryptEngine extends AbstractConscryptEngine
         checkPositionIndexes(dstsOffset, dstsOffset + dstsLength, dsts.length);
 
         // Determine the output capacity.
-        final int dstLength = calcDstsLength(dsts, dstsOffset, dstsLength);
-        final int endOffset = dstsOffset + dstsLength;
+        final int dstsEndOffset = dstsOffset + dstsLength;
+        final long dstLength = calcDstsLength(dsts, dstsOffset, dstsEndOffset);
 
         final int srcsEndOffset = srcsOffset + srcsLength;
         final long srcLength = calcSrcsLength(srcs, srcsOffset, srcsEndOffset);
@@ -863,7 +863,7 @@ final class ConscryptEngine extends AbstractConscryptEngine
             try {
                 if (dstLength > 0) {
                     // Write decrypted data to dsts buffers
-                    for (int idx = dstsOffset; idx < endOffset; ++idx) {
+                    for (int idx = dstsOffset; idx < dstsEndOffset; ++idx) {
                         ByteBuffer dst = dsts[idx];
                         if (!dst.hasRemaining()) {
                             continue;
@@ -933,17 +933,15 @@ final class ConscryptEngine extends AbstractConscryptEngine
         }
     }
 
-    private static int calcDstsLength(ByteBuffer[] dsts, int dstsOffset, int dstsLength) {
-        int capacity = 0;
-        for (int i = 0; i < dsts.length; i++) {
+    private static long calcDstsLength(ByteBuffer[] dsts, int dstsOffset, int dstsEndOffset) {
+        long capacity = 0;
+        for (int i = dstsOffset; i < dstsEndOffset; i++) {
             ByteBuffer dst = dsts[i];
             checkArgument(dst != null, "dsts[%d] is null", i);
             if (dst.isReadOnly()) {
                 throw new ReadOnlyBufferException();
             }
-            if (i >= dstsOffset && i < dstsOffset + dstsLength) {
-                capacity += dst.remaining();
-            }
+            capacity += dst.remaining();
         }
         return capacity;
     }
@@ -952,9 +950,7 @@ final class ConscryptEngine extends AbstractConscryptEngine
         long len = 0;
         for (int i = srcsOffset; i < srcsEndOffset; i++) {
             ByteBuffer src = srcs[i];
-            if (src == null) {
-                throw new IllegalArgumentException("srcs[" + i + "] is null");
-            }
+            checkArgument(src != null, "srcs[%d] is null", i);
             len += src.remaining();
         }
         return len;

--- a/testing/src/main/java/org/conscrypt/TestUtils.java
+++ b/testing/src/main/java/org/conscrypt/TestUtils.java
@@ -109,6 +109,15 @@ public final class TestUtils {
         private static final Random random = new Random(System.currentTimeMillis());
         abstract ByteBuffer newBuffer(int size);
 
+        public ByteBuffer[] newEmptyBuffers(int... sizes) {
+            int numBuffers = sizes.length;
+            ByteBuffer[] result = new ByteBuffer[numBuffers];
+            for (int i = 0; i < numBuffers; i++) {
+                result[i] = newBuffer(sizes[i]);
+            }
+            return result;
+        }
+
         public ByteBuffer[] newRandomBuffers(int... sizes) {
             int numBuffers = sizes.length;
             ByteBuffer[] result = new ByteBuffer[numBuffers];


### PR DESCRIPTION
Fixes #1372

I verified on OpenJDK 8, 11 and 21 that this is the RI expected behaviour, i.e. a null entry in a ByteBuffer array that is outside the selected range should *not* cause wrap or unwrap to fail.

Also made the unwrap check methods for srcs and dests more aligned with each other, although ultimately this should probably be more like the wrap approach where we simply take a copy of the selected ByteBuffer array range.  Now we have better tests we can do that in a future CL.

This is a slight behaviour change on all platforms (including Mainline) but as there were no tests for it, it won't break any CI, and as it is making the checks slightly more lenient it seems very unlikely to break any application code.

No impact on SSLSocket implementation as that only ever uses a single buffer.

I added a preconditions check for unwrap along the lines of the one for wrap (and converted to assertThrows).

Also because my spidey sense was tingling and I wasn't sure that this miscount could ever cause unwrap to produce more data than it was meant to I added an array offsets test along the lines of the one for wrap, only a bit more involved as it first checks that the exact amount of data flows as well as returning BUFFER_UNDERFLOW if you try to unwrap more data than is supposed to fit.  Didn't find any bugs but it's still a good regression test.