### PR TITLE
Throw SSLException in SSL_set1_ech_config_list

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -11857,7 +11857,7 @@ static jboolean NativeCrypto_SSL_set1_ech_config_list(JNIEnv* env, jclass, jlong
     int ret = SSL_set1_ech_config_list(ssl, reinterpret_cast<const uint8_t*>(configBytes.get()),
                                        configBytes.size());
     if (!ret) {
-        conscrypt::jniutil::throwParsingException(env, "Error parsing ECH config");
+        conscrypt::jniutil::throwSSLExceptionStr(env, "Error parsing ECH config");
         ERR_clear_error();
         JNI_TRACE("ssl=%p NativeCrypto_SSL_set1_ech_config_list(%p) => threw exception", ssl,
                   configJavaBytes);
@@ -11955,8 +11955,6 @@ static jboolean NativeCrypto_SSL_ech_accepted(JNIEnv* env, jclass, jlong ssl_add
     JNI_TRACE("ssl=%p NativeCrypto_SSL_ech_accepted", ssl);
 
     if (!SSL_ech_accepted(ssl)) {
-        conscrypt::jniutil::throwParsingException(env, "Invalid ECH config list");
-        ERR_clear_error();
         JNI_TRACE("ssl=%p NativeCrypto_SSL_ech_accepted => threw exception", ssl);
         return JNI_FALSE;
     }

--- a/common/src/main/java/org/conscrypt/NativeCrypto.java
+++ b/common/src/main/java/org/conscrypt/NativeCrypto.java
@@ -1627,8 +1627,8 @@ public final class NativeCrypto {
 
     static native void SSL_set_enable_ech_grease(long ssl, NativeSsl ssl_holder, boolean enable);
 
-    static native boolean SSL_set1_ech_config_list(
-            long ssl, NativeSsl ssl_holder, byte[] echConfig);
+    static native boolean SSL_set1_ech_config_list(long ssl, NativeSsl ssl_holder, byte[] echConfig)
+            throws SSLException;
 
     static native String SSL_get0_ech_name_override(long ssl, NativeSsl ssl_holder);
 

--- a/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
+++ b/openjdk/src/test/java/org/conscrypt/NativeCryptoTest.java
@@ -632,7 +632,7 @@ public class NativeCryptoTest {
         byte[] badConfigList = {
                 0x00, 0x05, (byte) 0xfe, 0x0d, (byte) 0xff, (byte) 0xff, (byte) 0xff};
         boolean set = false;
-        assertThrows(ParsingException.class,
+        assertThrows(SSLException.class,
                 () -> NativeCrypto.SSL_set1_ech_config_list(s, null, badConfigList));
         NativeCrypto.SSL_free(s, null);
         NativeCrypto.SSL_CTX_free(c, null);
@@ -663,8 +663,7 @@ public class NativeCryptoTest {
         long c = NativeCrypto.SSL_CTX_new();
         long s = NativeCrypto.SSL_new(c, null);
 
-        assertThrows(
-                ParsingException.class, () -> assertFalse(NativeCrypto.SSL_ech_accepted(s, null)));
+        assertFalse(NativeCrypto.SSL_ech_accepted(s, null));
 
         NativeCrypto.SSL_free(s, null);
         NativeCrypto.SSL_CTX_free(c, null);


### PR DESCRIPTION
Prior to this change, NativeCrypto.SSL_set1_ech_config_list would throw a OpenSSLX509CertificateFactory.ParsingException. Since the config list is not directly linked to that exception, use the more generic SSLException instead. Update the Java declaration to explicitly throws this exception.

NativeCrypto.SSL_ech_accepted was found to raise a similar exception. Simply return false.