### PR TITLE
Add a property for skipping Android subprojects.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 android.useAndroidX=true
+# Set to false in $HOME/.gradle/gradle.properties (or pass -Pconscrypt.includeAndroid=false)
+# to exclude Android sub-projects, e.g. when iterating on common/ code.
+conscrypt.includeAndroid=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,8 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "conscrypt"
-if (System.env.ANDROID_HOME && file(System.env.ANDROID_HOME).exists()) {
+if (providers.gradleProperty('conscrypt.includeAndroid').getOrElse('true').toBoolean()
+        && System.env.ANDROID_HOME && file(System.env.ANDROID_HOME).exists()) {
     include ":conscrypt-android"
     include ":conscrypt-android-platform"
     include ":conscrypt-android-stub"
@@ -27,7 +28,9 @@ if (System.env.ANDROID_HOME && file(System.env.ANDROID_HOME).exists()) {
     project(':conscrypt-benchmark-android').projectDir = "$rootDir/benchmark-android" as File
     project(':conscrypt-libcore-stub').projectDir = "$rootDir/libcore-stub" as File
 } else {
-    logger.warn('Android SDK has not been detected. Skipping Android projects.')
+    logger.warn('Android projects not included. ' +
+                'Ensure ANDROID_HOME is set and set conscrypt.includeAndroid=true ' +
+                'in gradle.properties to include them.')
 }
 
 include ":conscrypt-api-doclet"


### PR DESCRIPTION
Scratches a minor itch when developing for OpenJDK...

When working on `common/` code, there is no need to build or even include the Android sub-projects except as a final build check.  One way to achieve this is to unset `$ANDROID_HOME` and then `settings.gradle` will automatically exclude these sub-projects.

However doing that in a shell will work for the Gradle CLI but not IDEs started from a GUI desktop which will have its own set of environment variables.

The obvious fix for _that_ would be to use a local.properties entry, but these can't be used in `settings.gradle` without explicit code to read them, and we want to exclude them at this level as it also helps the project import cleanly into Jetbrains  IDEs.

So this change gates the Android sub-projects on an additional project-level property which can be overridden either within the project temporarily during `common/` development or in `$HOME/.gradle/gradle.properties`.

Tested manually both from the command line and within IDEs.