### PR TITLE
Build and test Conscrypt with Ubuntu 22.04 instead of the latest version of Ubuntu.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,10 +313,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-14, macos-latest, windows-latest]
+        platform: [ubuntu-20.04, ubuntu-latest, macos-14, macos-latest, windows-latest]
         java: [8, 11, 17, 21, 25, EA]
         dist: ['temurin', 'zulu']
         include:
+          - platform: ubuntu-20.04
+            separator: ':'
           - platform: ubuntu-latest
             separator: ':'
           - platform: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,11 +313,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-20.04, ubuntu-latest, macos-14, macos-latest, windows-latest]
+        platform: [ubuntu-22.04, ubuntu-latest, macos-14, macos-latest, windows-latest]
         java: [8, 11, 17, 21, 25, EA]
         dist: ['temurin', 'zulu']
         include:
-          - platform: ubuntu-20.04
+          - platform: ubuntu-22.04
             separator: ':'
           - platform: ubuntu-latest
             separator: ':'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   boringssl_clone:
     # This step ensures that all builders have the same version of BoringSSL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Clone BoringSSL repo
@@ -30,7 +30,7 @@ jobs:
   clang_format_check:
     # Only run on pull requests.
     if: ${{ startsWith(github.ref, 'refs/pull/') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -54,9 +54,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-22.04, macos-latest, windows-latest]
         include:
-          - platform: ubuntu-latest
+          - platform: ubuntu-22.04
             tools_url: https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip
           - platform: macos-latest
             tools_url: https://dl.google.com/android/repository/commandlinetools-mac-9477386_latest.zip
@@ -217,7 +217,7 @@ jobs:
   uberjar:
     needs: build
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -2,5 +2,5 @@ description = 'Conscrypt is an alternate Java Security Provider that uses Boring
 
 subprojects {
     // Keep this in `subprojects` for scripts and ease of use. Migrate to properties later.
-    version = "2.6-alpha"
+    version = "2.6-SNAPSHOT"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,5 +2,5 @@ description = 'Conscrypt is an alternate Java Security Provider that uses Boring
 
 subprojects {
     // Keep this in `subprojects` for scripts and ease of use. Migrate to properties later.
-    version = "2.6-SNAPSHOT"
+    version = "2.6-alpha"
 }


### PR DESCRIPTION
Release 2.6-alpha doesn't seem to work on Ubuntu 20.04, because it was compiled with a newer version of Ubuntu requires therefore newer versions of GLIBC.

We should probably compile Conscrypt on Ubuntu 20.04, so that is working on a wider range of Linux versions. But then, we should also test this in the CI pipeline.