### PR TITLE
Upstream changes from elsewhere into github.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -11845,8 +11845,6 @@ static jboolean NativeCrypto_SSL_set1_ech_config_list(JNIEnv* env, jclass, jlong
     SSL* ssl = to_SSL(env, ssl_address, true);
     JNI_TRACE("ssl=%p NativeCrypto_SSL_set1_ech_config_list(%p)", ssl, configJavaBytes);
     if (ssl == nullptr) {
-        conscrypt::jniutil::throwNullPointerException(env, "Null pointer, ssl address");
-        ERR_clear_error();
         return JNI_FALSE;
     }
     ScopedByteArrayRO configBytes(env, configJavaBytes);
@@ -11951,23 +11949,20 @@ static jboolean NativeCrypto_SSL_ech_accepted(JNIEnv* env, jclass, jlong ssl_add
     JNI_TRACE("NativeCrypto_SSL_ech_accepted");
     CHECK_ERROR_QUEUE_ON_RETURN;
     SSL* ssl = to_SSL(env, ssl_address, true);
-    JNI_TRACE("ssl=%p NativeCrypto_SSL_ech_accepted", ssl);
     if (ssl == nullptr) {
-        conscrypt::jniutil::throwNullPointerException(env, "Null pointer, ssl address");
-        ERR_clear_error();
         return JNI_FALSE;
     }
-    jboolean accepted = SSL_ech_accepted(ssl);
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_ech_accepted", ssl);
 
-    if (!accepted) {
+    if (!SSL_ech_accepted(ssl)) {
         conscrypt::jniutil::throwParsingException(env, "Invalid ECH config list");
         ERR_clear_error();
         JNI_TRACE("ssl=%p NativeCrypto_SSL_ech_accepted => threw exception", ssl);
         return JNI_FALSE;
     }
 
-    JNI_TRACE("ssl=%p NativeCrypto_SSL_ech_accepted => %d", ssl, accepted);
-    return accepted;
+    JNI_TRACE("ssl=%p NativeCrypto_SSL_ech_accepted => %d", ssl, JNI_TRUE);
+    return JNI_TRUE;
 }
 
 static jboolean NativeCrypto_SSL_CTX_ech_enable_server(JNIEnv* env, jclass, jlong ssl_ctx_address,

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -457,17 +457,11 @@ public final class Conscrypt {
         if (isConscrypt(socket)) {
             return toConscrypt(socket).getApplicationProtocol();
         }
-        try {
-            if (!Class.forName("com.android.org.conscrypt.AbstractConscryptSocket")
-                            .isInstance(socket)) {
-                throw new IllegalArgumentException(
-                        "Not a conscrypt socket: " + socket.getClass().getName());
-            }
-            return invokeConscryptMethod(socket, "getApplicationProtocol");
-        } catch (ClassNotFoundException e) {
+        if (!socket.getClass().getName().contains("conscrypt")) {
             throw new IllegalArgumentException(
-                    "Not a conscrypt socket: " + socket.getClass().getName(), e);
+                    "Not a conscrypt socket: " + socket.getClass().getName());
         }
+        return invokeConscryptMethod(socket, "getApplicationProtocol");
     }
 
     /**
@@ -751,17 +745,11 @@ public final class Conscrypt {
         if (isConscrypt(engine)) {
             return toConscrypt(engine).getApplicationProtocol();
         }
-        try {
-            if (!Class.forName("com.android.org.conscrypt.AbstractConscryptEngine")
-                            .isInstance(engine)) {
-                throw new IllegalArgumentException(
-                        "Not a conscrypt engine: " + engine.getClass().getName());
-            }
-            return invokeConscryptMethod(engine, "getApplicationProtocol");
-        } catch (ClassNotFoundException e) {
+        if (!engine.getClass().getName().contains("conscrypt")) {
             throw new IllegalArgumentException(
-                    "Not a conscrypt engine: " + engine.getClass().getName(), e);
+                    "Not a conscrypt engine: " + engine.getClass().getName());
         }
+        return invokeConscryptMethod(engine, "getApplicationProtocol");
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/DuckTypedHpkeSpi.java
+++ b/common/src/main/java/org/conscrypt/DuckTypedHpkeSpi.java
@@ -44,6 +44,9 @@ public class DuckTypedHpkeSpi implements HpkeSpi {
       if (targetMethod.isSynthetic()) {
         continue;
       }
+      if (targetMethod.getName().equals("engineInitSenderForTesting")) {
+          continue;
+      }
 
       Method sourceMethod =
           sourceClass.getMethod(targetMethod.getName(), targetMethod.getParameterTypes());
@@ -132,6 +135,10 @@ public class DuckTypedHpkeSpi implements HpkeSpi {
   @Override
   public void engineInitSenderForTesting(PublicKey recipientKey, byte[] info, PrivateKey senderKey,
           byte[] psk, byte[] pskId, byte[] sKe) throws InvalidKeyException {
+      if (!methods.containsKey("engineInitSenderForTesting")) {
+          throw new UnsupportedOperationException(
+                  "engineInitSenderForTesting is not supported by the delegate");
+      }
       invokeWithPossibleInvalidKey("engineInitSenderForTesting",
               recipientKey, info, senderKey, psk, pskId, sKe);
   }


### PR DESCRIPTION
Includes the following changes:
- Stop requiring testing method for HPKE duck typing
- Stop throwing an extra null pointer exception in native_crypto
- Simplify Conscrypt instance checks in `getApplicationProtocol`.