### PR TITLE
Project import generated by Copybara.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           "$SDKMANAGER" --sdk_root="$ANDROID_HOME" 'build-tools;30.0.3'
           "$SDKMANAGER" --sdk_root="$ANDROID_HOME" 'platforms;android-26'
           "$SDKMANAGER" --sdk_root="$ANDROID_HOME" 'extras;android;m2repository'
-          "$SDKMANAGER" --sdk_root="$ANDROID_HOME" 'ndk;28.2.13676358'
+          "$SDKMANAGER" --sdk_root="$ANDROID_HOME" 'ndk;27.3.13750724'
           "$SDKMANAGER" --sdk_root="$ANDROID_HOME" 'cmake;3.22.1'
 
       - name: Build with Gradle

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ ext {
     androidVersionName = "$version"
     androidMinSdkVersion = 19
     androidTargetSdkVersion = 26
-    androidNdkVersion = '28.2.13676358'
+    androidNdkVersion = '27.3.13750724'
     androidCmakeVersion = '3.22.1'
 }
 
@@ -40,6 +40,8 @@ android {
         versionName androidVersionName
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArgument "class", "org.conscrypt.ConscryptAndroidSuite"
+        multiDexEnabled true
 
         consumerProguardFiles 'proguard-rules.pro'
 
@@ -49,7 +51,7 @@ android {
                         '-DANDROID_STL=c++_static',
                         "-DBORINGSSL_HOME=$boringsslHome",
                         "-DCMAKE_CXX_STANDARD=17",
-                        '-DCMAKE_SHARED_LINKER_FLAGS=-z max-page-size=16384'
+                        '-DCMAKE_SHARED_LINKER_FLAGS=-z max-page-size=16384 -z common-page-size=16384'
                 cFlags '-fvisibility=hidden',
                         '-DBORINGSSL_SHARED_LIBRARY',
                         '-DBORINGSSL_IMPLEMENTATION',
@@ -82,6 +84,20 @@ android {
             srcDirs += "build/generated/resources"
         }
     }
+    sourceSets.androidTest {
+        java {
+            srcDirs = [
+                    "${rootDir}/common/src/test/java",
+                    "${rootDir}/openjdk/src/test/java",
+            ]
+        }
+        resources {
+            srcDirs = [
+                    "${rootDir}/common/src/test/resources",
+                    "${rootDir}/openjdk/src/test/resources",
+            ]
+        }
+    }
     externalNativeBuild {
         cmake {
             path 'CMakeLists.txt'
@@ -109,6 +125,10 @@ preBuild {
 
 dependencies {
     publicApiDocs project(':conscrypt-api-doclet')
+    androidTestImplementation project(':conscrypt-testing')
+    androidTestImplementation libs.bouncycastle.apis
+    androidTestImplementation libs.bouncycastle.provider
+    androidTestImplementation libs.mockito.android
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.1', {
         exclude module: 'support-annotations'
         exclude module: 'support-v4'

--- a/android/src/androidTest/AndroidManifest.xml
+++ b/android/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 android.useAndroidX=true
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 bnd = "6.4.0"
-bouncycastle = "1.84"
+bouncycastle = "1.77"
 caliper = "1.0-beta-2"
 errorprone = "2.31.0"
 jacoco = "0.8.12"
 jmh = "1.37"
 jmh-plugin = "0.7.2"
 junit = "4.13.2"
-mockito = "4.11.0"
+mockito = "2.28.2"
 netty-handler = "4.1.24.Final"
 netty-tcnative = "2.0.26.Final"
 shadow = "7.1.2"
@@ -31,6 +31,7 @@ jacoco-agent = { module = "org.jacoco:org.jacoco.agent", version.ref = "jacoco" 
 jacoco-ant = { module = "org.jacoco:org.jacoco.ant", version.ref = "jacoco" }
 junit = { module = "junit:junit", version.ref = "junit" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-android = { module = "org.mockito:mockito-android", version.ref = "mockito" }
 
 # JMH Benchmarking
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -17,9 +17,9 @@ sourceSets {
 dependencies {
     compileOnly project(':conscrypt-constants')
 
-    implementation libs.bouncycastle.apis,
-            libs.bouncycastle.provider,
-            libs.junit
+    implementation libs.bouncycastle.apis
+    implementation libs.bouncycastle.provider
+    api libs.junit
 }
 
 // No public methods here.


### PR DESCRIPTION
PiperOrigin-RevId: 932451632

Some changes to the android build, so that we can run tests on emulators.

- Allocate more ram, because I got some out-of-memory errors without that.
- Use an older version of "ndk", because the newer one produces code that doesn't work on older phones. I'll use to oldest version still supported here: https://github.com/android/ndk/wiki. Also, note that v28 is not mentioned there, so I think we shouldn't use that.
- Use older versions of BouncyCastle. Because the tests on android don't work with newer version.
- Add flag to make sure that alignment is 16k, as suggested here: https://developer.android.com/guide/practices/page-sizes#compile-r27-lower
- Add android test target, so that it can be run with:
  ./gradlew :conscrypt-android:connectedAndroidTest -PcheckErrorQueue
- added "multiDexEnabled true", because the test build doesn't fit into one dex.