### PR TITLE
Project import generated by Copybara.

### DIFF
--- a/common/src/main/java/org/conscrypt/OpenSSLProvider.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLProvider.java
@@ -582,8 +582,7 @@ public final class OpenSSLProvider extends Provider {
         put("Alg.Alias.CertificateFactory.X.509", "X509");
 
         /* === HPKE === */
-        String baseClass = classExists("android.crypto.hpke.HpkeSpi") ? PREFIX + "AndroidHpkeSpi"
-                                                                      : PREFIX + "HpkeImpl";
+        String baseClass = PREFIX + "HpkeImpl";
 
         put("ConscryptHpke.DHKEM_X25519_HKDF_SHA256/HKDF_SHA256/AES_128_GCM",
             baseClass + "$X25519_AES_128");


### PR DESCRIPTION
PiperOrigin-RevId: 930364116

AndroidHpkeSpi was introduced to be able to use HPKE both in android and in Conscrypt. But since it implements an android interface, it can only be used if that interface is available.

But it turns out that this is not really needed. HpkeImpl (which only implements org.conscrypt.HpkeSpi) does work with the android android.crypto.hpke API, because that API accepts not only services that implement the android.crypto.hpke.HpkeSpi, but also (with the help of a Duck-typed adapter) any object that implements the same methods as org.conscrypt.HpkeSpi.

So we can simply always use HpkeImpl.

This resolves https://github.com/google/conscrypt/issues/1508.