### PR TITLE
Project import generated by Copybara.

### DIFF
--- a/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
+++ b/common/src/main/java/org/conscrypt/AbstractConscryptSocket.java
@@ -513,6 +513,8 @@ abstract class AbstractConscryptSocket extends SSLSocket {
         return builder.toString();
     }
 
+    public abstract void setNamedGroups(String[] namedGroups);
+
     abstract String getCurveNameForTesting();
 
     /**

--- a/common/src/main/java/org/conscrypt/Conscrypt.java
+++ b/common/src/main/java/org/conscrypt/Conscrypt.java
@@ -362,6 +362,16 @@ public final class Conscrypt {
     }
 
     /**
+     * Sets the prioritized array of key exchange named groups names that can be used over the
+     * TLS socket.
+     *
+     * <p>See {@link SSLParameters#setNamedGroups(String[])} for more details.
+     */
+    public static void setNamedGroups(SSLSocket socket, String[] namedGroups) {
+        toConscrypt(socket).setNamedGroups(namedGroups);
+    }
+
+    /**
      * This method enables Server Name Indication (SNI) and overrides the hostname supplied
      * during socket creation.  If the hostname is not a valid SNI hostname, the SNI extension
      * will be omitted from the handshake.

--- a/common/src/main/java/org/conscrypt/ConscryptEngine.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngine.java
@@ -212,6 +212,10 @@ final class ConscryptEngine extends AbstractConscryptEngine
         }
     }
 
+    public void setNamedGroups(String[] namedGroups) {
+        sslParameters.setNamedGroups(namedGroups);
+    }
+
     String getCurveNameForTesting() {
         return ssl.getCurveNameForTesting();
     }

--- a/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptEngineSocket.java
@@ -442,6 +442,11 @@ class ConscryptEngineSocket extends OpenSSLSocketImpl implements SSLParametersIm
     }
 
     @Override
+    public final void setNamedGroups(String[] namedGroups) {
+        engine.setNamedGroups(namedGroups);
+    }
+
+    @Override
     public final String getCurveNameForTesting() {
         return engine.getCurveNameForTesting();
     }

--- a/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
+++ b/common/src/main/java/org/conscrypt/ConscryptFileDescriptorSocket.java
@@ -763,6 +763,11 @@ class ConscryptFileDescriptorSocket extends OpenSSLSocketImpl
     }
 
     @Override
+    public final void setNamedGroups(String[] namedGroups) {
+        sslParameters.setNamedGroups(namedGroups);
+    }
+
+    @Override
     public final String getCurveNameForTesting() {
         return ssl.getCurveNameForTesting();
     }

--- a/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
+++ b/common/src/main/java/org/conscrypt/OpenSSLSocketImpl.java
@@ -146,5 +146,7 @@ public abstract class OpenSSLSocketImpl extends AbstractConscryptSocket {
                 SSLUtils.decodeProtocols(protocols == null ? EmptyArray.BYTE : protocols));
     }
 
+    @Override public abstract void setNamedGroups(String[] namedGroups);
+
     @Override public abstract String getCurveNameForTesting();
 }

--- a/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
+++ b/common/src/test/java/org/conscrypt/javax/net/ssl/SSLSocketTest.java
@@ -82,6 +82,7 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.X509ExtendedTrustManager;
+import org.conscrypt.Conscrypt;
 
 import tests.net.DelegatingSSLSocketFactory;
 import tests.util.ForEachRunner;
@@ -1209,6 +1210,34 @@ public class SSLSocketTest {
             assertEquals("X25519", getCurveName(client));
             assertEquals("X25519", getCurveName(server));
         }
+        client.close();
+        server.close();
+        context.close();
+    }
+
+    @Test
+    public void socket_setNamedGroups_works() throws Exception {
+        TestSSLContext context = TestSSLContext.create();
+        final SSLSocket client = (SSLSocket) context.clientContext.getSocketFactory().createSocket(
+                context.host, context.port);
+        Conscrypt.setNamedGroups(client, new String[] {"P-384"});
+
+        // For the server, we don't set the named groups. P-384 should be
+        // enabled by default.
+        final SSLSocket server = (SSLSocket) context.serverSocket.accept();
+        Future<Void> s = runAsync(() -> {
+            server.startHandshake();
+            return null;
+        });
+        Future<Void> c = runAsync(() -> {
+            client.startHandshake();
+            return null;
+        });
+        s.get();
+        c.get();
+        // This must works even if sslParametersSupportsNamedGroups is false.
+        assertEquals("P-384", getCurveName(client));
+        assertEquals("P-384", getCurveName(server));
         client.close();
         server.close();
         context.close();


### PR DESCRIPTION
PiperOrigin-RevId: 933117874

The JCE API allows to use PQC algorithms using SSLParameters.setNamedGroups, see:
https://docs.oracle.com/en/java/javase/25/docs/api/java.base/javax/net/ssl/SSLParameters.html
But this was only added in Java 20, so it is not available for older Java versions. And for Android, it is only available since Android API level 37:
https://developer.android.com/reference/javax/net/ssl/SSLParameters.

Other versions of Java and Android can't use this. We add a function Conscrypt.setNamedGroups that allows to do that.