### PR TITLE
Handle SSLParameters in ConscryptServerSocket.

### DIFF
--- a/android/src/main/java/org/conscrypt/Platform.java
+++ b/android/src/main/java/org/conscrypt/Platform.java
@@ -263,6 +263,16 @@ final public class Platform {
         }
     }
 
+    public static void setSSLParameters(SSLParameters params, SSLParametersImpl impl) {
+        try {
+            setSSLParametersOnImpl(params, impl);
+        } catch (NoSuchMethodException | IllegalAccessException ignored) {
+            // Ignored
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
     public static void setSSLParameters(SSLParameters params, SSLParametersImpl impl,
                                         AbstractConscryptSocket socket) {
         try {
@@ -274,9 +284,7 @@ final public class Platform {
                     socket.setHostname(sniHostname);
                 }
             }
-        } catch (NoSuchMethodException ignored) {
-            // Ignored
-        } catch (IllegalAccessException ignored) {
+        } catch (NoSuchMethodException | IllegalAccessException ignored) {
             // Ignored
         } catch (InvocationTargetException e) {
             throw new RuntimeException(e.getCause());
@@ -294,9 +302,7 @@ final public class Platform {
                     engine.setHostname(sniHostname);
                 }
             }
-        } catch (NoSuchMethodException ignored) {
-            // Ignored
-        } catch (IllegalAccessException ignored) {
+        } catch (NoSuchMethodException | IllegalAccessException ignored) {
             // Ignored
         } catch (InvocationTargetException e) {
             throw new RuntimeException(e.getCause());
@@ -340,6 +346,16 @@ final public class Platform {
         }
     }
 
+    public static void getSSLParameters(SSLParameters params, SSLParametersImpl impl) {
+        try {
+            getSSLParametersFromImpl(params, impl);
+        } catch (NoSuchMethodException | IllegalAccessException ignored) {
+            // Ignored
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
     public static void getSSLParameters(SSLParameters params, SSLParametersImpl impl,
                                         AbstractConscryptSocket socket) {
         try {
@@ -348,9 +364,7 @@ final public class Platform {
             if (Build.VERSION.SDK_INT >= 24) {
                 setParametersSniHostname(params, impl, socket);
             }
-        } catch (NoSuchMethodException ignored) {
-            // Ignored
-        } catch (IllegalAccessException ignored) {
+        } catch (NoSuchMethodException | IllegalAccessException ignored) {
             // Ignored
         } catch (InvocationTargetException e) {
             throw new RuntimeException(e.getCause());
@@ -377,9 +391,7 @@ final public class Platform {
             if (Build.VERSION.SDK_INT >= 24) {
                 setParametersSniHostname(params, impl, engine);
             }
-        } catch (NoSuchMethodException ignored) {
-            // Ignored
-        } catch (IllegalAccessException ignored) {
+        } catch (NoSuchMethodException | IllegalAccessException ignored) {
             // Ignored
         } catch (InvocationTargetException e) {
             throw new RuntimeException(e.getCause());

--- a/common/src/main/java/org/conscrypt/ConscryptServerSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptServerSocket.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 
 /**
@@ -77,6 +78,19 @@ final class ConscryptServerSocket extends SSLServerSocket {
     @Override
     public String[] getSupportedProtocols() {
         return NativeCrypto.getSupportedProtocols();
+    }
+
+    @Override
+    public SSLParameters getSSLParameters() {
+        SSLParameters params = super.getSSLParameters();
+        Platform.getSSLParameters(params, sslParameters);
+        return params;
+    }
+
+    @Override
+    public void setSSLParameters(SSLParameters params) {
+        super.setSSLParameters(params);
+        Platform.setSSLParameters(params, sslParameters);
     }
 
     /**

--- a/common/src/main/java/org/conscrypt/SSLParametersImpl.java
+++ b/common/src/main/java/org/conscrypt/SSLParametersImpl.java
@@ -240,6 +240,7 @@ final class SSLParametersImpl implements Cloneable {
         this.useSessionTickets = sslParams.useSessionTickets;
         this.useSni = sslParams.useSni;
         this.channelIdEnabled = sslParams.channelIdEnabled;
+        this.namedGroups = (sslParams.namedGroups == null) ? null : sslParams.namedGroups.clone();
     }
 
     /**

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -73,14 +73,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLProtocolException;
-import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
@@ -1099,6 +1096,65 @@ public class SSLSocketTest {
             SSLParameters parameters = client.getSSLParameters();
             setNamedGroups(parameters, new String[] {"P-521", "X25519", "P-384"});
             client.setSSLParameters(parameters);
+            client.startHandshake();
+            return null;
+        });
+        s.get();
+        c.get();
+        if (sslParametersSupportsNamedGroups()) {
+            // P-384 is the first named group in the server's list that both support.
+            assertEquals("P-384", getCurveName(client));
+            assertEquals("P-384", getCurveName(server));
+        } else {
+            // The defaults are used, and X25519 gets priority.
+            assertEquals("X25519", getCurveName(client));
+            assertEquals("X25519", getCurveName(server));
+        }
+        client.close();
+        server.close();
+        context.close();
+    }
+
+    @Test
+    public void handshake_setsNamedGroupsBeforeAccept_usesFirstServerNamedGroupThatClientSupports()
+            throws Exception {
+        TestSSLContext context = TestSSLContext.create();
+        final SSLSocket client = (SSLSocket) context.clientContext.getSocketFactory().createSocket(
+                context.host, context.port);
+
+        {
+            SSLParameters parameters = context.serverSocket.getSSLParameters();
+            setNamedGroups(parameters, new String[] {"P-384", "X25519"});
+            context.serverSocket.setSSLParameters(parameters);
+
+            if (sslParametersSupportsNamedGroups()) {
+                assertArrayEquals(new String[] {"P-384", "X25519"},
+                                  getNamedGroupsOrNull(context.serverSocket.getSSLParameters()));
+            } else {
+                assertArrayEquals(null,
+                                  getNamedGroupsOrNull(context.serverSocket.getSSLParameters()));
+            }
+        }
+        {
+            SSLParameters parameters = client.getSSLParameters();
+            setNamedGroups(parameters, new String[] {"P-521", "X25519", "P-384"});
+            client.setSSLParameters(parameters);
+
+            if (sslParametersSupportsNamedGroups()) {
+                assertArrayEquals(new String[] {"P-521", "X25519", "P-384"},
+                                  getNamedGroupsOrNull(client.getSSLParameters()));
+            } else {
+                assertArrayEquals(null, getNamedGroupsOrNull(client.getSSLParameters()));
+            }
+        }
+
+        final SSLSocket server = (SSLSocket) context.serverSocket.accept();
+
+        Future<Void> s = runAsync(() -> {
+            server.startHandshake();
+            return null;
+        });
+        Future<Void> c = runAsync(() -> {
             client.startHandshake();
             return null;
         });

--- a/openjdk/src/main/java/org/conscrypt/Java8PlatformUtil.java
+++ b/openjdk/src/main/java/org/conscrypt/Java8PlatformUtil.java
@@ -83,14 +83,14 @@ final class Java8PlatformUtil {
         return null;
     }
 
-    private static void setSSLParameters(SSLParameters params, SSLParametersImpl impl) {
+    static void setSSLParameters(SSLParameters params, SSLParametersImpl impl) {
         impl.setEndpointIdentificationAlgorithm(params.getEndpointIdentificationAlgorithm());
         impl.setUseCipherSuitesOrder(params.getUseCipherSuitesOrder());
         impl.setSNIMatchers(params.getSNIMatchers());
         impl.setAlgorithmConstraints(params.getAlgorithmConstraints());
     }
 
-    private static void getSSLParameters(SSLParameters params, SSLParametersImpl impl) {
+    static void getSSLParameters(SSLParameters params, SSLParametersImpl impl) {
         params.setEndpointIdentificationAlgorithm(impl.getEndpointIdentificationAlgorithm());
         params.setUseCipherSuitesOrder(impl.getUseCipherSuitesOrder());
         params.setSNIMatchers(impl.getSNIMatchers());

--- a/openjdk/src/main/java/org/conscrypt/Java9PlatformUtil.java
+++ b/openjdk/src/main/java/org/conscrypt/Java9PlatformUtil.java
@@ -45,6 +45,17 @@ final class Java9PlatformUtil {
         SSL_PARAMETERS_SET_APPLICATION_PROTOCOLS_METHOD = setApplicationProtocolsMethod;
     }
 
+    static void setSSLParameters(SSLParameters src, SSLParametersImpl dest) {
+        Java8PlatformUtil.setSSLParameters(src, dest);
+        try {
+            Method getNamedGroupsMethod = src.getClass().getMethod("getNamedGroups");
+            dest.setNamedGroups((String[]) getNamedGroupsMethod.invoke(src));
+        } catch (ReflectiveOperationException | SecurityException e) {
+            // Method is not available. Ignore.
+        }
+        dest.setApplicationProtocols(getApplicationProtocols(src));
+    }
+
     static void setSSLParameters(SSLParameters src, SSLParametersImpl dest,
                                  AbstractConscryptSocket socket) {
         Java8PlatformUtil.setSSLParameters(src, dest, socket);
@@ -83,6 +94,21 @@ final class Java9PlatformUtil {
         }
 
         dest.setApplicationProtocols(getApplicationProtocols(src));
+    }
+
+    static void getSSLParameters(SSLParameters dest, SSLParametersImpl src) {
+        Java8PlatformUtil.getSSLParameters(dest, src);
+
+        try {
+            String[] namedGroups = src.getNamedGroups();
+            Method setNamedGroupsMethod =
+                    dest.getClass().getMethod("setNamedGroups", String[].class);
+            setNamedGroupsMethod.invoke(dest, (Object) namedGroups);
+        } catch (ReflectiveOperationException | SecurityException e) {
+            // Method is not available. Ignore.
+        }
+
+        setApplicationProtocols(dest, src.getApplicationProtocols());
     }
 
     static void getSSLParameters(SSLParameters dest, SSLParametersImpl src,

--- a/openjdk/src/main/java/org/conscrypt/Platform.java
+++ b/openjdk/src/main/java/org/conscrypt/Platform.java
@@ -256,6 +256,16 @@ final public class Platform {
         // TODO: figure this out on the RI
     }
 
+    static void setSSLParameters(SSLParameters params, SSLParametersImpl impl) {
+        if (JAVA_VERSION >= 9) {
+            Java9PlatformUtil.setSSLParameters(params, impl);
+        } else if (JAVA_VERSION >= 8) {
+            Java8PlatformUtil.setSSLParameters(params, impl);
+        } else {
+            impl.setEndpointIdentificationAlgorithm(params.getEndpointIdentificationAlgorithm());
+        }
+    }
+
     static void setSSLParameters(SSLParameters params, SSLParametersImpl impl,
                                  AbstractConscryptSocket socket) {
         if (JAVA_VERSION >= 9) {
@@ -264,6 +274,16 @@ final public class Platform {
             Java8PlatformUtil.setSSLParameters(params, impl, socket);
         } else {
             impl.setEndpointIdentificationAlgorithm(params.getEndpointIdentificationAlgorithm());
+        }
+    }
+
+    static void getSSLParameters(SSLParameters params, SSLParametersImpl impl) {
+        if (JAVA_VERSION >= 9) {
+            Java9PlatformUtil.getSSLParameters(params, impl);
+        } else if (JAVA_VERSION >= 8) {
+            Java8PlatformUtil.getSSLParameters(params, impl);
+        } else {
+            params.setEndpointIdentificationAlgorithm(impl.getEndpointIdentificationAlgorithm());
         }
     }
 


### PR DESCRIPTION
ConscryptServerSocket currently doesn't overload the getSSLParameters and getSSLParameters methods, which means that some arguments are ignored. This means that the Socket returned by the createServerSocket (before "accept" is called) will ignore SSLParameters.

PiperOrigin-RevId: 906966157