### PR TITLE
Temporarily disable new cert checks in tests.

### DIFF
--- a/openjdk/src/test/java/org/conscrypt/ConscryptOpenJdkSuite.java
+++ b/openjdk/src/test/java/org/conscrypt/ConscryptOpenJdkSuite.java
@@ -186,6 +186,11 @@ import org.junit.runners.Suite;
 public class ConscryptOpenJdkSuite {
     @BeforeClass
     public static void setupStatic() {
+        // Java 26 introduced additional certificate checking in SunX509KeyManagerImpl
+        // that rejects test certificates lacking proper Key Usage extensions.  Disable
+        // it here so that certificate quality issues are not masked as TLS failures.
+        // TODO(#1486) Fix test certificate generation in TestKeyStore and remove this.
+        System.setProperty("jdk.tls.SunX509KeyManager.certChecking", "false");
         installConscryptAsDefaultProvider();
     }
 }


### PR DESCRIPTION
See #1486 for details. This reduces test noise until the certificate generation in TestKeyStore is compatible with the new checks in Java 26 KeyStore choose*Alias methods.