### PR TITLE
Use size_t as type for i.

### DIFF
--- a/common/src/jni/main/cpp/conscrypt/native_crypto.cc
+++ b/common/src/jni/main/cpp/conscrypt/native_crypto.cc
@@ -9883,7 +9883,7 @@ static void NativeCrypto_SSL_set1_groups(JNIEnv* env, jclass, jlong sslAddress,
     std::vector<int> groups_vector;
     groups_vector.reserve(groups_ro.size());
     const jint* groups_ptr = groups_ro.get();
-    for (int i = 0; i < groups_ro.size(); i++) {
+    for (size_t i = 0; i < groups_ro.size(); i++) {
         groups_vector.push_back(groups_ptr[i]);
     }
 


### PR DESCRIPTION
This avoids conversion of size_t to int.